### PR TITLE
refactor(peer): optimize device list API response fields

### DIFF
--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -118,15 +118,21 @@ export class PeerService {
         : [];
     const userMap = new Map(users.map((u) => [u.guid, u]));
 
-    // 版本号转换函数：将 1004040 格式转换为 1.4.4 格式
+    // 版本号转换函数：将 1001100 格式转换为 1.1.10 格式
+    // 格式说明：major*1000000 + minor*1000 + patch*10 + patch_version
+    // 例如：1.1.10 -> 1001100, 1.1.10-1 -> 1001101
     const formatVersion = (ver: number | null | undefined): string => {
       if (!ver) return '';
-      const verStr = String(ver);
-      // 假设格式为：主版本*1000000 + 次版本*1000 + 修订号
       const major = Math.floor(ver / 1000000);
       const minor = Math.floor((ver % 1000000) / 1000);
-      const patch = ver % 1000;
-      return `${major}.${minor}.${patch}`;
+      const patch = Math.floor((ver % 1000) / 10);
+      const patchVersion = ver % 10;
+
+      let version = `${major}.${minor}.${patch}`;
+      if (patchVersion > 0) {
+        version += `-${patchVersion}`;
+      }
+      return version;
     };
 
     // 转换响应格式

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -118,6 +118,17 @@ export class PeerService {
         : [];
     const userMap = new Map(users.map((u) => [u.guid, u]));
 
+    // 版本号转换函数：将 1004040 格式转换为 1.4.4 格式
+    const formatVersion = (ver: number | null | undefined): string => {
+      if (!ver) return '';
+      const verStr = String(ver);
+      // 假设格式为：主版本*1000000 + 次版本*1000 + 修订号
+      const major = Math.floor(ver / 1000000);
+      const minor = Math.floor((ver % 1000000) / 1000);
+      const patch = ver % 1000;
+      return `${major}.${minor}.${patch}`;
+    };
+
     // 转换响应格式
     const data = peers.map((peer) => {
       const sysinfo = sysinfoMap.get(peer.uuid);
@@ -127,26 +138,24 @@ export class PeerService {
         (peer.deviceGroup as { name?: string } | null)?.name || '';
 
       return {
-        guid: peer.uuid,
         id: peer.id,
+        guid: peer.uuid,
         status: peer.status,
-        user: peer.userGuid || '',
+        is_online: isOnline,
+        last_online: peer.updatedAt.toISOString(),
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',
-        group_name: deviceGroupName,
         device_group_name: deviceGroupName,
         strategy_name: '', // 策略功能未实现，暂返回空
-        last_online: peer.updatedAt.toISOString(),
         info: {
+          hostname: sysinfo?.hostname || '',
           username: sysinfo?.username || '',
           os: sysinfo?.os || '',
-          device_name: sysinfo?.hostname || '',
-          ip: '',
-          version: peer.ver ? String(peer.ver) : '',
+          version: formatVersion(peer.ver),
           cpu: sysinfo?.cpu || '',
           memory: sysinfo?.memory || '',
+          ip: '',
         },
-        is_online: isOnline,
       };
     });
 


### PR DESCRIPTION
## Summary
- Remove `user` and `group_name` fields to simplify response structure
- Rename `device_name` to `hostname` for clearer semantics
- Add version number format conversion (e.g., 1001100 -> 1.1.10, 1001101 -> 1.1.10-1)
- Optimize field ordering for better readability and maintainability

## Changes
### Field Removal
- Removed `user` field (was returning userGuid)
- Removed `group_name` field (duplicate of `device_group_name`)

### Field Renaming
- Renamed `device_name` to `hostname` in info object

### Version Number Conversion
Implemented correct version number parsing based on Rust algorithm:
- Format: `major*1000000 + minor*1000 + patch*10 + patch_version`
- Examples:
  - `1001100` → `1.1.10`
  - `1002030` → `1.2.3`
  - `1001101` → `1.1.10-1` (with patch version)

### Field Ordering
Reorganized response fields in logical order:
1. Basic info: `id`, `guid`, `status`
2. Online status: `is_online`, `last_online`
3. User info: `user_name`, `note`
4. Group info: `device_group_name`, `strategy_name`
5. Detailed info: `info` object

## Test plan
- [ ] Verify device list API returns correct data format
- [ ] Confirm version number conversion works correctly (1001100 -> 1.1.10, 1001101 -> 1.1.10-1)
- [ ] Check field ordering matches expectations
- [ ] Confirm removed fields no longer appear in response
- [ ] Test with various version numbers including patch versions