### PR TITLE
fix(dashboard): resolve device name to hostname from sysinfos table

### DIFF
--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -9,6 +9,7 @@ import { DeviceGroup } from '../device-group/entities/device-group.entity';
 import { ConnectionAudit } from '../audit/entities/connection-audit.entity';
 import { FileAudit } from '../audit/entities/file-audit.entity';
 import { AlarmAudit } from '../audit/entities/alarm-audit.entity';
+import { Sysinfo } from '../../common/entities/sysinfo.entity';
 import { AuthModule } from '../auth/auth.module';
 
 /**
@@ -32,6 +33,7 @@ import { AuthModule } from '../auth/auth.module';
       ConnectionAudit,
       FileAudit,
       AlarmAudit,
+      Sysinfo,
     ]),
     AuthModule,
   ],

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -8,6 +8,7 @@ import { DeviceGroup } from '../device-group/entities/device-group.entity';
 import { ConnectionAudit } from '../audit/entities/connection-audit.entity';
 import { FileAudit } from '../audit/entities/file-audit.entity';
 import { AlarmAudit } from '../audit/entities/alarm-audit.entity';
+import { Sysinfo } from '../../common/entities/sysinfo.entity';
 import {
   DashboardOverviewDto,
   DashboardStatisticsDto,
@@ -34,6 +35,8 @@ export class DashboardService {
     private readonly fileAuditRepository: Repository<FileAudit>,
     @InjectRepository(AlarmAudit)
     private readonly alarmAuditRepository: Repository<AlarmAudit>,
+    @InjectRepository(Sysinfo)
+    private readonly sysinfoRepository: Repository<Sysinfo>,
   ) {}
 
   /**
@@ -386,12 +389,21 @@ export class DashboardService {
     recentAlarmEvents.forEach((e) => allDeviceUuids.add(e.deviceUuid));
 
     const uuidToIdMap = new Map<string, string>();
+    const uuidToHostnameMap = new Map<string, string>();
     if (allDeviceUuids.size > 0) {
       const peers = await this.peerRepository
         .createQueryBuilder('peer')
         .where('peer.uuid IN (:...uuids)', { uuids: Array.from(allDeviceUuids) })
         .getMany();
       peers.forEach((peer) => uuidToIdMap.set(peer.uuid, peer.id));
+
+      const sysinfos = await this.sysinfoRepository
+        .createQueryBuilder('sysinfo')
+        .where('sysinfo.uuid IN (:...uuids)', { uuids: Array.from(allDeviceUuids) })
+        .getMany();
+      sysinfos.forEach((s) => {
+        if (s.hostname) uuidToHostnameMap.set(s.uuid, s.hostname);
+      });
     }
 
     const activeConnections = recentConnections.map((conn) => ({
@@ -399,7 +411,7 @@ export class DashboardService {
       userId: conn.peerId || 'unknown',
       userName: conn.peerName || 'unknown',
       deviceId: uuidToIdMap.get(conn.deviceUuid) || conn.deviceId,
-      deviceName: conn.deviceUuid,
+      deviceName: uuidToHostnameMap.get(conn.deviceUuid) || conn.deviceUuid,
       startTime: conn.establishedAt || conn.createdAt,
       duration: conn.closedAt && conn.establishedAt
         ? Math.round((conn.closedAt.getTime() - conn.establishedAt.getTime()) / 1000 / 60)


### PR DESCRIPTION
## Summary
- Fix Dashboard realtime API returning UUID as `deviceName` instead of the actual hostname
- Batch-query the `sysinfos` table to build a `uuid -> hostname` mapping, then use the hostname in the response
- Affects `activeConnections[].deviceName`

## Changes
- `src/modules/dashboard/dashboard.module.ts`: Add `Sysinfo` entity to `TypeOrmModule.forFeature`
- `src/modules/dashboard/dashboard.service.ts`: Inject `Sysinfo` repository, query `sysinfos` table for hostname by UUID, and use mapped hostname as `deviceName`. Falls back to UUID when hostname is not available.

## Test plan
- [ ] Verify `/api/dashboard/realtime` returns hostname in `activeConnections[].deviceName` when sysinfo record exists
- [ ] Verify fallback to UUID when no sysinfo record or hostname is null