### PR TITLE
feat(peers): add status column to peers table for device enable/disable

### DIFF
--- a/src/common/entities/index.ts
+++ b/src/common/entities/index.ts
@@ -2,5 +2,5 @@
  * 共享实体模块
  * 导出所有被多个模块使用的实体
  */
-export { Peer } from './peer.entity';
+export { Peer, PeerStatus } from './peer.entity';
 export { Sysinfo } from './sysinfo.entity';

--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -10,6 +10,16 @@ import {
 } from 'typeorm';
 
 /**
+ * 设备状态枚举
+ * 1: 正常
+ * 0: 禁用
+ */
+export enum PeerStatus {
+  DISABLED = 0,
+  ACTIVE = 1,
+}
+
+/**
  * 设备实体
  * 管理所有注册设备的基本信息
  */
@@ -53,6 +63,16 @@ export class Peer {
   @ManyToOne('DeviceGroup', 'peers', { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'deviceGroupGuid' })
   deviceGroup: any;
+
+  /**
+   * 设备状态
+   * 1: 正常, 0: 禁用
+   */
+  @Column({
+    type: 'integer',
+    default: PeerStatus.ACTIVE,
+  })
+  status: PeerStatus;
 
   /**
    * 版本号

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -8,7 +8,7 @@ import { Repository, In } from 'typeorm';
 import * as uuid from 'uuid';
 import { DeviceGroup } from './entities/device-group.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
-import { Peer } from '../../common/entities/peer.entity';
+import { Peer, PeerStatus } from '../../common/entities/peer.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
 
 @Injectable()
@@ -527,7 +527,7 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    peer.userGuid = null;
+    peer.status = PeerStatus.DISABLED;
     await this.peerRepository.save(peer);
   }
 
@@ -543,7 +543,8 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    throw new BadRequestException('无法启用设备，需要重新分配用户');
+    peer.status = PeerStatus.ACTIVE;
+    await this.peerRepository.save(peer);
   }
 
   /**

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -129,7 +129,7 @@ export class PeerService {
       return {
         guid: peer.uuid,
         id: peer.id,
-        status: peer.userGuid ? 1 : 2, // 1=正常, 2=禁用(无关联用户)
+        status: peer.status,
         user: peer.userGuid || '',
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',


### PR DESCRIPTION
## Summary
- 为 peers 表新增 `status` 字段（1=正常，0=禁用），替代之前通过 `userGuid` 是否存在推断设备状态的逻辑
- `/api/peers` 接口直接返回 `peer.status` 字段值
- `disableDevice`/`enableDevice` 改为设置 `peer.status` 字段

## Changes

| 文件 | 变更 |
|------|------|
| `peer.entity.ts` | 新增 `PeerStatus` 枚举（ACTIVE=1, DISABLED=0）和 `status` 列 |
| `index.ts` | 导出 `PeerStatus` |
| `peer.service.ts` | `status` 直接返回 `peer.status` |
| `device-group.service.ts` | `disableDevice` 设置 `PeerStatus.DISABLED`，`enableDevice` 设置 `PeerStatus.ACTIVE` |

## Test plan
- [ ] 验证 peers 表自动添加 status 列，现有数据默认值为 1
- [ ] 验证 `/api/peers` 返回的 status 字段正确反映设备状态
- [ ] 验证禁用设备后 status 变为 0，启用后变为 1
- [ ] 验证前端设备列表 Status 列正确显示 Normal/Disabled