### PR TITLE
refactor(sysinfo): remove address book fields from sysinfos table

### DIFF
--- a/src/common/entities/sysinfo.entity.ts
+++ b/src/common/entities/sysinfo.entity.ts
@@ -26,21 +26,6 @@ export class Sysinfo {
   @Column({ nullable: true })
   memory: string;
 
-  @Column({ name: 'preset_address_book_name', nullable: true })
-  presetAddressBookName: string;
-
-  @Column({ name: 'preset_address_book_tag', nullable: true })
-  presetAddressBookTag: string;
-
-  @Column({ name: 'preset_address_book_alias', nullable: true })
-  presetAddressBookAlias: string;
-
-  @Column({ name: 'preset_address_book_password', nullable: true })
-  presetAddressBookPassword: string;
-
-  @Column({ name: 'preset_address_book_note', nullable: true })
-  presetAddressBookNote: string;
-
   @Column({ name: 'preset_username', nullable: true })
   presetUsername: string;
 

--- a/src/modules/sysinfo/entities/sysinfo.entity.ts
+++ b/src/modules/sysinfo/entities/sysinfo.entity.ts
@@ -26,21 +26,6 @@ export class Sysinfo {
   @Column({ nullable: true })
   memory: string;
 
-  @Column({ name: 'preset_address_book_name', nullable: true })
-  presetAddressBookName: string;
-
-  @Column({ name: 'preset_address_book_tag', nullable: true })
-  presetAddressBookTag: string;
-
-  @Column({ name: 'preset_address_book_alias', nullable: true })
-  presetAddressBookAlias: string;
-
-  @Column({ name: 'preset_address_book_password', nullable: true })
-  presetAddressBookPassword: string;
-
-  @Column({ name: 'preset_address_book_note', nullable: true })
-  presetAddressBookNote: string;
-
   @Column({ name: 'preset_username', nullable: true })
   presetUsername: string;
 

--- a/src/modules/sysinfo/sysinfo.service.ts
+++ b/src/modules/sysinfo/sysinfo.service.ts
@@ -70,26 +70,6 @@ export class SysinfoService {
         existingSysinfo.memory = sysinfoDto.memory;
 
       // 更新预设字段（如果提供了新值）
-      if (sysinfoDto['preset-address-book-name']) {
-        existingSysinfo.presetAddressBookName =
-          sysinfoDto['preset-address-book-name'];
-      }
-      if (sysinfoDto['preset-address-book-tag']) {
-        existingSysinfo.presetAddressBookTag =
-          sysinfoDto['preset-address-book-tag'];
-      }
-      if (sysinfoDto['preset-address-book-alias']) {
-        existingSysinfo.presetAddressBookAlias =
-          sysinfoDto['preset-address-book-alias'];
-      }
-      if (sysinfoDto['preset-address-book-password']) {
-        existingSysinfo.presetAddressBookPassword =
-          sysinfoDto['preset-address-book-password'];
-      }
-      if (sysinfoDto['preset-address-book-note']) {
-        existingSysinfo.presetAddressBookNote =
-          sysinfoDto['preset-address-book-note'];
-      }
       if (sysinfoDto['preset-username']) {
         existingSysinfo.presetUsername = sysinfoDto['preset-username'];
       }
@@ -115,11 +95,6 @@ export class SysinfoService {
         os: sysinfoDto.os,
         cpu: sysinfoDto.cpu,
         memory: sysinfoDto.memory,
-        presetAddressBookName: sysinfoDto['preset-address-book-name'],
-        presetAddressBookTag: sysinfoDto['preset-address-book-tag'],
-        presetAddressBookAlias: sysinfoDto['preset-address-book-alias'],
-        presetAddressBookPassword: sysinfoDto['preset-address-book-password'],
-        presetAddressBookNote: sysinfoDto['preset-address-book-note'],
         presetUsername: sysinfoDto['preset-username'],
         presetStrategyName: sysinfoDto['preset-strategy-name'],
         presetDeviceGroupName: sysinfoDto['preset-device-group-name'],
@@ -130,7 +105,7 @@ export class SysinfoService {
     const savedSysinfo = await this.sysinfoRepository.save(sysinfo);
 
     // 处理预设功能
-    await this.processPresetSettings(savedSysinfo);
+    await this.processPresetSettings(savedSysinfo, sysinfoDto);
 
     return savedSysinfo;
   }
@@ -140,13 +115,25 @@ export class SysinfoService {
    * 根据预设配置自动添加设备到地址簿和设备组
    *
    * @param sysinfo 系统信息对象
+   * @param dto 系统信息DTO
    * @private
    */
-  private async processPresetSettings(sysinfo: Sysinfo): Promise<void> {
+  private async processPresetSettings(
+    sysinfo: Sysinfo,
+    dto: SysinfoDto,
+  ): Promise<void> {
     try {
       // 处理预设地址簿
-      if (sysinfo.presetAddressBookName) {
-        await this.addToAddressBook(sysinfo);
+      if (dto['preset-address-book-name']) {
+        await this.addToAddressBook(
+          sysinfo.uuid,
+          sysinfo.hostname,
+          dto['preset-address-book-name'],
+          dto['preset-address-book-tag'],
+          dto['preset-address-book-alias'],
+          dto['preset-address-book-password'],
+          dto['preset-address-book-note'],
+        );
       }
 
       // 处理预设设备组
@@ -166,39 +153,53 @@ export class SysinfoService {
    * 将设备添加到预设地址簿
    * 根据预设配置自动将设备添加到指定的地址簿
    *
-   * @param sysinfo 系统信息对象
+   * @param deviceId 设备ID
+   * @param hostname 主机名
+   * @param addressBookName 地址簿名称
+   * @param tag 标签（可选）
+   * @param alias 别名（可选）
+   * @param password 密码（可选）
+   * @param note 备注（可选）
    * @private
    */
-  private async addToAddressBook(sysinfo: Sysinfo): Promise<void> {
+  private async addToAddressBook(
+    deviceId: string,
+    hostname: string,
+    addressBookName: string,
+    tag?: string,
+    alias?: string,
+    password?: string,
+    note?: string,
+  ): Promise<void> {
     // 查找或创建地址簿
     const addressBook = await this.addressBookRepository.findOne({
-      where: { name: sysinfo.presetAddressBookName },
+      where: { name: addressBookName },
     });
 
     if (!addressBook) {
       // 如果地址簿不存在，跳过添加
       this.logger.warn(
-        `预设地址簿 "${sysinfo.presetAddressBookName}" 不存在，跳过添加设备`,
+        `预设地址簿 "${addressBookName}" 不存在，跳过添加设备`,
       );
       return;
     }
 
     // 检查设备是否已存在于地址簿
     const existingPeer = await this.addressBookPeerRepository.findOne({
-      where: { deviceId: sysinfo.uuid, addressBookGuid: addressBook.guid },
+      where: { deviceId: deviceId, addressBookGuid: addressBook.guid },
     });
 
     if (existingPeer) {
       this.logger.debug(
-        `设备 ${sysinfo.uuid} 已存在于地址簿 ${addressBook.name}`,
+        `设备 ${deviceId} 已存在于地址簿 ${addressBook.name}`,
       );
       return;
     }
 
     // 处理预设标签
     let tags: string[] = [];
-    if (sysinfo.presetAddressBookTag) {
-      tags = sysinfo.presetAddressBookTag
+    if (tag) {
+      tags = tag
         .split(',')
         .map((t) => t.trim())
         .filter((t) => t);
@@ -227,14 +228,14 @@ export class SysinfoService {
     const peer = this.addressBookPeerRepository.create({
       guid: peerGuid,
       addressBookGuid: addressBook.guid,
-      deviceId: sysinfo.uuid,
-      alias: sysinfo.presetAddressBookAlias || sysinfo.hostname,
-      password: sysinfo.presetAddressBookPassword,
-      note: sysinfo.presetAddressBookNote || sysinfo.presetNote,
+      deviceId: deviceId,
+      alias: alias || hostname,
+      password: password,
+      note: note,
     });
 
     await this.addressBookPeerRepository.save(peer);
-    this.logger.log(`设备 ${sysinfo.uuid} 已添加到地址簿 ${addressBook.name}`);
+    this.logger.log(`设备 ${deviceId} 已添加到地址簿 ${addressBook.name}`);
   }
 
   /**

--- a/src/modules/sysinfo/sysinfo.service.ts
+++ b/src/modules/sysinfo/sysinfo.service.ts
@@ -196,29 +196,23 @@ export class SysinfoService {
       return;
     }
 
-    // 处理预设标签
-    let tags: string[] = [];
+    // 处理预设标签（仅验证，不自动创建）
     if (tag) {
-      tags = tag
+      const tags = tag
         .split(',')
         .map((t) => t.trim())
         .filter((t) => t);
 
-      // 确保标签存在
+      // 验证标签是否存在，记录不存在的标签
       for (const tagName of tags) {
         const existingTag = await this.addressBookTagRepository.findOne({
           where: { name: tagName, addressBookGuid: addressBook.guid },
         });
 
         if (!existingTag) {
-          const newTag = this.addressBookTagRepository.create({
-            guid: uuidv4(),
-            addressBookGuid: addressBook.guid,
-            name: tagName,
-            color: 0,
-          });
-          await this.addressBookTagRepository.save(newTag);
-          this.logger.log(`创建标签: ${tagName}`);
+          this.logger.warn(
+            `标签 "${tagName}" 在地址簿 ${addressBook.name} 中不存在，跳过`,
+          );
         }
       }
     }

--- a/src/modules/sysinfo/sysinfo.service.ts
+++ b/src/modules/sysinfo/sysinfo.service.ts
@@ -196,20 +196,23 @@ export class SysinfoService {
       return;
     }
 
-    // 处理预设标签（仅验证，不自动创建）
+    // 处理预设标签（收集已存在的标签，不自动创建）
+    const existingTags: AddressBookTag[] = [];
     if (tag) {
-      const tags = tag
+      const tagNames = tag
         .split(',')
         .map((t) => t.trim())
         .filter((t) => t);
 
-      // 验证标签是否存在，记录不存在的标签
-      for (const tagName of tags) {
+      // 查找已存在的标签
+      for (const tagName of tagNames) {
         const existingTag = await this.addressBookTagRepository.findOne({
           where: { name: tagName, addressBookGuid: addressBook.guid },
         });
 
-        if (!existingTag) {
+        if (existingTag) {
+          existingTags.push(existingTag);
+        } else {
           this.logger.warn(
             `标签 "${tagName}" 在地址簿 ${addressBook.name} 中不存在，跳过`,
           );
@@ -217,7 +220,7 @@ export class SysinfoService {
       }
     }
 
-    // 创建设备记录
+    // 创建设备记录并绑定标签
     const peerGuid = uuidv4();
     const peer = this.addressBookPeerRepository.create({
       guid: peerGuid,
@@ -226,10 +229,13 @@ export class SysinfoService {
       alias: alias || hostname,
       password: password,
       note: note,
+      tags: existingTags,
     });
 
     await this.addressBookPeerRepository.save(peer);
-    this.logger.log(`设备 ${deviceId} 已添加到地址簿 ${addressBook.name}`);
+    this.logger.log(
+      `设备 ${deviceId} 已添加到地址簿 ${addressBook.name}${existingTags.length > 0 ? `，绑定标签: ${existingTags.map((t) => t.name).join(', ')}` : ''}`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Remove `preset_address_book_*` fields from `sysinfos` table to eliminate data redundancy
- Refactor address book handling to process DTO parameters directly instead of storing them in database
- Bind existing tags to devices when adding them to address books (no auto-creation)
- API interface remains unchanged - still accepts address book parameters but processes them directly

## Changes

### Entity Layer
- Removed 5 address book related fields from both `Sysinfo` entity files:
  - `presetAddressBookName`
  - `presetAddressBookTag`
  - `presetAddressBookAlias`
  - `presetAddressBookPassword`
  - `presetAddressBookNote`

### Service Layer
- **createSysinfo method**: No longer stores address book fields in sysinfos table
- **processPresetSettings method**: Updated to accept DTO parameter and pass address book data directly
- **addToAddressBook method**: 
  - Refactored to accept individual parameters instead of sysinfo object
  - Collect existing tags from address book
  - Bind existing tags to device when creating AddressBookPeer
  - Log warning for non-existent tags and skip them
  - Enhanced log message to show bound tags

## Data Flow
**Before**: API → DTO → Store in sysinfos table → processPresetSettings → addToAddressBook → address book tables

**After**: API → DTO → Store in sysinfos table (without address book fields) → processPresetSettings with DTO → addToAddressBook with DTO params → address book tables

## Behavior Details

### Address Book Handling
- ✅ If address book doesn't exist: Log warning and skip adding device
- ✅ If device already exists in address book: Skip update, preserve existing data
- ✅ Only add device when address book exists and device doesn't exist

### Tag Handling
- ✅ Tags must be pre-created manually, system will NOT auto-create them
- ✅ When adding device to address book:
  - Collect all existing tags from the specified tag list
  - Bind collected tags to the device
  - Log warning for non-existent tags and skip them
- ✅ Prevents tags from being recreated after manual deletion
- ✅ Preserves user's tag management decisions

### Example Scenario
```
Device submits sysinfo with:
- preset-address-book-name: "Office"
- preset-address-book-tag: "VIP,Server,Production"

System behavior:
1. Check if "Office" address book exists → Yes
2. Check if device exists in "Office" → No
3. Find existing tags in "Office":
   - "VIP" exists → collect
   - "Server" doesn't exist → log warning, skip
   - "Production" exists → collect
4. Create device in "Office" and bind tags: ["VIP", "Production"]
5. Log: "Device xxx added to address book Office, bound tags: VIP, Production"
```

## Benefits
1. **Data Integrity**: Eliminates redundant storage of address book data in sysinfos table
2. **User Control**: Tags must be explicitly created by users, preventing unwanted auto-creation
3. **Proper Tag Binding**: Devices are properly tagged when added to address books
4. **Consistency**: Existing data always takes priority over new incoming data
5. **Maintainability**: Clear separation between device info and address book configuration

## Test plan
- [ ] Verify API still accepts all address book parameters
- [ ] Verify devices are correctly added to address books
- [ ] Verify existing tags are bound to devices
- [ ] Verify non-existent tags are skipped with warning logs
- [ ] Verify tags are NOT auto-created when they don't exist
- [ ] Verify existing device data is preserved (no updates)
- [ ] Run database migration if needed