### PR TITLE
feat(peers): add status field to peers table for device enable/disable

### DIFF
--- a/src/common/entities/index.ts
+++ b/src/common/entities/index.ts
@@ -2,5 +2,5 @@
  * 共享实体模块
  * 导出所有被多个模块使用的实体
  */
-export { Peer } from './peer.entity';
+export { Peer, PeerStatus } from './peer.entity';
 export { Sysinfo } from './sysinfo.entity';

--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -10,6 +10,16 @@ import {
 } from 'typeorm';
 
 /**
+ * 设备状态枚举
+ * 1: 正常
+ * 0: 禁用
+ */
+export enum PeerStatus {
+  DISABLED = 0,
+  ACTIVE = 1,
+}
+
+/**
  * 设备实体
  * 管理所有注册设备的基本信息
  */
@@ -53,6 +63,16 @@ export class Peer {
   @ManyToOne('DeviceGroup', 'peers', { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'deviceGroupGuid' })
   deviceGroup: any;
+
+  /**
+   * 设备状态
+   * 1: 正常, 0: 禁用
+   */
+  @Column({
+    type: 'integer',
+    default: PeerStatus.ACTIVE,
+  })
+  status: PeerStatus;
 
   /**
    * 版本号

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Patch,
   Delete,
   Body,
@@ -283,6 +284,24 @@ export class DeviceGroupController {
   async enableDevice(@Param('guid') guid: string) {
     await this.deviceGroupService.enableDevice(guid);
     return { message: '设备已启用' };
+  }
+
+  /**
+   * 批量启用/禁用设备
+   * 管理员可以批量启用或禁用设备
+   *
+   * @param body 包含设备GUID列表和禁用标志
+   * @returns 操作结果
+   */
+  @Put('enable-peers')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async enablePeers(
+    @Body() body: { data: { rows: string[]; disable: boolean } },
+  ) {
+    const { rows, disable } = body.data;
+    await this.deviceGroupService.setPeersStatus(rows, !disable);
+    return { message: disable ? '设备已禁用' : '设备已启用' };
   }
 
   /**

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -8,7 +8,7 @@ import { Repository, In } from 'typeorm';
 import * as uuid from 'uuid';
 import { DeviceGroup } from './entities/device-group.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
-import { Peer } from '../../common/entities/peer.entity';
+import { Peer, PeerStatus } from '../../common/entities/peer.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
 
 @Injectable()
@@ -527,7 +527,7 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    peer.userGuid = null;
+    peer.status = PeerStatus.DISABLED;
     await this.peerRepository.save(peer);
   }
 
@@ -543,7 +543,8 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    throw new BadRequestException('无法启用设备，需要重新分配用户');
+    peer.status = PeerStatus.ACTIVE;
+    await this.peerRepository.save(peer);
   }
 
   /**
@@ -559,6 +560,21 @@ export class DeviceGroupService {
     }
 
     await this.peerRepository.remove(peer);
+  }
+
+  /**
+   * 批量设置设备状态
+   * @param guids 设备GUID列表
+   * @param enable true=启用, false=禁用
+   */
+  async setPeersStatus(guids: string[], enable: boolean) {
+    const status = enable ? PeerStatus.ACTIVE : PeerStatus.DISABLED;
+    await this.peerRepository
+      .createQueryBuilder()
+      .update(Peer)
+      .set({ status })
+      .where('uuid IN (:...guids)', { guids })
+      .execute();
   }
 
   /**

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import { Peer, Sysinfo } from '../../common/entities';
+import { Peer, PeerStatus, Sysinfo } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
 import { DeviceGroup } from './entities/device-group.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
@@ -129,7 +129,7 @@ export class PeerService {
       return {
         guid: peer.uuid,
         id: peer.id,
-        status: peer.userGuid ? 1 : 2, // 1=正常, 2=禁用(无关联用户)
+        status: peer.status === PeerStatus.ACTIVE ? 1 : 0,
         user: peer.userGuid || '',
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',


### PR DESCRIPTION
## Summary
- 为 peers 表新增 `status` 字段（1=正常，0=禁用），替代之前通过 `userGuid` 是否存在推断设备状态的逻辑
- 修改 `/api/peers` 接口使用新的 `peer.status` 字段返回设备状态
- 重构 `disableDevice`/`enableDevice` 方法，改为设置 `peer.status` 字段而非清除 `userGuid`
- 新增 `PUT /api/enable-peers` 批量启用/禁用设备接口，对齐前端调用需求

## Changes Detail

### Peer 实体 (`peer.entity.ts`)
- 新增 `PeerStatus` 枚举：`ACTIVE = 1`, `DISABLED = 0`
- 新增 `status` 列，类型 `integer`，默认值 `1`（ACTIVE）
- TypeORM `synchronize: true` 会自动为现有数据添加该列并设置默认值

### /api/peers 接口 (`peer.service.ts`)
- `status` 字段从 `peer.userGuid ? 1 : 2` 改为 `peer.status === PeerStatus.ACTIVE ? 1 : 0`
- 返回值与前端 valueEnum `{1: Normal, 0: Disabled}` 完全对齐

### Enable/Disable 逻辑 (`device-group.service.ts`)
- `disableDevice`: 从 `peer.userGuid = null` 改为 `peer.status = PeerStatus.DISABLED`
- `enableDevice`: 从抛出异常改为 `peer.status = PeerStatus.ACTIVE`
- 新增 `setPeersStatus(guids, enable)` 批量设置状态方法

### 批量接口 (`device-group.controller.ts`)
- 新增 `PUT /api/enable-peers` 接口
- 请求体: `{data: {rows: [guid1, guid2, ...], disable: boolean}}`
- 对齐前端 `Q.xb` 函数的调用格式

## Test plan
- [ ] 验证 peers 表自动添加 status 列，现有数据默认值为 1
- [ ] 验证 `/api/peers` 返回的 status 字段正确反映设备状态
- [ ] 验证禁用设备后 status 变为 0，启用后变为 1
- [ ] 验证 `PUT /api/enable-peers` 批量操作正常工作
- [ ] 验证前端设备列表 Status 列正确显示 Normal/Disabled