### PR TITLE
refactor(docker): remove unused /app/data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,6 @@ RUN npm ci --only=production
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
 
-# Create directory for SQLite database
-RUN mkdir -p /app/data
-
 # Expose the application port
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- 删除 Dockerfile 中创建 `/app/data` 目录的指令
- 该目录未被使用,SQLite 数据库文件存储在 `/app/rustdesk.db`

## Changes
- 移除 `RUN mkdir -p /app/data` 指令
- 数据库文件实际位置: `/app/rustdesk.db`

## Rationale
通过代码分析发现,数据库配置为:
```typescript
TypeOrmModule.forRoot({
  type: 'sqlite',
  database: 'rustdesk.db',  // 位于 /app/rustdesk.db
  ...
})
```

`/app/data` 目录从未被使用,删除以简化 Dockerfile。

## Test plan
- [ ] 构建新的 Docker 镜像
- [ ] 验证应用正常运行
- [ ] 确认数据库文件创建在 `/app/rustdesk.db`