### PR TITLE
fix: correct login response type field for TFA check

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -233,7 +233,7 @@ export class AuthService {
       if (!tfaCode) {
         // 返回TFA验证提示
         return {
-          type: 'email_check',
+          type: 'tfa_check',
           tfa_type: 'tfa_check',
           secret: user.tfaSecret,
           user: {


### PR DESCRIPTION
## Problem

When a user with TFA enabled logs in without providing a TFA code, the login API response returns:

```json
{
  "type": "email_check",
  "tfa_type": "tfa_check",
  ...
}
```

The `type` field incorrectly shows `"email_check"` for TFA scenarios, making it ambiguous for the frontend to distinguish between email verification and TFA verification prompts.

## Fix

Changed `type` from `"email_check"` to `"tfa_check"` when the response is a TFA verification prompt, so `type` now matches `tfa_type`:

```json
{
  "type": "tfa_check",
  "tfa_type": "tfa_check",
  ...
}
```

Email verification responses remain unchanged (`type: "email_check"`).

## Impact

- **Breaking change for frontend**: If the frontend currently relies on `type === "email_check"` to handle both email and TFA verification flows, it should be updated to check `type === "tfa_check"` for TFA or use the `tfa_type` field for disambiguation.