### PR TITLE
fix(audit): simplify note handling for client requests

### DIFF
--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -155,10 +155,6 @@ export class AuditService {
     if (dto.type !== undefined && dto.type !== existingConnection.type) {
       existingConnection.type = dto.type;
     }
-    // 有值则覆盖，无值保留原值
-    if (dto.note !== undefined && dto.note !== '') {
-      existingConnection.note = dto.note;
-    }
     existingConnection.action = action;
     return await this.connectionAuditRepository.save(existingConnection);
   }
@@ -182,7 +178,6 @@ export class AuditService {
       peerId: dto.peer ? dto.peer[0] : null,
       peerName: dto.peer ? dto.peer[1] : null,
       type: dto.type !== undefined ? dto.type : null,
-      note: dto.note || null,
       requestedAt: action === 'open' ? new Date() : null,
       establishedAt: action === 'established' ? new Date() : null,
       closedAt: action === 'close' ? new Date() : null,


### PR DESCRIPTION
## Summary

Simplify note handling to match the actual client behavior: note is only sent via a dedicated `{id, session_id, note}` request, never alongside connection state updates.

## Changes

- Remove `ValidateIf`/`null` from DTO, `note` is simply `string | undefined`
- Remove note handling from `updateExistingConnection` and `createNewConnection`
- Note is only processed in `addConnectionNote` (the note-only request path)

## Client Behavior

Client sends note as a standalone request:
```json
{ "id": "device-id", "session_id": 1234567890, "note": "备注内容" }
```
This request is identified by the absence of `uuid` and the presence of `note`.