### PR TITLE
fix(docker): correct HEALTHCHECK endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PORT=3000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/api', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+  CMD node -e "require('http').get('http://localhost:3000/api/login', (r) => {process.exit(r.statusCode === 401 ? 0 : 1)})"
 
 # Start the application
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary
- 修复 Dockerfile 中 HEALTHCHECK 配置错误
- 将健康检查端点从不存在的 `/api` 改为 `/api/login`
- 原配置会导致容器持续被标记为 unhealthy

## Changes
- 修改 HEALTHCHECK 检查路径: `/api` → `/api/login`
- 修改预期状态码: `200` → `401`
- `/api/login` 返回 401 表示服务正常运行(需要认证)

## Test plan
- [ ] 构建新的 Docker 镜像
- [ ] 运行容器并验证健康检查状态
- [ ] 使用 `docker inspect --format='{{.State.Health.Status}}' <container_id>` 确认状态为 healthy