### PR TITLE
fix: use dedicated lastHeartbeat field for device online status

### DIFF
--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -95,6 +95,13 @@ export class Peer {
   createdAt: Date;
 
   /**
+   * 最后心跳时间
+   * 设备最后一次发送心跳的时间，用于判断设备在线状态
+   */
+  @Column({ type: 'datetime', nullable: true })
+  lastHeartbeat: Date | null;
+
+  /**
    * 更新时间
    */
   @UpdateDateColumn()

--- a/src/modules/auth/services/auth-device.service.ts
+++ b/src/modules/auth/services/auth-device.service.ts
@@ -46,8 +46,10 @@ export class AuthDeviceService {
 
     if (peer) {
       // 更新peer的userGuid，绑定设备到用户
-      peer.userGuid = userGuid;
-      await this.peerRepository.save(peer);
+      await this.peerRepository.update(
+        { uuid: deviceUuid },
+        { userGuid: userGuid },
+      );
       this.logger.log(`设备 ${deviceUuid} 已绑定到用户 ${userGuid}`);
     }
     // 如果peer不存在，设备会在心跳时自动创建
@@ -68,8 +70,10 @@ export class AuthDeviceService {
     });
 
     if (peer) {
-      peer.userGuid = null;
-      await this.peerRepository.save(peer);
+      await this.peerRepository.update(
+        { uuid: deviceUuid },
+        { userGuid: null },
+      );
       this.logger.log(
         `用户 ${userGuid} 退出登录，已解除设备 ${deviceUuid} 的绑定`,
       );

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -65,11 +65,11 @@ export class DashboardService {
       where: { status: PeerStatus.ACTIVE },
     });
 
-    // 在线设备统计：最近5分钟内有心跳的设备
-    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+    // 在线设备统计：最近1分钟内有心跳的设备
+    const oneMinuteAgo = new Date(Date.now() - 60 * 1000);
     const deviceOnline = await this.peerRepository
       .createQueryBuilder('peer')
-      .where('peer.updatedAt >= :threshold', { threshold: fiveMinutesAgo })
+      .where('peer.lastHeartbeat >= :threshold', { threshold: oneMinuteAgo })
       .andWhere('peer.status = :status', { status: PeerStatus.ACTIVE })
       .getCount();
 

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -354,8 +354,10 @@ export class DeviceGroupService {
 
     // 更新设备的设备组
     for (const peer of peers) {
-      peer.deviceGroupGuid = guid;
-      await this.peerRepository.save(peer);
+      await this.peerRepository.update(
+        { uuid: peer.uuid },
+        { deviceGroupGuid: guid },
+      );
     }
 
     return { message: '设备添加成功' };
@@ -385,8 +387,10 @@ export class DeviceGroupService {
 
     // 移除设备的设备组
     for (const peer of peers) {
-      peer.deviceGroupGuid = null;
-      await this.peerRepository.save(peer);
+      await this.peerRepository.update(
+        { uuid: peer.uuid },
+        { deviceGroupGuid: null },
+      );
     }
 
     return { message: '设备移除成功' };
@@ -532,8 +536,10 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    peer.status = PeerStatus.DISABLED;
-    await this.peerRepository.save(peer);
+    await this.peerRepository.update(
+      { uuid: guid },
+      { status: PeerStatus.DISABLED },
+    );
   }
 
   /**
@@ -548,8 +554,10 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    peer.status = PeerStatus.ACTIVE;
-    await this.peerRepository.save(peer);
+    await this.peerRepository.update(
+      { uuid: guid },
+      { status: PeerStatus.ACTIVE },
+    );
   }
 
   /**
@@ -637,6 +645,8 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
+    const updateData: Partial<Peer> = {};
+
     switch (type) {
       case 'user_name': {
         const user = await this.userRepository.findOne({
@@ -645,7 +655,7 @@ export class DeviceGroupService {
         if (!user) {
           throw new NotFoundException('用户不存在');
         }
-        peer.userGuid = user.guid;
+        updateData.userGuid = user.guid;
         break;
       }
       case 'device_group_name': {
@@ -655,7 +665,7 @@ export class DeviceGroupService {
         if (!deviceGroup) {
           throw new NotFoundException('设备组不存在');
         }
-        peer.deviceGroupGuid = deviceGroup.guid;
+        updateData.deviceGroupGuid = deviceGroup.guid;
         break;
       }
       case 'note':
@@ -671,6 +681,8 @@ export class DeviceGroupService {
         throw new BadRequestException(`不支持的属性类型: ${type}`);
     }
 
-    await this.peerRepository.save(peer);
+    if (Object.keys(updateData).length > 0) {
+      await this.peerRepository.update({ uuid: guid }, updateData);
+    }
   }
 }

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -110,11 +110,14 @@ export class PeerService {
 
     // 按是否在线筛选
     if (is_online === '1') {
-      queryBuilder.andWhere('peer.updatedAt > :oneMinuteAgo', { oneMinuteAgo });
-    } else if (is_online === '0') {
-      queryBuilder.andWhere('peer.updatedAt <= :oneMinuteAgo', {
+      queryBuilder.andWhere('peer.lastHeartbeat > :oneMinuteAgo', {
         oneMinuteAgo,
       });
+    } else if (is_online === '0') {
+      queryBuilder.andWhere(
+        '(peer.lastHeartbeat IS NULL OR peer.lastHeartbeat <= :oneMinuteAgo)',
+        { oneMinuteAgo },
+      );
     }
 
     // 按用户名筛选（模糊匹配）
@@ -199,7 +202,9 @@ export class PeerService {
     // 转换响应格式
     const data = peers.map((peer) => {
       const sysinfo = sysinfoMap.get(peer.uuid);
-      const isOnline = peer.updatedAt > oneMinuteAgo;
+      const isOnline = peer.lastHeartbeat
+        ? peer.lastHeartbeat > oneMinuteAgo
+        : false;
       const user = peer.userGuid ? userMap.get(peer.userGuid) : null;
       const deviceGroupName =
         (peer.deviceGroup as { name?: string } | null)?.name || '';
@@ -209,7 +214,9 @@ export class PeerService {
         guid: peer.uuid,
         status: peer.status,
         is_online: isOnline,
-        last_online: peer.updatedAt.toISOString(),
+        last_online: peer.lastHeartbeat
+          ? peer.lastHeartbeat.toISOString()
+          : null,
         user: peer.userGuid || '',
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -44,6 +44,7 @@ export class HeartbeatService {
           id: data.id,
           ver: data.ver,
           modifiedAt: data.modified_at,
+          lastHeartbeat: new Date(),
         },
       );
       this.logger.debug(`设备 ${data.uuid} 心跳已更新`);
@@ -54,6 +55,7 @@ export class HeartbeatService {
         uuid: data.uuid,
         ver: data.ver,
         modifiedAt: data.modified_at,
+        lastHeartbeat: new Date(),
       });
       await this.peerRepository.save(peer);
       this.logger.log(`新设备 ${data.uuid} 已注册`);

--- a/src/modules/sysinfo/sysinfo.service.ts
+++ b/src/modules/sysinfo/sysinfo.service.ts
@@ -261,8 +261,10 @@ export class SysinfoService {
 
     if (peer) {
       // 更新设备的设备组
-      peer.deviceGroupGuid = deviceGroup.guid;
-      await this.peerRepository.save(peer);
+      await this.peerRepository.update(
+        { uuid: sysinfo.uuid },
+        { deviceGroupGuid: deviceGroup.guid },
+      );
       this.logger.log(
         `设备 ${sysinfo.uuid} 已关联到设备组 ${deviceGroup.name}`,
       );


### PR DESCRIPTION
## Problem

Device online status was incorrectly determined by the `updatedAt` field, which is auto-updated by TypeORM's `@UpdateDateColumn` on every `save()` call. This caused two issues:

1. **Heartbeats couldn't maintain online status**: The heartbeat service used `update()` which doesn't refresh `updatedAt`, so existing devices would go offline after 1 minute and heartbeats couldn't bring them back online.
2. **Management operations made offline devices appear online**: Operations like assigning device groups, enabling/disabling devices, and binding/unbinding users used `save()`, which updated `updatedAt` and made offline devices appear online.

Additionally, the online status threshold was inconsistent: `peer.service.ts` used 1 minute while `dashboard.service.ts` used 5 minutes.

## Solution

- Added a dedicated `lastHeartbeat` column to the `Peer` entity to track the last heartbeat time independently.
- Updated heartbeat service to set `lastHeartbeat` on both new and existing devices.
- Changed online status determination to use `lastHeartbeat` instead of `updatedAt` across `peer.service.ts` and `dashboard.service.ts`.
- Unified the online threshold to 1 minute across all services.
- Switched all management operations from `save()` to `update()` to avoid the `updatedAt` side effect.

## Files Changed

- `src/common/entities/peer.entity.ts` — Added `lastHeartbeat` column
- `src/modules/heartbeat/heartbeat.service.ts` — Update `lastHeartbeat` on heartbeat
- `src/modules/device-group/peer.service.ts` — Use `lastHeartbeat` for online status
- `src/modules/dashboard/dashboard.service.ts` — Use `lastHeartbeat` for online count
- `src/modules/device-group/device-group.service.ts` — Switch `save()` to `update()`
- `src/modules/auth/services/auth-device.service.ts` — Switch `save()` to `update()`
- `src/modules/sysinfo/sysinfo.service.ts` — Switch `save()` to `update()`