### PR TITLE
feat(ab): add tag, id, alias filtering for peers endpoint

### DIFF
--- a/src/modules/address-book/dto/index.ts
+++ b/src/modules/address-book/dto/index.ts
@@ -10,7 +10,7 @@ export { AddPeerDto, UpdatePeerDto } from './peer.dto';
 export { AddTagDto, UpdateTagDto, RenameTagDto } from './tag.dto';
 
 /** 查询相关 DTO - 分页查询、设备列表查询 */
-export { PaginationDto, PeersQueryDto } from './query.dto';
+export { PaginationDto, PeersQueryDto, TagMatchMode } from './query.dto';
 
 /** 规则相关 DTO - 规则查询、创建和更新 */
 export { RuleQueryDto, CreateRuleDto, UpdateRuleDto } from './rule.dto';

--- a/src/modules/address-book/dto/query.dto.ts
+++ b/src/modules/address-book/dto/query.dto.ts
@@ -4,6 +4,8 @@ import {
   IsOptional,
   Min,
   IsNotEmpty,
+  IsArray,
+  IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -44,6 +46,22 @@ export class PaginationDto {
 }
 
 /**
+ * 标签匹配模式枚举
+ */
+export enum TagMatchMode {
+  /**
+   * 并集模式（OR）
+   * 匹配任意一个标签即可
+   */
+  UNION = 'union',
+  /**
+   * 交集模式（AND）
+   * 必须匹配所有标签
+   */
+  INTERSECTION = 'intersection',
+}
+
+/**
  * 设备列表查询数据传输对象
  * 继承分页参数，增加地址簿标识参数
  */
@@ -58,7 +76,7 @@ export class PeersQueryDto extends PaginationDto {
 
   /**
    * 设备ID过滤
-   * 用于按设备ID筛选
+   * 用于按设备ID模糊匹配
    */
   @IsOptional()
   @IsString()
@@ -66,9 +84,28 @@ export class PeersQueryDto extends PaginationDto {
 
   /**
    * 别名过滤
-   * 用于按别名筛选
+   * 用于按别名模糊匹配
    */
   @IsOptional()
   @IsString()
   alias?: string;
+
+  /**
+   * 标签过滤
+   * 用于按标签精确匹配，支持多个标签
+   */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  /**
+   * 标签匹配模式
+   * union: 并集（匹配任意一个标签）
+   * intersection: 交集（必须匹配所有标签）
+   * 默认值: union
+   */
+  @IsOptional()
+  @IsEnum(TagMatchMode)
+  tagMode?: TagMatchMode = TagMatchMode.UNION;
 }

--- a/src/modules/address-book/services/address-book-peer.service.ts
+++ b/src/modules/address-book/services/address-book-peer.service.ts
@@ -12,7 +12,7 @@ import {
   AddressBookPeerTag,
   ShareRule,
 } from '../entities';
-import { AddPeerDto, UpdatePeerDto, PeersQueryDto } from '../dto';
+import { AddPeerDto, UpdatePeerDto, PeersQueryDto, TagMatchMode } from '../dto';
 import { Sysinfo, Peer } from '../../../common/entities';
 
 @Injectable()
@@ -59,7 +59,7 @@ export class AddressBookPeerService {
       rule: ShareRule,
     ) => Promise<AddressBook>,
   ) {
-    const { current = 1, pageSize = 100, ab, id, alias } = query;
+    const { current = 1, pageSize = 100, ab, id, alias, tags, tagMode = TagMatchMode.UNION } = query;
     const skip = (current - 1) * pageSize;
 
     const addressBook = await this.addressBookRepository.findOne({
@@ -93,6 +93,35 @@ export class AddressBookPeerService {
         )`,
         { id: `%${id}%` },
       );
+    }
+
+    // 按标签过滤（精确匹配）
+    if (tags && tags.length > 0) {
+      if (tagMode === TagMatchMode.INTERSECTION) {
+        // 交集模式：必须包含所有标签
+        queryBuilder.andWhere(
+          `abp.guid IN (
+            SELECT apt.peerGuid 
+            FROM address_book_peer_tags apt
+            JOIN address_book_tags t ON apt.tagGuid = t.guid
+            WHERE t.addressBookGuid = :addressBookGuid AND t.name IN (:...tagNames)
+            GROUP BY apt.peerGuid
+            HAVING COUNT(DISTINCT t.name) = :tagCount
+          )`,
+          { tagNames: tags, tagCount: tags.length },
+        );
+      } else {
+        // 并集模式（默认）：匹配任意一个标签即可
+        queryBuilder.andWhere(
+          `abp.guid IN (
+            SELECT DISTINCT apt.peerGuid 
+            FROM address_book_peer_tags apt
+            JOIN address_book_tags t ON apt.tagGuid = t.guid
+            WHERE t.addressBookGuid = :addressBookGuid AND t.name IN (:...tagNames)
+          )`,
+          { tagNames: tags },
+        );
+      }
     }
 
     const [peers, total] = await queryBuilder


### PR DESCRIPTION
## Summary
- Add advanced filtering capabilities for the `/ab/peers` endpoint
- Implement tag exact matching with support for union/intersection modes
- Support id and alias fuzzy matching

## Changes

### New Features
1. **Tag Filtering**
   - Add `tags` parameter for exact tag matching
   - Add `tagMode` parameter with two modes:
     - `union` (default): Match peers with ANY of the specified tags
     - `intersection`: Match peers with ALL specified tags

2. **ID Fuzzy Matching**
   - Support partial ID matching using LIKE query
   - Already existed, preserved in this update

3. **Alias Fuzzy Matching**
   - Support partial alias matching using LIKE query
   - Already existed, preserved in this update

### Modified Files
- `src/modules/address-book/dto/query.dto.ts`
  - Add `TagMatchMode` enum
  - Extend `PeersQueryDto` with `tags` and `tagMode` fields
  
- `src/modules/address-book/services/address-book-peer.service.ts`
  - Implement tag filtering logic with union/intersection support
  - Import `TagMatchMode` enum

- `src/modules/address-book/dto/index.ts`
  - Export `TagMatchMode` enum

## API Usage

### Request Example
```
GET /api/ab/peers?ab=<guid>&tags=server,production&tagMode=intersection&id=123&alias=test
```

### Parameters
| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| ab | string | ✅ | Address book GUID |
| tags | string[] | ❌ | Array of tag names for exact matching |
| tagMode | enum | ❌ | Matching mode: `union` (default) or `intersection` |
| id | string | ❌ | Device ID (fuzzy matching) |
| alias | string | ❌ | Alias (fuzzy matching) |

## Testing
- ✅ Build successful
- ✅ Code compiles without errors

## Technical Details

### Union Mode (OR)
Returns peers that have at least one of the specified tags:
```sql
SELECT DISTINCT apt.peerGuid 
FROM address_book_peer_tags apt
JOIN address_book_tags t ON apt.tagGuid = t.guid
WHERE t.addressBookGuid = :addressBookGuid AND t.name IN (:...tagNames)
```

### Intersection Mode (AND)
Returns peers that have all specified tags:
```sql
SELECT apt.peerGuid 
FROM address_book_peer_tags apt
JOIN address_book_tags t ON apt.tagGuid = t.guid
WHERE t.addressBookGuid = :addressBookGuid AND t.name IN (:...tagNames)
GROUP BY apt.peerGuid
HAVING COUNT(DISTINCT t.name) = :tagCount
```