### PR TITLE
fix(ab): support single tag parameter in peers query

### DIFF
--- a/src/modules/address-book/dto/query.dto.ts
+++ b/src/modules/address-book/dto/query.dto.ts
@@ -7,7 +7,7 @@ import {
   IsArray,
   IsEnum,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
 
 /**
  * 分页查询数据传输对象
@@ -93,8 +93,13 @@ export class PeersQueryDto extends PaginationDto {
   /**
    * 标签过滤
    * 用于按标签精确匹配，支持多个标签
+   * 支持单个标签或多个标签（重复参数名）
    */
   @IsOptional()
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+    return Array.isArray(value) ? value : [value];
+  })
   @IsArray()
   @IsString({ each: true })
   tags?: string[];


### PR DESCRIPTION
## Summary
- Add Transform decorator to convert single string to array for tags parameter
- Allows both single tag (tags=tag1) and multiple tags (tags=tag1&tags=tag2)

## Problem
When querying with a single tag parameter like , the API returned error:
```
{"message":["tags must be an array"],"error":"Bad Request","statusCode":400}
```

## Solution
Add @Transform decorator to automatically convert single string to array.

## Usage
```
# Single tag
GET /api/ab/peers?ab=xxx&tags=mytag

# Multiple tags (union)
GET /api/ab/peers?ab=xxx&tags=tag1&tags=tag2

# Multiple tags (intersection)
GET /api/ab/peers?ab=xxx&tags=tag1&tags=tag2&tagMode=intersection
```