### PR TITLE
refactor(audit): align conn query params with file audit interface

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -128,36 +128,39 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按远程设备ID过滤
-   * - 支持按连接类型过滤
-   * - 支持按创建时间过滤
+   * - 支持按被控端设备ID过滤（deviceId模糊匹配）
+   * - 支持按时间段过滤（startTime/endTime范围查询）
+   * - 支持按连接类型过滤（type）
    *
    * 安全措施：
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param remote 远程设备ID（模糊匹配）
-   * @param conn_type 连接类型
+   * @param deviceId 被控端设备ID（模糊匹配）
+   * @param type 连接类型
+   * @param startTime 开始时间（ISO 8601格式）
+   * @param endTime 结束时间（ISO 8601格式）
    * @param pageSize 每页记录数
    * @param current 当前页码
-   * @param created_at 创建时间（UTC时间字符串）
    * @returns 连接审计列表
    */
   @UseGuards(AdminGuard)
   @Get('conn')
   async queryConnectionAudits(
-    @Query('remote') remote?: string,
-    @Query('conn_type') conn_type?: number,
+    @Query('deviceId') deviceId?: string,
+    @Query('type') type?: number,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
     @Query('pageSize') pageSize?: number,
     @Query('current') current?: number,
-    @Query('created_at') created_at?: string,
   ) {
     return await this.auditService.queryConnectionAudits({
-      remote,
-      conn_type,
+      deviceId,
+      type,
+      startTime,
+      endTime,
       pageSize,
       current,
-      created_at,
     });
   }
 

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -189,18 +189,20 @@ export class AuditService {
    * @returns 连接审计列表
    */
   async queryConnectionAudits(filters: {
-    remote?: string;
-    conn_type?: number;
+    deviceId?: string;
+    type?: number;
+    startTime?: string;
+    endTime?: string;
     pageSize?: number;
     current?: number;
-    created_at?: string;
   }) {
     const {
-      remote,
-      conn_type,
+      deviceId,
+      type,
+      startTime,
+      endTime,
       pageSize = 10,
       current = 1,
-      created_at,
     } = filters;
     const skip = (current - 1) * pageSize;
 
@@ -222,22 +224,26 @@ export class AuditService {
         'ca.createdAt',
       ]);
 
-    // 按远程设备ID过滤
-    if (remote) {
-      queryBuilder.andWhere('ca.peerId LIKE :remote', {
-        remote: `%${remote}%`,
+    // 按被控端设备ID过滤（模糊匹配）
+    if (deviceId) {
+      queryBuilder.andWhere('ca.deviceId LIKE :deviceId', {
+        deviceId: `%${deviceId}%`,
       });
     }
 
     // 按连接类型过滤
-    if (conn_type !== undefined) {
-      queryBuilder.andWhere('ca.type = :conn_type', { conn_type });
+    if (type !== undefined) {
+      queryBuilder.andWhere('ca.type = :type', { type });
     }
 
-    // 按创建时间过滤
-    if (created_at) {
-      const createdAt = new Date(created_at);
-      queryBuilder.andWhere('ca.createdAt >= :createdAt', { createdAt });
+    // 按时间段过滤
+    if (startTime) {
+      const start = new Date(startTime);
+      queryBuilder.andWhere('ca.createdAt >= :startTime', { startTime: start });
+    }
+    if (endTime) {
+      const end = new Date(endTime);
+      queryBuilder.andWhere('ca.createdAt <= :endTime', { endTime: end });
     }
 
     queryBuilder.orderBy('ca.createdAt', 'DESC').skip(skip).take(pageSize);


### PR DESCRIPTION
## Summary

Align connection audit query interface parameters with file audit query interface.

### Changes

- Replace `remote` with `deviceId` (fuzzy match on controlled device ID)
- Replace `conn_type` with `type`
- Replace `created_at` single time filter with `startTime`/`endTime` range query

### Before

`GET /api/audits/conn?remote=&conn_type=&pageSize=&current=&created_at=`

### After

`GET /api/audits/conn?deviceId=&type=&startTime=&endTime=&pageSize=&current=`

Now both conn and file audit query interfaces share the same parameter structure.