### PR TITLE
feat(workflow): update release workflow to use manual trigger and conventional changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,8 +36,7 @@ jobs:
         uses: TriPSs/conventional-changelog-action@v5
         id: changelog
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          git-message: 'chore(release): {version}'
+          github-token: ${{ secrets.RELEASE_TOKEN }}
           tag-prefix: ''
 
       - name: Build and push Docker images
@@ -110,7 +108,3 @@ jobs:
             ```
           draft: false
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number (without v prefix, e.g., 1.0.0)'
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -43,20 +38,13 @@ jobs:
         id: changelog
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ inputs.version }}
-          git-message: 'chore(release): v{version}'
-          git-user-name: 'github-actions[bot]'
-          git-user-email: 'github-actions[bot]@users.noreply.github.com'
-          preset: 'conventionalcommits'
-          release-count: 1
-          skip-commit: false
-          skip-tag: false
-          skip-on-empty: true
+          git-message: 'chore(release): {version}'
+          tag-prefix: ''
 
       - name: Build and push Docker images
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
-          VERSION=${{ inputs.version }}
+          VERSION=${{ steps.changelog.outputs.version }}
           MAJOR=$(echo $VERSION | cut -d. -f1)
           
           docker buildx create --use
@@ -89,8 +77,8 @@ jobs:
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v1
         with:
-          tag: v${{ inputs.version }}
-          name: v${{ inputs.version }}
+          tag: ${{ steps.changelog.outputs.version }}
+          name: ${{ steps.changelog.outputs.version }}
           body: |
             ${{ steps.changelog.outputs.changelog }}
             
@@ -100,13 +88,13 @@ jobs:
             
             ### Docker Hub
             ```bash
-            docker pull databk/rustdesk-console:${{ inputs.version }}
+            docker pull databk/rustdesk-console:${{ steps.changelog.outputs.version }}
             docker pull databk/rustdesk-console:latest
             ```
             
             ### GitHub Container Registry
             ```bash
-            docker pull ghcr.io/databk/rustdesk-console:${{ inputs.version }}
+            docker pull ghcr.io/databk/rustdesk-console:${{ steps.changelog.outputs.version }}
             docker pull ghcr.io/databk/rustdesk-console:latest
             ```
             
@@ -118,7 +106,7 @@ jobs:
               -p 3000:3000 \
               -e JWT_SECRET=your-secret-key \
               -e ADMIN_PASSWORD=your-password \
-              databk/rustdesk-console:${{ inputs.version }}
+              databk/rustdesk-console:${{ steps.changelog.outputs.version }}
             ```
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,27 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (without v prefix, e.g., 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
   packages: write
 
 jobs:
-  build:
-    name: Build
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -32,101 +38,59 @@ jobs:
       - name: Build application
         run: npm run build
 
-  build-docker:
-    name: Build Docker Images
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major=$(echo $VERSION | cut -d. -f1)" >> $GITHUB_OUTPUT
-          echo "minor=$(echo $VERSION | cut -d. -f2)" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: |
-            databk/rustdesk-console:latest
-            databk/rustdesk-console:${{ steps.version.outputs.version }}
-            databk/rustdesk-console:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push to GitHub Container Registry
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/databk/rustdesk-console:latest
-            ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.version }}
-            ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  create-release:
-    name: Create GitHub Release
-    needs: [build, build-docker]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Get previous tag
-        id: prev-tag
-        run: |
-          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF#refs/tags/}$" | head -n1)
-          if [ -z "$PREV_TAG" ]; then
-            echo "has-previous=false" >> $GITHUB_OUTPUT
-          else
-            echo "has-previous=true" >> $GITHUB_OUTPUT
-            echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
-          fi
-
       - name: Generate changelog
+        uses: TriPSs/conventional-changelog-action@v5
         id: changelog
-        uses: metcalfc/changelog-generator@v4
         with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
