### PR TITLE
fix: handle JSON parsing for file audit data in statistics

### DIFF
--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -123,10 +123,25 @@ export class DashboardService {
     let totalFileSize = 0;
     fileRecords.forEach((file) => {
       // 计算文件总大小
-      if (file.files && Array.isArray(file.files)) {
-        file.files.forEach(([, size]) => {
-          totalFileSize += size || 0;
-        });
+      try {
+        if (file.files) {
+          // 处理可能的字符串格式(JSON字符串)
+          let filesArray = file.files;
+          if (typeof file.files === 'string') {
+            filesArray = JSON.parse(file.files);
+          }
+
+          if (Array.isArray(filesArray)) {
+            filesArray.forEach((item) => {
+              if (Array.isArray(item) && item.length >= 2) {
+                const size = item[1];
+                totalFileSize += typeof size === 'number' ? size : 0;
+              }
+            });
+          }
+        }
+      } catch (error) {
+        // 解析失败,跳过此文件
       }
     });
 
@@ -241,11 +256,27 @@ export class DashboardService {
 
     allFileTransfers.forEach((file) => {
       // 计算文件总大小
-      if (file.files && Array.isArray(file.files)) {
-        file.files.forEach(([, size]) => {
-          totalFilesSize += size || 0;
-        });
+      try {
+        if (file.files) {
+          // 处理可能的字符串格式(JSON字符串)
+          let filesArray = file.files;
+          if (typeof file.files === 'string') {
+            filesArray = JSON.parse(file.files);
+          }
+
+          if (Array.isArray(filesArray)) {
+            filesArray.forEach((item) => {
+              if (Array.isArray(item) && item.length >= 2) {
+                const size = item[1];
+                totalFilesSize += typeof size === 'number' ? size : 0;
+              }
+            });
+          }
+        }
+      } catch (error) {
+        // 解析失败,跳过此文件
       }
+
       // 根据类型统计上传/下载
       if (file.type === 0) {
         uploadCount++;


### PR DESCRIPTION
## Summary

Fix TypeError in Dashboard statistics API when processing file audit data.

## Problem

The `/dashboard/statistics` endpoint was throwing a TypeError:
```
TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
```

This occurred when trying to process the `files` field from FileAudit entities.

## Root Cause

In SQLite, JSON columns are stored as strings. When TypeORM reads the `files` field (defined as `Array<[string, number]>`), it may return:
- A JSON string that needs parsing
- An already parsed array
- null/undefined

The original code assumed it was always an array and tried to iterate directly, causing the error.

## Solution

Updated file data processing in both `getOverview()` and `getStatistics()` methods to:

1. **Handle multiple formats**: Check if `files` is a string and parse it
2. **Type safety**: Verify the parsed result is an array before iterating
3. **Error handling**: Wrap in try-catch to gracefully handle malformed data
4. **Proper extraction**: Safely extract file size from tuple `[filename, size]`

## Changes

- `src/modules/dashboard/dashboard.service.ts`
  - Updated file size calculation in `getOverview()` method
  - Updated file size calculation in `getStatistics()` method
  - Added JSON parsing for string format
  - Added array type checking
  - Added error handling

## Testing

- ✅ Code compiles successfully
- ✅ Handles JSON string format
- ✅ Handles array format
- ✅ Handles null/undefined gracefully
- ✅ Matches audit service's data structure

## Related

Fixes the 500 error reported when calling `/dashboard/statistics` endpoint.