### PR TITLE
feat(device): add batch device status update API

### DIFF
--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -17,6 +17,10 @@ import { DeviceGroupQueryDto } from './dto/device-group.dto';
 import { PeerQueryDto } from './dto/peer.dto';
 import { UserQueryDto } from './dto/user.dto';
 import { DeviceQueryDto } from './dto/device.dto';
+import {
+  UpdateDeviceStatusDto,
+  DeviceOperationResult,
+} from './dto/device-status.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AdminGuard } from '../../common/guards/admin.guard';
 
@@ -287,6 +291,28 @@ export class DeviceGroupController {
   async enableDevice(@Param('guid') guid: string) {
     await this.deviceGroupService.enableDevice(guid);
     return { message: '设备已启用' };
+  }
+
+  /**
+   * 批量更新设备状态
+   * 管理员可以批量启用或禁用设备
+   *
+   * @param dto 更新状态请求
+   * @returns 操作结果
+   */
+  @Patch('devices/status')
+  @UseGuards(AdminGuard)
+  async updateDeviceStatus(
+    @Body() dto: UpdateDeviceStatusDto,
+  ): Promise<{ success: boolean; data: DeviceOperationResult }> {
+    const result = await this.deviceGroupService.updateDeviceStatus(
+      dto.guids,
+      dto.status,
+    );
+    return {
+      success: result.failedCount === 0,
+      data: result,
+    };
   }
 
   /**

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -10,6 +10,11 @@ import { DeviceGroup } from './entities/device-group.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
 import { Peer, PeerStatus } from '../../common/entities/peer.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
+import {
+  DeviceStatus,
+  DeviceOperationResult,
+  DeviceOperationFailure,
+} from './dto/device-status.dto';
 
 @Injectable()
 /**
@@ -545,6 +550,61 @@ export class DeviceGroupService {
 
     peer.status = PeerStatus.ACTIVE;
     await this.peerRepository.save(peer);
+  }
+
+  /**
+   * 批量更新设备状态
+   * 支持批量启用或禁用多个设备，返回详细的成功/失败信息
+   *
+   * @param guids 设备GUID列表
+   * @param status 目标状态
+   * @returns 操作结果，包含成功和失败的设备信息
+   */
+  async updateDeviceStatus(
+    guids: string[],
+    status: DeviceStatus,
+  ): Promise<DeviceOperationResult> {
+    const succeeded: string[] = [];
+    const failed: DeviceOperationFailure[] = [];
+
+    const existingPeers = await this.peerRepository.find({
+      where: { uuid: In(guids) },
+      select: ['uuid'],
+    });
+
+    const existingUuids = new Set(existingPeers.map((p) => p.uuid));
+
+    for (const guid of guids) {
+      if (!existingUuids.has(guid)) {
+        failed.push({ guid, reason: 'Device not found' });
+      }
+    }
+
+    const guidsToUpdate = guids.filter((guid) => existingUuids.has(guid));
+
+    if (guidsToUpdate.length > 0) {
+      const statusValue =
+        status === DeviceStatus.ENABLED
+          ? PeerStatus.ACTIVE
+          : PeerStatus.DISABLED;
+
+      await this.peerRepository
+        .createQueryBuilder()
+        .update(Peer)
+        .set({ status: statusValue })
+        .where('uuid IN (:...uuids)', { uuids: guidsToUpdate })
+        .execute();
+
+      succeeded.push(...guidsToUpdate);
+    }
+
+    return {
+      succeeded,
+      failed,
+      total: guids.length,
+      succeededCount: succeeded.length,
+      failedCount: failed.length,
+    };
   }
 
   /**

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -564,23 +564,24 @@ export class DeviceGroupService {
     guids: string[],
     status: DeviceStatus,
   ): Promise<DeviceOperationResult> {
+    const uniqueGuids = [...new Set(guids)];
     const succeeded: string[] = [];
     const failed: DeviceOperationFailure[] = [];
 
     const existingPeers = await this.peerRepository.find({
-      where: { uuid: In(guids) },
+      where: { uuid: In(uniqueGuids) },
       select: ['uuid'],
     });
 
     const existingUuids = new Set(existingPeers.map((p) => p.uuid));
 
-    for (const guid of guids) {
+    for (const guid of uniqueGuids) {
       if (!existingUuids.has(guid)) {
         failed.push({ guid, reason: 'Device not found' });
       }
     }
 
-    const guidsToUpdate = guids.filter((guid) => existingUuids.has(guid));
+    const guidsToUpdate = uniqueGuids.filter((guid) => existingUuids.has(guid));
 
     if (guidsToUpdate.length > 0) {
       const statusValue =
@@ -601,7 +602,7 @@ export class DeviceGroupService {
     return {
       succeeded,
       failed,
-      total: guids.length,
+      total: uniqueGuids.length,
       succeededCount: succeeded.length,
       failedCount: failed.length,
     };

--- a/src/modules/device-group/dto/device-status.dto.ts
+++ b/src/modules/device-group/dto/device-status.dto.ts
@@ -1,0 +1,29 @@
+import { IsArray, IsString, IsEnum, ArrayMinSize } from 'class-validator';
+
+export enum DeviceStatus {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+}
+
+export class UpdateDeviceStatusDto {
+  @IsArray()
+  @ArrayMinSize(1, { message: 'At least one device GUID is required' })
+  @IsString({ each: true, message: 'Device GUID must be a string' })
+  guids: string[];
+
+  @IsEnum(DeviceStatus, { message: 'Status must be "enabled" or "disabled"' })
+  status: DeviceStatus;
+}
+
+export interface DeviceOperationFailure {
+  guid: string;
+  reason: string;
+}
+
+export interface DeviceOperationResult {
+  succeeded: string[];
+  failed: DeviceOperationFailure[];
+  total: number;
+  succeededCount: number;
+  failedCount: number;
+}


### PR DESCRIPTION
## Summary

Add a new RESTful API endpoint for batch updating device status (enable/disable).

## Changes

- **New Endpoint**: `PATCH /api/devices/status`
- **DTO**: Add `UpdateDeviceStatusDto` with validation
- **Service**: Add `updateDeviceStatus` method in `DeviceGroupService`
- **Controller**: Add `PATCH /devices/status` endpoint in `DeviceGroupController`

## API Design

### Request

```http
PATCH /api/devices/status
Content-Type: application/json

{
  "guids": ["uuid-1", "uuid-2", "uuid-3"],
  "status": "disabled"
}
```

### Response

```json
{
  "success": true,
  "data": {
    "succeeded": ["uuid-1", "uuid-2"],
    "failed": [
      {
        "guid": "uuid-3",
        "reason": "Device not found"
      }
    ],
    "total": 3,
    "succeededCount": 2,
    "failedCount": 1
  }
}
```

## Design Rationale

| Aspect | Old Design | New Design |
|--------|------------|------------|
| HTTP Method | `POST` | `PATCH` ✓ |
| URL | `/devices/:guid/disable` (verb) | `/devices/status` (noun) ✓ |
| Batch Support | ❌ | ✓ |
| Endpoint Count | 2 (enable/disable) | 1 (unified) ✓ |
| Error Handling | Simple message | Detailed success/failure list ✓ |

## Backward Compatibility

The existing single-device endpoints are preserved:
- `POST /devices/:guid/enable`
- `POST /devices/:guid/disable`

## Testing

- [x] Lint passed
- [x] TypeScript compilation passed