-          headRef: ${{ github.ref_name }}
-          baseRef: ${{ steps.prev-tag.outputs.tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ inputs.version }}
+          git-message: 'chore(release): v{version}'
+          git-user-name: 'github-actions[bot]'
+          git-user-email: 'github-actions[bot]@users.noreply.github.com'
+          preset: 'conventionalcommits'
+          release-count: 1
+          skip-commit: false
+          skip-tag: false
+          skip-on-empty: true
 
-      - name: Create Release
+      - name: Build and push Docker images
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: |
+          VERSION=${{ inputs.version }}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          
+          docker buildx create --use
+          
+          # Login to Docker Hub
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+          
+          # Login to GitHub Container Registry
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          
+          # Build and push to Docker Hub
+          docker buildx build --push \
+            --tag databk/rustdesk-console:latest \
+            --tag databk/rustdesk-console:$VERSION \
+            --tag databk/rustdesk-console:$MAJOR \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            .
+          
+          # Build and push to GitHub Container Registry
+          docker buildx build --push \
+            --tag ghcr.io/databk/rustdesk-console:latest \
+            --tag ghcr.io/databk/rustdesk-console:$VERSION \
+            --tag ghcr.io/databk/rustdesk-console:$MAJOR \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            .
+
+      - name: Create GitHub Release
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ steps.version.outputs.version }}
+          tag: v${{ inputs.version }}
+          name: v${{ inputs.version }}
           body: |
             ${{ steps.changelog.outputs.changelog }}
             
@@ -136,13 +100,13 @@ jobs:
             
             ### Docker Hub
             ```bash
-            docker pull databk/rustdesk-console:${{ steps.version.outputs.version }}
+            docker pull databk/rustdesk-console:${{ inputs.version }}
             docker pull databk/rustdesk-console:latest
             ```
             
             ### GitHub Container Registry
             ```bash
-            docker pull ghcr.io/databk/rustdesk-console:${{ steps.version.outputs.version }}
+            docker pull ghcr.io/databk/rustdesk-console:${{ inputs.version }}
             docker pull ghcr.io/databk/rustdesk-console:latest
             ```
             
@@ -154,10 +118,11 @@ jobs:
               -p 3000:3000 \
               -e JWT_SECRET=your-secret-key \
               -e ADMIN_PASSWORD=your-password \
-              databk/rustdesk-console:${{ steps.version.outputs.version }}
+              databk/rustdesk-console:${{ inputs.version }}
             ```
           draft: false
           prerelease: false
-          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
## Summary

- Change release workflow trigger from tag push to manual `workflow_dispatch`
- Add version input parameter (without v prefix, e.g., `1.0.0`)
- Replace `metcalfc/changelog-generator@v4` with `TriPSs/conventional-changelog-action@v5`
- Consolidate build, docker, and release steps into a single job for better workflow
- Auto-generate release commit and tag using conventional-changelog-action
- Update Docker build process to use buildx directly

## Changes

### Workflow Trigger
- **Before**: Triggered on tag push (`*.*.*`)
- **After**: Manual trigger with version input parameter

### Changelog Generation
- **Before**: `metcalfc/changelog-generator@v4`
- **After**: `TriPSs/conventional-changelog-action@v5` with conventionalcommits preset

### Workflow Structure
- **Before**: 3 separate jobs (build, build-docker, create-release)
- **After**: Single consolidated job (release) for better efficiency

### Release Process
- Automatically creates release commit with message `chore(release): v{version}`
- Automatically creates git tag `v{version}`
- Creates GitHub release with changelog and Docker image information

## Test Plan

- [ ] Verify workflow can be manually triggered from GitHub Actions UI
- [ ] Test with a version number input (e.g., `1.0.0`)
- [ ] Verify changelog is generated correctly based on conventional commits
- [ ] Verify release commit and tag are created
- [ ] Verify Docker images are built and pushed correctly
- [ ] Verify GitHub release is created with proper changelog