### PR TITLE
feat(audit): add ConnType enum and use -1 for unestablished connections

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -130,14 +130,14 @@ export class AuditsController {
    * - 支持分页查询
    * - 支持按被控端设备ID过滤（deviceId模糊匹配）
    * - 支持按时间段过滤（startTime/endTime范围查询）
-   * - 支持按连接类型过滤（type）
+   * - 支持按连接类型过滤（type，-1表示未建立连接）
    *
    * 安全措施：
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
    * @param deviceId 被控端设备ID（模糊匹配）
-   * @param type 连接类型
+   * @param type 连接类型（-1表示未建立连接）
    * @param startTime 开始时间（ISO 8601格式）
    * @param endTime 结束时间（ISO 8601格式）
    * @param pageSize 每页记录数

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere } from 'typeorm';
-import { ConnectionAudit } from './entities/connection-audit.entity';
+import { ConnectionAudit, ConnType } from './entities/connection-audit.entity';
 import { FileAudit } from './entities/file-audit.entity';
 import { AlarmAudit } from './entities/alarm-audit.entity';
 import { ConnectionAuditDto } from './dto/connection-audit.dto';
@@ -109,7 +109,7 @@ export class AuditService {
       action,
       peerId: dto.peer ? dto.peer[0] : null,
       peerName: dto.peer ? dto.peer[1] : null,
-      type: dto.type !== undefined ? dto.type : null,
+      type: dto.type !== undefined ? dto.type : ConnType.NOT_ESTABLISHED,
       requestedAt: action === 'open' ? new Date() : null,
       establishedAt: action === 'established' ? new Date() : null,
       closedAt: action === 'close' ? new Date() : null,
@@ -231,7 +231,7 @@ export class AuditService {
       });
     }
 
-    // 按连接类型过滤
+    // 按连接类型过滤（-1 表示未建立连接）
     if (type !== undefined) {
       queryBuilder.andWhere('ca.type = :type', { type });
     }

--- a/src/modules/audit/entities/connection-audit.entity.ts
+++ b/src/modules/audit/entities/connection-audit.entity.ts
@@ -5,6 +5,18 @@ import {
   CreateDateColumn,
 } from 'typeorm';
 
+/**
+ * 连接类型枚举
+ */
+export enum ConnType {
+  NOT_ESTABLISHED = -1,
+  REMOTE_CONTROL = 0,
+  FILE_TRANSFER = 1,
+  PORT_FORWARD = 2,
+  CAMERA = 3,
+  TERMINAL = 4,
+}
+
 @Entity('connection_audits')
 export class ConnectionAudit {
   @PrimaryGeneratedColumn()
@@ -34,8 +46,8 @@ export class ConnectionAudit {
   @Column({ type: 'varchar', length: 255, nullable: true })
   peerName: string | null;
 
-  @Column({ type: 'int', nullable: true })
-  type: number | null;
+  @Column({ type: 'int', default: ConnType.NOT_ESTABLISHED })
+  type: number;
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
## Changes

- Define `ConnType` enum with `NOT_ESTABLISHED = -1` and types 0-4 in connection-audit entity
- Change connection audit `type` field default from `null` to `ConnType.NOT_ESTABLISHED` (-1)
- Remove `nullable` from `type` column, set DB default to -1
- Support `type=-1` query parameter on `GET /api/audits/conn` to filter unestablished connections

## Notes

- Historical data with `type IS NULL` needs to be migrated to `type = -1` separately
- DTO validation (`@Min(0) @Max(4)`) is intentionally unchanged since unestablished connections don't send a `type` field