### PR TITLE
feat(audit): enhance file audit query with advanced filters

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -167,20 +167,18 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按对端设备ID过滤（peerId精确匹配，remote模糊匹配）
-   * - 支持按时间段过滤（startTime/endTime范围查询，created_at单点查询）
+   * - 支持按对端设备ID过滤（peerId模糊匹配）
+   * - 支持按时间段过滤（startTime/endTime范围查询）
    * - 支持按文件传输类型过滤（type: 0-发送, 1-接收）
    *
    * 安全措施：
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param peerId 对端设备ID（精确匹配）
-   * @param remote 对端设备ID（模糊匹配，向后兼容）
+   * @param peerId 对端设备ID（模糊匹配）
    * @param type 文件传输类型（0: SEND, 1: RECEIVE）
    * @param startTime 开始时间（ISO 8601格式）
    * @param endTime 结束时间（ISO 8601格式）
-   * @param created_at 创建时间（UTC时间字符串，向后兼容）
    * @param pageSize 每页记录数
    * @param current 当前页码
    * @returns 文件审计列表
@@ -189,21 +187,17 @@ export class AuditsController {
   @Get('file')
   async queryFileAudits(
     @Query('peerId') peerId?: string,
-    @Query('remote') remote?: string,
     @Query('type') type?: number,
     @Query('startTime') startTime?: string,
     @Query('endTime') endTime?: string,
-    @Query('created_at') created_at?: string,
     @Query('pageSize') pageSize?: number,
     @Query('current') current?: number,
   ) {
     return await this.auditService.queryFileAudits({
       peerId,
-      remote,
       type,
       startTime,
       endTime,
-      created_at,
       pageSize,
       current,
     });

--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -167,32 +167,45 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按远程设备ID过滤
-   * - 支持按创建时间过滤
+   * - 支持按对端设备ID过滤（peerId精确匹配，remote模糊匹配）
+   * - 支持按时间段过滤（startTime/endTime范围查询，created_at单点查询）
+   * - 支持按文件传输类型过滤（type: 0-发送, 1-接收）
    *
    * 安全措施：
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param remote 远程设备ID（模糊匹配）
+   * @param peerId 对端设备ID（精确匹配）
+   * @param remote 对端设备ID（模糊匹配，向后兼容）
+   * @param type 文件传输类型（0: SEND, 1: RECEIVE）
+   * @param startTime 开始时间（ISO 8601格式）
+   * @param endTime 结束时间（ISO 8601格式）
+   * @param created_at 创建时间（UTC时间字符串，向后兼容）
    * @param pageSize 每页记录数
    * @param current 当前页码
-   * @param created_at 创建时间（UTC时间字符串）
    * @returns 文件审计列表
    */
   @UseGuards(AdminGuard)
   @Get('file')
   async queryFileAudits(
+    @Query('peerId') peerId?: string,
     @Query('remote') remote?: string,
+    @Query('type') type?: number,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
+    @Query('created_at') created_at?: string,
     @Query('pageSize') pageSize?: number,
     @Query('current') current?: number,
-    @Query('created_at') created_at?: string,
   ) {
     return await this.auditService.queryFileAudits({
+      peerId,
       remote,
+      type,
+      startTime,
+      endTime,
+      created_at,
       pageSize,
       current,
-      created_at,
     });
   }
 

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -257,21 +257,17 @@ export class AuditService {
    */
   async queryFileAudits(filters: {
     peerId?: string;
-    remote?: string;
     type?: number;
     startTime?: string;
     endTime?: string;
-    created_at?: string;
     pageSize?: number;
     current?: number;
   }) {
     const {
       peerId,
-      remote,
       type,
       startTime,
       endTime,
-      created_at,
       pageSize = 10,
       current = 1,
     } = filters;
@@ -294,13 +290,10 @@ export class AuditService {
         'fa.createdAt',
       ]);
 
-    // 按对端设备ID过滤（优先使用peerId精确匹配）
+    // 按对端设备ID过滤（模糊匹配）
     if (peerId) {
-      queryBuilder.andWhere('fa.peerId = :peerId', { peerId });
-    } else if (remote) {
-      // 向后兼容：使用remote模糊匹配
-      queryBuilder.andWhere('fa.peerId LIKE :remote', {
-        remote: `%${remote}%`,
+      queryBuilder.andWhere('fa.peerId LIKE :peerId', {
+        peerId: `%${peerId}%`,
       });
     }
 
@@ -309,20 +302,14 @@ export class AuditService {
       queryBuilder.andWhere('fa.type = :type', { type });
     }
 
-    // 按时间段过滤（优先使用startTime/endTime范围查询）
-    if (startTime || endTime) {
-      if (startTime) {
-        const start = new Date(startTime);
-        queryBuilder.andWhere('fa.createdAt >= :startTime', { startTime: start });
-      }
-      if (endTime) {
-        const end = new Date(endTime);
-        queryBuilder.andWhere('fa.createdAt <= :endTime', { endTime: end });
-      }
-    } else if (created_at) {
-      // 向后兼容：使用created_at单点查询
-      const createdAt = new Date(created_at);
-      queryBuilder.andWhere('fa.createdAt >= :createdAt', { createdAt });
+    // 按时间段过滤
+    if (startTime) {
+      const start = new Date(startTime);
+      queryBuilder.andWhere('fa.createdAt >= :startTime', { startTime: start });
+    }
+    if (endTime) {
+      const end = new Date(endTime);
+      queryBuilder.andWhere('fa.createdAt <= :endTime', { endTime: end });
     }
 
     queryBuilder.orderBy('fa.createdAt', 'DESC').skip(skip).take(pageSize);

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -256,12 +256,25 @@ export class AuditService {
    * @returns 文件审计列表
    */
   async queryFileAudits(filters: {
+    peerId?: string;
     remote?: string;
+    type?: number;
+    startTime?: string;
+    endTime?: string;
+    created_at?: string;
     pageSize?: number;
     current?: number;
-    created_at?: string;
   }) {
-    const { remote, pageSize = 10, current = 1, created_at } = filters;
+    const {
+      peerId,
+      remote,
+      type,
+      startTime,
+      endTime,
+      created_at,
+      pageSize = 10,
+      current = 1,
+    } = filters;
     const skip = (current - 1) * pageSize;
 
     const queryBuilder = this.fileAuditRepository
@@ -281,15 +294,33 @@ export class AuditService {
         'fa.createdAt',
       ]);
 
-    // 按远程设备ID过滤
-    if (remote) {
+    // 按对端设备ID过滤（优先使用peerId精确匹配）
+    if (peerId) {
+      queryBuilder.andWhere('fa.peerId = :peerId', { peerId });
+    } else if (remote) {
+      // 向后兼容：使用remote模糊匹配
       queryBuilder.andWhere('fa.peerId LIKE :remote', {
         remote: `%${remote}%`,
       });
     }
 
-    // 按创建时间过滤
-    if (created_at) {
+    // 按文件传输类型过滤
+    if (type !== undefined) {
+      queryBuilder.andWhere('fa.type = :type', { type });
+    }
+
+    // 按时间段过滤（优先使用startTime/endTime范围查询）
+    if (startTime || endTime) {
+      if (startTime) {
+        const start = new Date(startTime);
+        queryBuilder.andWhere('fa.createdAt >= :startTime', { startTime: start });
+      }
+      if (endTime) {
+        const end = new Date(endTime);
+        queryBuilder.andWhere('fa.createdAt <= :endTime', { endTime: end });
+      }
+    } else if (created_at) {
+      // 向后兼容：使用created_at单点查询
       const createdAt = new Date(created_at);
       queryBuilder.andWhere('fa.createdAt >= :createdAt', { createdAt });
     }


### PR DESCRIPTION
## 功能描述

为 `/api/audits/file` 接口增加高级查询功能，支持更灵活的审计记录查询。

## 查询参数

### 1. 时间段查询
- **startTime**: 开始时间（ISO 8601格式）
- **endTime**: 结束时间（ISO 8601格式）
- 支持范围查询，可单独使用或组合使用

### 2. 文件传输类型过滤
- **type**: 文件传输类型
  - `0`: SEND（发送）
  - `1`: RECEIVE（接收）

### 3. 对端设备ID查询
- **peerId**: 对端设备ID（模糊匹配）

### 4. 分页参数
- **pageSize**: 每页记录数（默认10）
- **current**: 当前页码（默认1）

## 使用示例

```bash
# 查询指定时间范围内的发送文件记录
GET /api/audits/file?startTime=2024-01-01T00:00:00Z&endTime=2024-01-31T23:59:59Z&type=0

# 查询指定对端设备的所有文件传输记录（模糊匹配）
GET /api/audits/file?peerId=123456

# 组合查询
GET /api/audits/file?peerId=123456&type=1&startTime=2024-01-01T00:00:00Z

# 分页查询
GET /api/audits/file?pageSize=20&current=2
```

## 变更说明

### 新增功能
- ✅ 时间范围查询（startTime/endTime）
- ✅ 文件传输类型过滤（type）
- ✅ 对端设备ID模糊查询（peerId）

### 移除参数
- ❌ `remote` 参数（已移除，使用 peerId 替代）
- ❌ `created_at` 参数（已移除，使用 startTime/endTime 替代）

## 测试

- ✅ 编译通过
- ✅ 查询功能正常
- ✅ 参数验证正确