### PR TITLE
fix: restore device_name field and update user field in peer service response

### DIFF
--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -149,12 +149,13 @@ export class PeerService {
         status: peer.status,
         is_online: isOnline,
         last_online: peer.updatedAt.toISOString(),
+        user: user?.username || '',
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',
         device_group_name: deviceGroupName,
         strategy_name: '', // 策略功能未实现，暂返回空
         info: {
-          hostname: sysinfo?.hostname || '',
+          device_name: sysinfo?.hostname || '',
           username: sysinfo?.username || '',
           os: sysinfo?.os || '',
           version: formatVersion(peer.ver),

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -149,7 +149,7 @@ export class PeerService {
         status: peer.status,
         is_online: isOnline,
         last_online: peer.updatedAt.toISOString(),
-        user: user?.username || '',
+        user: peer.userGuid || '',
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',
         device_group_name: deviceGroupName,


### PR DESCRIPTION
## Summary
- Restore `info.hostname` field back to `info.device_name` to match v1.0.0 format
- Add back the `user` field at top level of the response object
- Change `user` field to return user GUID instead of username

## Changes
This PR modifies `src/modules/device-group/peer.service.ts` to:
1. Changed `info.hostname` to `info.device_name`
2. Added `user` field alongside existing `user_name` field
3. Modified `user` field to return `peer.userGuid` instead of `user?.username`

## Test plan
- [ ] Verify the response contains `info.device_name` instead of `info.hostname`
- [ ] Verify the response includes `user` field with GUID value
- [ ] Verify the response includes `user_name` field with username value
- [ ] Test API endpoints that consume this service