### PR TITLE
refactor(peers): align API response fields with frontend device list

### DIFF
--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -123,20 +123,30 @@ export class PeerService {
       const sysinfo = sysinfoMap.get(peer.uuid);
       const isOnline = peer.updatedAt > oneMinuteAgo;
       const user = peer.userGuid ? userMap.get(peer.userGuid) : null;
+      const deviceGroupName =
+        (peer.deviceGroup as { name?: string } | null)?.name || '';
 
       return {
+        guid: peer.uuid,
         id: peer.id,
+        status: peer.userGuid ? 1 : 2, // 1=正常, 2=禁用(无关联用户)
+        user: peer.userGuid || '',
+        user_name: user?.username || '',
+        note: sysinfo?.presetNote || '',
+        group_name: deviceGroupName,
+        device_group_name: deviceGroupName,
+        strategy_name: '', // 策略功能未实现，暂返回空
+        last_online: peer.updatedAt.toISOString(),
         info: {
           username: sysinfo?.username || '',
           os: sysinfo?.os || '',
           device_name: sysinfo?.hostname || '',
+          ip: '',
+          version: peer.ver ? String(peer.ver) : '',
+          cpu: sysinfo?.cpu || '',
+          memory: sysinfo?.memory || '',
         },
-        status: isOnline ? 1 : 0,
-        user: user?.username || '',
-        user_name: user?.username || '', // 用于前端过滤
-        device_group_name:
-          (peer.deviceGroup as { name?: string } | null)?.name || '',
-        note: '',
+        is_online: isOnline,
       };
     });
 


### PR DESCRIPTION
## Summary
- 重写 `/api/peers` 接口返回字段，严格对齐前端设备列表的列映射需求
- 新增 `guid`、`group_name`、`strategy_name`、`last_online`、`is_online` 字段
- 修正 `status` 语义：从在线/离线(1/0)改为正常/禁用(1/2)
- 修正 `user` 字段：从返回用户名改为返回用户 UUID
- 扩展 `info` 对象：新增 `ip`、`version`、`cpu`、`memory` 字段
- `note` 字段改为从 `sysinfo.presetNote` 获取，而非硬编码空串
- 策略相关字段暂返回空字符串，待策略功能实现后补充

## Changes Detail

| 字段 | 修改前 | 修改后 |
|------|--------|--------|
| `guid` | 无 | `peer.uuid` |
| `id` | `peer.id` | `peer.id`（不变） |
| `status` | 在线1/离线0 | 正常1/禁用2（基于userGuid是否存在） |
| `user` | 用户名(username) | 用户UUID(userGuid) |
| `user_name` | 用户名 | 用户名（不变） |
| `note` | 硬编码空串 | `sysinfo.presetNote` |
| `group_name` | 无 | 设备组名称（与device_group_name相同） |
| `device_group_name` | 设备组名称 | 设备组名称（不变） |
| `strategy_name` | 无 | 空串（策略未实现） |
| `last_online` | 无 | `peer.updatedAt` ISO 8601格式 |
| `info.ip` | 无 | 空串（数据库无此字段） |
| `info.version` | 无 | `peer.ver` 转字符串 |
| `info.cpu` | 无 | `sysinfo.cpu` |
| `info.memory` | 无 | `sysinfo.memory` |
| `is_online` | 无 | 基于updatedAt判断在线状态 |

## Test plan
- [ ] 验证 `/api/peers?current=1&pageSize=20` 返回字段与前端映射一致
- [ ] 验证 `status` 字段正确反映设备禁用状态
- [ ] 验证 `is_online` 字段正确反映在线状态
- [ ] 验证 `last_online` 返回 ISO 8601 格式
- [ ] 验证 `info` 对象包含所有前端需要的子字段
- [ ] 验证权限过滤逻辑不受影响