### PR TITLE
fix(ci): correct release workflow title, version and contributors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,12 +114,13 @@ jobs:
           skip-commit: 'true'
           skip-tag: 'true'
           skip-on-empty: 'true'
+          skip-version-resolution: 'true'
           output-file: 'false'
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          name: Release ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           body: |
             ${{ steps.changelog.outputs.changelog }}
             
@@ -151,5 +152,6 @@ jobs:
             ```
           draft: false
           prerelease: false
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove "Release" prefix from release title, show version number only (e.g. `1.0.0` instead of `Release 1.0.0`)
- Add `skip-version-resolution: 'true'` to changelog action so the version in changelog matches the tag version instead of auto-calculating from commits (was showing `0.1.0` for `1.0.0` tag)
- Add `generate_release_notes: false` to prevent GitHub from auto-generating a contributors section with irrelevant accounts

## Test plan
- [ ] Merge and re-trigger the 1.0.0 release to verify the release title is just the version number
- [ ] Verify changelog header shows correct version (1.0.0)
- [ ] Verify no auto-generated contributors section appears in the release body