### PR TITLE
fix: resolve @typescript-eslint/no-unsafe-return lint error

### DIFF
--- a/src/modules/address-book/dto/query.dto.ts
+++ b/src/modules/address-book/dto/query.dto.ts
@@ -96,7 +96,7 @@ export class PeersQueryDto extends PaginationDto {
    * 支持单个标签或多个标签（重复参数名）
    */
   @IsOptional()
-  @Transform(({ value }) => {
+  @Transform(({ value }: { value: string | string[] }) => {
     if (!value) return undefined;
     return Array.isArray(value) ? value : [value];
   })

--- a/src/modules/address-book/services/address-book-peer.service.ts
+++ b/src/modules/address-book/services/address-book-peer.service.ts
@@ -59,7 +59,15 @@ export class AddressBookPeerService {
       rule: ShareRule,
     ) => Promise<AddressBook>,
   ) {
-    const { current = 1, pageSize = 100, ab, id, alias, tags, tagMode = TagMatchMode.UNION } = query;
+    const {
+      current = 1,
+      pageSize = 100,
+      ab,
+      id,
+      alias,
+      tags,
+      tagMode = TagMatchMode.UNION,
+    } = query;
     const skip = (current - 1) * pageSize;
 
     const addressBook = await this.addressBookRepository.findOne({

--- a/src/modules/device-group/dto/peer.dto.ts
+++ b/src/modules/device-group/dto/peer.dto.ts
@@ -1,4 +1,11 @@
-import { IsString, IsNumber, Min, IsInt, IsOptional, IsIn } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  Min,
+  IsInt,
+  IsOptional,
+  IsIn,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 /**

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -111,7 +111,9 @@ export class PeerService {
     if (is_online === '1') {
       queryBuilder.andWhere('peer.updatedAt > :oneMinuteAgo', { oneMinuteAgo });
     } else if (is_online === '0') {
-      queryBuilder.andWhere('peer.updatedAt <= :oneMinuteAgo', { oneMinuteAgo });
+      queryBuilder.andWhere('peer.updatedAt <= :oneMinuteAgo', {
+        oneMinuteAgo,
+      });
     }
 
     // 按用户名筛选（模糊匹配）


### PR DESCRIPTION
## Summary
- Add explicit type annotation `string | string[]` to the `value` parameter in the `@Transform` decorator callback in `PeersQueryDto` (`src/modules/address-book/dto/query.dto.ts`)
- This resolves the `@typescript-eslint/no-unsafe-return` lint error caused by the implicit `any` type

## Test plan
- [x] `npm run lint` passes with no errors