### PR TITLE
feat(audit): add note field to connection audit

### DIFF
--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere } from 'typeorm';
 import { ConnectionAudit } from './entities/connection-audit.entity';
@@ -36,12 +36,53 @@ export class AuditService {
   /**
    * 记录连接审计
    * 记录远程桌面连接的详细信息，包括连接建立、断开等操作
+   * 也支持仅添加备注（note-only）的请求
    *
    * @param dto 连接审计数据
    * @returns 保存的连接审计记录
    */
   async auditConnection(dto: ConnectionAuditDto): Promise<ConnectionAudit> {
-    // 支持前端发送的下划线格式字段
+    // 判断是否为仅添加备注的请求（无 uuid 和 conn_id，有 session_id 和 note）
+    if (!dto.uuid && dto.session_id !== undefined && dto.note !== undefined) {
+      return this.addConnectionNote(dto);
+    }
+
+    return this.upsertConnectionAudit(dto);
+  }
+
+  /**
+   * 仅添加备注
+   * 通过 deviceId + sessionId 查找已有连接记录并更新备注
+   */
+  private async addConnectionNote(
+    dto: ConnectionAuditDto,
+  ): Promise<ConnectionAudit> {
+    const sessionId = String(dto.session_id);
+
+    const existingConnection = await this.connectionAuditRepository.findOne({
+      where: {
+        deviceId: dto.id,
+        sessionId,
+      },
+    });
+
+    if (!existingConnection) {
+      throw new NotFoundException(
+        `Connection audit not found for deviceId=${dto.id}, sessionId=${sessionId}`,
+      );
+    }
+
+    existingConnection.note = dto.note || null;
+    return await this.connectionAuditRepository.save(existingConnection);
+  }
+
+  /**
+   * 创建或更新连接审计记录
+   * 处理完整的连接状态上报（含 uuid）
+   */
+  private async upsertConnectionAudit(
+    dto: ConnectionAuditDto,
+  ): Promise<ConnectionAudit> {
     const connId = dto.conn_id !== undefined ? String(dto.conn_id) : null;
     const sessionId =
       dto.session_id !== undefined ? String(dto.session_id) : null;
@@ -70,36 +111,67 @@ export class AuditService {
     });
 
     if (existingConnection) {
-      // 更新现有连接记录
-      if (action === 'open' && !existingConnection.requestedAt) {
-        existingConnection.requestedAt = new Date();
-      }
-      if (action === 'established' && !existingConnection.establishedAt) {
-        existingConnection.establishedAt = new Date();
-      }
-      if (action === 'close' && !existingConnection.closedAt) {
-        existingConnection.closedAt = new Date();
-      }
-      if (sessionId !== null && sessionId !== existingConnection.sessionId) {
-        existingConnection.sessionId = sessionId;
-      }
-      if (dto.ip && dto.ip !== existingConnection.ip) {
-        existingConnection.ip = dto.ip;
-      }
-      if (dto.peer && dto.peer[0] !== existingConnection.peerId) {
-        existingConnection.peerId = dto.peer[0];
-      }
-      if (dto.peer && dto.peer[1] !== existingConnection.peerName) {
-        existingConnection.peerName = dto.peer[1];
-      }
-      if (dto.type !== undefined && dto.type !== existingConnection.type) {
-        existingConnection.type = dto.type;
-      }
-      existingConnection.action = action;
-      return await this.connectionAuditRepository.save(existingConnection);
+      return this.updateExistingConnection(
+        existingConnection,
+        dto,
+        action,
+        sessionId,
+      );
     }
 
-    // 创建新连接
+    return this.createNewConnection(dto, action, connId, sessionId);
+  }
+
+  /**
+   * 更新已有连接审计记录
+   */
+  private async updateExistingConnection(
+    existingConnection: ConnectionAudit,
+    dto: ConnectionAuditDto,
+    action: string,
+    sessionId: string | null,
+  ): Promise<ConnectionAudit> {
+    if (action === 'open' && !existingConnection.requestedAt) {
+      existingConnection.requestedAt = new Date();
+    }
+    if (action === 'established' && !existingConnection.establishedAt) {
+      existingConnection.establishedAt = new Date();
+    }
+    if (action === 'close' && !existingConnection.closedAt) {
+      existingConnection.closedAt = new Date();
+    }
+    if (sessionId !== null && sessionId !== existingConnection.sessionId) {
+      existingConnection.sessionId = sessionId;
+    }
+    if (dto.ip && dto.ip !== existingConnection.ip) {
+      existingConnection.ip = dto.ip;
+    }
+    if (dto.peer && dto.peer[0] !== existingConnection.peerId) {
+      existingConnection.peerId = dto.peer[0];
+    }
+    if (dto.peer && dto.peer[1] !== existingConnection.peerName) {
+      existingConnection.peerName = dto.peer[1];
+    }
+    if (dto.type !== undefined && dto.type !== existingConnection.type) {
+      existingConnection.type = dto.type;
+    }
+    // 有值则覆盖，无值保留原值
+    if (dto.note !== undefined && dto.note !== '') {
+      existingConnection.note = dto.note;
+    }
+    existingConnection.action = action;
+    return await this.connectionAuditRepository.save(existingConnection);
+  }
+
+  /**
+   * 创建新连接审计记录
+   */
+  private async createNewConnection(
+    dto: ConnectionAuditDto,
+    action: string,
+    connId: string | null,
+    sessionId: string | null,
+  ): Promise<ConnectionAudit> {
     const connectionAudit = this.connectionAuditRepository.create({
       deviceId: dto.id,
       deviceUuid: dto.uuid,
@@ -110,6 +182,7 @@ export class AuditService {
       peerId: dto.peer ? dto.peer[0] : null,
       peerName: dto.peer ? dto.peer[1] : null,
       type: dto.type !== undefined ? dto.type : null,
+      note: dto.note || null,
       requestedAt: action === 'open' ? new Date() : null,
       establishedAt: action === 'established' ? new Date() : null,
       closedAt: action === 'close' ? new Date() : null,
@@ -218,6 +291,7 @@ export class AuditService {
         'ca.peerId',
         'ca.peerName',
         'ca.type',
+        'ca.note',
         'ca.requestedAt',
         'ca.establishedAt',
         'ca.closedAt',

--- a/src/modules/audit/dto/connection-audit.dto.ts
+++ b/src/modules/audit/dto/connection-audit.dto.ts
@@ -26,8 +26,7 @@ export class ConnectionAuditDto {
   conn_id?: number;
 
   @IsNumber()
-  @IsOptional()
-  session_id?: number;
+  session_id: number;
 
   // ip 字段在 action 为 close 时可能不发送
   @IsString()

--- a/src/modules/audit/dto/connection-audit.dto.ts
+++ b/src/modules/audit/dto/connection-audit.dto.ts
@@ -6,24 +6,28 @@ import {
   Min,
   Max,
   IsNumber,
+  MaxLength,
 } from 'class-validator';
 
 /**
  * ConnectionAuditDto
- * 用于记录连接审计信息
+ * 用于记录连接审计信息，支持连接状态上报和备注添加
  */
 export class ConnectionAuditDto {
   @IsString()
   id: string;
 
   @IsString()
-  uuid: string;
+  @IsOptional()
+  uuid?: string;
 
   @IsNumber()
-  conn_id: number;
+  @IsOptional()
+  conn_id?: number;
 
   @IsNumber()
-  session_id: number;
+  @IsOptional()
+  session_id?: number;
 
   // ip 字段在 action 为 close 时可能不发送
   @IsString()
@@ -44,4 +48,9 @@ export class ConnectionAuditDto {
   @Max(4)
   @IsOptional()
   type?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(256)
+  note?: string;
 }

--- a/src/modules/audit/entities/connection-audit.entity.ts
+++ b/src/modules/audit/entities/connection-audit.entity.ts
@@ -48,4 +48,7 @@ export class ConnectionAudit {
 
   @Column({ type: 'datetime', nullable: true })
   closedAt: Date | null;
+
+  @Column({ type: 'varchar', length: 256, nullable: true })
+  note: string | null;
 }


### PR DESCRIPTION
## Summary

Add a `note` field to connection audit records, allowing clients to attach remarks to connections.

## Changes

- **Entity**: Add nullable `note` varchar(256) column to `connection_audits` table
- **DTO**: Make `uuid` and `conn_id` optional in `ConnectionAuditDto` to support note-only requests; add `note` field with `MaxLength(256)` validation
- **Service**: Refactor `auditConnection` into separate methods for clarity:
  - `addConnectionNote`: handles note-only requests (matched by `deviceId` + `sessionId`)
  - `upsertConnectionAudit`: handles full connection state updates
  - `updateExistingConnection`: updates existing records
  - `createNewConnection`: creates new records
- **Query**: Include `note` in connection audit query results

## Note Update Strategy

- **Full connection request** (with `uuid`): if `note` has a value, overwrite the existing note; if omitted or empty, preserve the original note
- **Note-only request** (without `uuid`, with `session_id` + `note`): find the record by `deviceId` + `sessionId` and update the note; throws `NotFoundException` if no matching record exists

## Client Usage Example

```bash
# Add a note to an existing connection
curl -X POST http://your-server/api/audit/conn \
  -H "Content-Type: application/json" \
  -d '{
    "id": "abc123",
    "session_id": 1715432890,
    "note": "测试连接，一切正常"
  }'
```

## Test Plan

- [x] Lint passes
- [x] TypeScript compilation passes
- [ ] Manual test: submit note-only request
- [ ] Manual test: submit full connection request with note
- [ ] Manual test: verify note appears in query results