### PR TITLE
feat: add device_group_guid parameter to peer query

### DIFF
--- a/src/modules/device-group/dto/peer.dto.ts
+++ b/src/modules/device-group/dto/peer.dto.ts
@@ -51,6 +51,10 @@ export class PeerQueryDto {
 
   @IsOptional()
   @IsString()
+  device_group_guid?: string; // 按设备组GUID筛选（精确匹配）
+
+  @IsOptional()
+  @IsString()
   device_group_name?: string; // 按设备组名称筛选（模糊匹配）
 
   @IsOptional()

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -61,6 +61,7 @@ export class PeerService {
       status,
       is_online,
       user_name,
+      device_group_guid,
       device_group_name,
       os,
     } = query;
@@ -127,8 +128,15 @@ export class PeerService {
       );
     }
 
+    // 按设备组GUID筛选（精确匹配，优先级更高）
+    if (device_group_guid) {
+      queryBuilder.andWhere('peer.deviceGroupGuid = :deviceGroupGuid', {
+        deviceGroupGuid: device_group_guid,
+      });
+    }
+
     // 按设备组名称筛选（模糊匹配）
-    if (device_group_name) {
+    if (device_group_name && !device_group_guid) {
       queryBuilder.andWhere('deviceGroup.name LIKE :deviceGroupName', {
         deviceGroupName: `%${device_group_name}%`,
       });


### PR DESCRIPTION
## 功能描述

为设备查询接口添加 `device_group_guid` 参数，支持按设备组GUID精确筛选设备。

## 修改内容

### 1. 修改 PeerQueryDto
- 添加 `device_group_guid` 参数，支持按设备组GUID精确匹配
- 保留 `device_group_name` 参数，支持按设备组名称模糊匹配

### 2. 修改 PeerService
- 在 `getAccessiblePeers` 方法中添加按 `device_group_guid` 筛选的逻辑
- `device_group_guid` 优先级高于 `device_group_name`，避免重复筛选

## 使用场景

前端共用一个设备列表组件时，可以通过此参数查询特定设备组中的设备：

```javascript
// 查询所有设备
GET /api/peers?current=1&pageSize=10

// 查询设备组中的设备（精确匹配）
GET /api/peers?device_group_guid=xxx

// 查询设备组中的在线设备
GET /api/peers?device_group_guid=xxx&is_online=1

// 查询设备组中按用户名筛选
GET /api/peers?device_group_guid=xxx&user_name=张三
```

## 优势

1. **前端组件复用**：一个组件可以处理所有场景（所有设备、设备组设备）
2. **筛选功能完整**：支持所有现有的筛选条件组合
3. **代码维护简单**：只维护一套筛选逻辑
4. **性能更好**：GUID有索引，精确匹配性能更优

## 测试

- ✅ TypeScript 编译通过
- ✅ ESLint 检查通过（无新增错误）
- ✅ 功能逻辑正确