### PR TITLE
fix(throttler): resolve rate limiting double counting issue

### DIFF
--- a/src/modules/heartbeat/heartbeat.controller.ts
+++ b/src/modules/heartbeat/heartbeat.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { HeartbeatService } from './heartbeat.service';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { Public } from '../auth/decorators/public.decorator';
+import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard';
 
 /**
  * 心跳控制器
@@ -12,6 +13,7 @@ import { Public } from '../auth/decorators/public.decorator';
  * - POST /api/heartbeat - 接收设备心跳
  */
 @Controller('heartbeat')
+@UseGuards(DeviceThrottlerGuard)
 export class HeartbeatController {
   constructor(private readonly HeartbeatService: HeartbeatService) {}
 

--- a/src/modules/heartbeat/heartbeat.module.ts
+++ b/src/modules/heartbeat/heartbeat.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { APP_GUARD } from '@nestjs/core';
 import { HeartbeatController } from './heartbeat.controller';
 import { HeartbeatService } from './heartbeat.service';
 import { Peer } from '../../common/entities';
@@ -24,10 +23,6 @@ import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard
   controllers: [HeartbeatController],
   providers: [
     HeartbeatService,
-    {
-      provide: APP_GUARD,
-      useClass: DeviceThrottlerGuard,
-    },
   ],
   exports: [HeartbeatService],
 })

--- a/src/modules/sysinfo/sysinfo.controller.ts
+++ b/src/modules/sysinfo/sysinfo.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { SysinfoService } from './sysinfo.service';
 import { SysinfoDto } from './dto/sysinfo.dto';
 import { Public } from '../auth/decorators/public.decorator';
+import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard';
 
 /**
  * 系统信息控制器
@@ -12,6 +13,7 @@ import { Public } from '../auth/decorators/public.decorator';
  * - POST /api/sysinfo - 提交系统信息
  */
 @Controller()
+@UseGuards(DeviceThrottlerGuard)
 export class SysinfoController {
   constructor(private readonly sysinfoService: SysinfoService) {}
 

--- a/src/modules/sysinfo/sysinfo.module.ts
+++ b/src/modules/sysinfo/sysinfo.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { APP_GUARD } from '@nestjs/core';
 import { SysinfoController } from './sysinfo.controller';
 import { SysinfoService } from './sysinfo.service';
 import { Sysinfo, Peer } from '../../common/entities';
@@ -39,10 +38,6 @@ import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard
   controllers: [SysinfoController],
   providers: [
     SysinfoService,
-    {
-      provide: APP_GUARD,
-      useClass: DeviceThrottlerGuard,
-    },
   ],
   exports: [SysinfoService],
 })


### PR DESCRIPTION
## Summary

Fix the rate limiting double counting bug where requests were counted twice, causing the configured limit to be effectively halved (e.g., limit=5 only allowed 2 requests).

## Problem

The login endpoint and other rate-limited endpoints were experiencing double counting, where each request was being counted twice by the throttling system. This was caused by incorrect usage of `APP_GUARD` in multiple modules.

## Root Cause

- **sysinfo.module.ts** and **heartbeat.module.ts** were incorrectly registering `DeviceThrottlerGuard` as a global `APP_GUARD`
- Combined with the global `ThrottlerGuard` already registered in **app.module.ts**, this resulted in each request being processed by **2 global guards**
- Each guard independently incremented the counter, causing double counting

## Solution

1. **Remove** incorrect `APP_GUARD` registrations from:
   - `src/modules/sysinfo/sysinfo.module.ts`
   - `src/modules/heartbeat/heartbeat.module.ts`

2. **Add** controller-level guards using `@UseGuards(DeviceThrottlerGuard)`:
   - `src/modules/sysinfo/sysinfo.controller.ts`
   - `src/modules/heartbeat/heartbeat.controller.ts`

3. **Keep** the global `ThrottlerGuard` in `app.module.ts` for default rate limiting

## Changes

- Modified 4 files
- Removed duplicate global guard registrations
- Added proper controller-level guard decorations
- Maintains existing functionality while fixing the double counting issue

## Testing

Verified that:
- Login endpoint (`POST /login`) now correctly allows **5 requests per minute** (previously only 2)
- Rate limiting headers are properly set
- No breaking changes to existing API behavior