### PR TITLE
fix(ci): use package.json version for changelog and skip auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,17 +104,18 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Generate conventional changelog
+      - name: Generate changelog
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ steps.version.outputs.version }}
+          version-file: package.json
+          version-path: version
           skip-git-pull: 'true'
           skip-commit: 'true'
           skip-tag: 'true'
           skip-on-empty: 'true'
-          skip-version-resolution: 'true'
+          skip-bump: 'true'
           output-file: 'false'
 
       - name: Create Release


### PR DESCRIPTION
## Summary
- Replace unsupported `version` and `skip-version-resolution` inputs with `version-file`/`version-path` reading from `package.json`
- Add `skip-bump: 'true'` to prevent the changelog action from auto-incrementing the version number
- This fixes the changelog showing `0.1.0` instead of `1.0.0`

### Root cause
`TriPSs/conventional-changelog-action@v5` does not support `version` or `skip-version-resolution` inputs (they are silently ignored). The action auto-calculates version from conventional commits, defaulting to `0.1.0` for the first release.

## Test plan
- [ ] Merge and re-trigger the 1.0.0 release
- [ ] Verify changelog header shows `# 1.0.0` instead of `# 0.1.0`