### PR TITLE
fix(ci): remove v prefix from docker image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           tags: |
             databk/rustdesk-console:latest
             databk/rustdesk-console:${{ steps.version.outputs.version }}
-            databk/rustdesk-console:v${{ steps.version.outputs.major }}
+            databk/rustdesk-console:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -84,7 +84,7 @@ jobs:
           tags: |
             ghcr.io/databk/rustdesk-console:latest
             ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.version }}
-            ghcr.io/databk/rustdesk-console:v${{ steps.version.outputs.major }}
+            ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- 移除 Docker 镜像标签中 major 版本号的 `v` 前缀
- 修改了 `.github/workflows/release.yml` 中的两处镜像标签配置
- 现在推送 `1.0.0` 标签时,将生成 `1` 而不是 `v1` 的镜像标签

## Changes
- Docker Hub: `databk/rustdesk-console:v${{ steps.version.outputs.major }}` → `databk/rustdesk-console:${{ steps.version.outputs.major }}`
- GitHub Container Registry: `ghcr.io/databk/rustdesk-console:v${{ steps.version.outputs.major }}` → `ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.major }}`

## Test plan
- [ ] 验证 GitHub Actions 配置语法正确
- [ ] 下次发布时确认镜像标签格式符合预期