### PR TITLE
docs: improve footer tagline clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,5 +361,5 @@ This project is licensed under the **GNU Affero General Public License v3.0** (A
 ---
 
 <p align="center">
-  <strong>Built with ❤️ using NestJS | Powering RustDesk Console</strong>
+  <strong>Built with ❤️ using NestJS | The RustDesk Console Backend</strong>
 </p>


### PR DESCRIPTION
Updated the footer tagline in README:

- Changed 'Powering RustDesk Console' to 'The RustDesk Console Backend'
- This avoids confusion since the project IS RustDesk Console itself, not something powering it

**Before**: Built with ❤️ using NestJS | Powering RustDesk Console  
**After**: Built with ❤️ using NestJS | The RustDesk Console Backend