### PR TITLE
fix: change file audit query param from peerId to deviceId

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -167,7 +167,7 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按远程设备ID过滤（deviceId模糊匹配）
+   * - 支持按被控端设备ID过滤（deviceId模糊匹配）
    * - 支持按时间段过滤（startTime/endTime范围查询）
    * - 支持按文件传输类型过滤（type: 0-发送, 1-接收）
    *
@@ -175,7 +175,7 @@ export class AuditsController {
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param deviceId 远程设备ID（模糊匹配）
+   * @param deviceId 被控端设备ID（模糊匹配）
    * @param type 文件传输类型（0: SEND, 1: RECEIVE）
    * @param startTime 开始时间（ISO 8601格式）
    * @param endTime 结束时间（ISO 8601格式）

--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -167,7 +167,7 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按对端设备ID过滤（peerId模糊匹配）
+   * - 支持按远程设备ID过滤（deviceId模糊匹配）
    * - 支持按时间段过滤（startTime/endTime范围查询）
    * - 支持按文件传输类型过滤（type: 0-发送, 1-接收）
    *
@@ -175,7 +175,7 @@ export class AuditsController {
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param peerId 对端设备ID（模糊匹配）
+   * @param deviceId 远程设备ID（模糊匹配）
    * @param type 文件传输类型（0: SEND, 1: RECEIVE）
    * @param startTime 开始时间（ISO 8601格式）
    * @param endTime 结束时间（ISO 8601格式）
@@ -186,7 +186,7 @@ export class AuditsController {
   @UseGuards(AdminGuard)
   @Get('file')
   async queryFileAudits(
-    @Query('peerId') peerId?: string,
+    @Query('deviceId') deviceId?: string,
     @Query('type') type?: number,
     @Query('startTime') startTime?: string,
     @Query('endTime') endTime?: string,
@@ -194,7 +194,7 @@ export class AuditsController {
     @Query('current') current?: number,
   ) {
     return await this.auditService.queryFileAudits({
-      peerId,
+      deviceId,
       type,
       startTime,
       endTime,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -256,7 +256,7 @@ export class AuditService {
    * @returns 文件审计列表
    */
   async queryFileAudits(filters: {
-    peerId?: string;
+    deviceId?: string;
     type?: number;
     startTime?: string;
     endTime?: string;
@@ -264,7 +264,7 @@ export class AuditService {
     current?: number;
   }) {
     const {
-      peerId,
+      deviceId,
       type,
       startTime,
       endTime,
@@ -290,10 +290,10 @@ export class AuditService {
         'fa.createdAt',
       ]);
 
-    // 按对端设备ID过滤（模糊匹配）
-    if (peerId) {
-      queryBuilder.andWhere('fa.peerId LIKE :peerId', {
-        peerId: `%${peerId}%`,
+    // 按远程设备ID过滤（模糊匹配）
+    if (deviceId) {
+      queryBuilder.andWhere('fa.deviceId LIKE :deviceId', {
+        deviceId: `%${deviceId}%`,
       });
     }
 

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -290,7 +290,7 @@ export class AuditService {
         'fa.createdAt',
       ]);
 
-    // 按远程设备ID过滤（模糊匹配）
+    // 按被控端设备ID过滤（模糊匹配）
     if (deviceId) {
       queryBuilder.andWhere('fa.deviceId LIKE :deviceId', {
         deviceId: `%${deviceId}%`,


### PR DESCRIPTION
## Summary

- Change the query parameter of `GET /api/audits/file` from `peerId` to `deviceId`
- `deviceId` is the correct field that corresponds to the remote device for filtering

## Changes

- **audit.controller.ts**: Updated `@Query('peerId')` to `@Query('deviceId')` and related JSDoc
- **audit.service.ts**: Updated `queryFileAudits` filter parameter from `peerId` to `deviceId`, and changed the WHERE clause from `fa.peerId LIKE` to `fa.deviceId LIKE`