### PR TITLE
chore(ci): add dependabot configuration for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "YuZhiYuanDev"
+    assignees:
+      - "YuZhiYuanDev"
+    versioning-strategy: "increase-if-necessary"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "YuZhiYuanDev"
+    assignees:
+      - "YuZhiYuanDev"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automate dependency updates.

### Features
- **npm dependencies**: Weekly checks on Monday 09:00 (Asia/Shanghai), max 10 PRs
- **GitHub Actions**: Weekly checks on Monday 09:00 (Asia/Shanghai), max 5 PRs, grouped updates

### Configuration Details
- Reviewer and assignee: YuZhiYuanDev
- Commit message prefix: `chore` for npm, `ci` for github-actions
- Version strategy: increase-if-necessary
- Ignore major version updates to prevent breaking changes