### PR TITLE
fix(ci): scope changelog to changes since last release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,11 +104,23 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Get previous tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF#refs/tags/}$" | head -n1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "has-previous=false" >> $GITHUB_OUTPUT
+          else
+            echo "has-previous=true" >> $GITHUB_OUTPUT
+            echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate changelog
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          from-tag: ${{ steps.prev-tag.outputs.tag }}
           version-file: package.json
           version-path: version
           skip-git-pull: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,18 +117,11 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: metcalfc/changelog-generator@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          from-tag: ${{ steps.prev-tag.outputs.tag }}
-          version-file: package.json
-          version-path: version
-          skip-git-pull: 'true'
-          skip-commit: 'true'
-          skip-tag: 'true'
-          skip-on-empty: 'true'
-          skip-bump: 'true'
-          output-file: 'false'
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+          headRef: ${{ github.ref_name }}
+          baseRef: ${{ steps.prev-tag.outputs.tag }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

- Replace `TriPSs/conventional-changelog-action@v5` with `metcalfc/changelog-generator@v4`
- Use `headRef` and `baseRef` parameters to generate changelog between two tags
- This ensures the Release body only includes commits since the last release

## Problem

When releasing v1.1.0, the generated Release description included all commits from the entire project history instead of only the changes since v1.0.0.

The previous fix attempted to use `from-tag` parameter with `TriPSs/conventional-changelog-action@v5`, but that action **does not support** this parameter (see warning in Action logs).

## Solution

Use `metcalfc/changelog-generator@v4` which natively supports:
- `headRef`: The target tag (current release)
- `baseRef`: The previous tag (last release)

This generates changelog only for commits between the two tags.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a new release (e.g., by pushing a new tag like v1.1.1)
- [ ] Verify the changelog only includes commits since the previous tag
- [ ] For the first release (no previous tag), verify behavior is graceful