### PR TITLE
fix: use tag_name instead of tag for action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: softprops/action-gh-release@v1
         with:
-          tag: ${{ steps.changelog.outputs.version }}
+          tag_name: ${{ steps.changelog.outputs.version }}
           name: ${{ steps.changelog.outputs.version }}
           body: |
             ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary

Fix the GitHub Release workflow by using the correct parameter name for `softprops/action-gh-release@v1`.

## Problem

The workflow was using `tag` parameter which is not valid for `softprops/action-gh-release@v1`:

```
Warning: Unexpected input(s) 'tag', valid inputs are ['body', 'body_path', 'name', 'tag_name', 'draft', 'prerelease', 'files', 'fail_on_unmatched_files', 'repository', 'token', 'target_commitish', 'discussion_category_name', 'generate_release_notes', 'append_body'] 

Error: ⚠️ GitHub Releases requires a tag
```

## Solution

Change `tag` to `tag_name` in the workflow file.

## Changes

```yaml
# Before
tag: ${{ steps.changelog.outputs.version }}

# After  
tag_name: ${{ steps.changelog.outputs.version }}
```