### PR TITLE
feat(audit): add admin endpoint to update connection audit note

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -1,7 +1,20 @@
-import { Controller, Post, Body, UseGuards, Get, Query } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Get,
+  Query,
+  Patch,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuditService } from './audit.service';
-import { ConnectionAuditDto } from './dto/connection-audit.dto';
+import {
+  ConnectionAuditDto,
+  UpdateConnectionAuditDto,
+} from './dto/connection-audit.dto';
 import { FileAuditDto } from './dto/file-audit.dto';
 import { AlarmAuditDto } from './dto/alarm-audit.dto';
 import { Public } from '../auth/decorators/public.decorator';
@@ -162,6 +175,27 @@ export class AuditsController {
       pageSize,
       current,
     });
+  }
+
+  /**
+   * 更新连接审计记录
+   * 管理端对连接审计记录进行部分更新（如添加/修改/清空备注）
+   *
+   * @param id 连接审计记录主键
+   * @param dto 更新数据
+   */
+  @UseGuards(AdminGuard)
+  @Patch('conn/:id')
+  async updateConnectionAudit(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateConnectionAuditDto,
+  ) {
+    const result = await this.auditService.updateConnectionAudit(id, dto);
+    return {
+      message: '连接审计更新成功',
+      status: 'success',
+      data: result,
+    };
   }
 
   /**

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -5,6 +5,7 @@ import { ConnectionAudit, ConnType } from './entities/connection-audit.entity';
 import { FileAudit } from './entities/file-audit.entity';
 import { AlarmAudit } from './entities/alarm-audit.entity';
 import { ConnectionAuditDto } from './dto/connection-audit.dto';
+import { UpdateConnectionAuditDto } from './dto/connection-audit.dto';
 import { FileAuditDto } from './dto/file-audit.dto';
 import { AlarmAuditDto } from './dto/alarm-audit.dto';
 
@@ -70,6 +71,26 @@ export class AuditService {
       throw new NotFoundException(
         `Connection audit not found for deviceId=${dto.id}, sessionId=${sessionId}`,
       );
+    }
+
+    existingConnection.note = dto.note || null;
+    return await this.connectionAuditRepository.save(existingConnection);
+  }
+
+  /**
+   * 管理端更新连接审计记录
+   * 按主键查找记录并更新 note 字段
+   */
+  async updateConnectionAudit(
+    id: number,
+    dto: UpdateConnectionAuditDto,
+  ): Promise<ConnectionAudit> {
+    const existingConnection = await this.connectionAuditRepository.findOne({
+      where: { id },
+    });
+
+    if (!existingConnection) {
+      throw new NotFoundException(`Connection audit not found for id=${id}`);
     }
 
     existingConnection.note = dto.note || null;

--- a/src/modules/audit/dto/connection-audit.dto.ts
+++ b/src/modules/audit/dto/connection-audit.dto.ts
@@ -53,3 +53,13 @@ export class ConnectionAuditDto {
   @MaxLength(256)
   note?: string;
 }
+
+/**
+ * UpdateConnectionAuditDto
+ * 管理端更新连接审计记录
+ */
+export class UpdateConnectionAuditDto {
+  @IsString()
+  @MaxLength(256)
+  note: string;
+}


### PR DESCRIPTION
## Summary

Add a RESTful admin endpoint for updating connection audit records (currently supporting note field).

## Changes

- **DTO**: Add `UpdateConnectionAuditDto` with required `note` field (max 256 chars)
- **Service**: Add `updateConnectionAudit(id, dto)` method — lookup by primary key, throw `NotFoundException` if not found
- **Controller**: Add `PATCH /audits/conn/:id` in `AuditsController` (protected by `AdminGuard`)
- Empty string clears note (stored as `null`)

## API Usage

```bash
# Add or update note
curl -X PATCH http://your-server/api/audits/conn/42 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <admin-token>" \
  -d '{"note": "管理员备注"}'

# Clear note
curl -X PATCH http://your-server/api/audits/conn/42 \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <admin-token>" \
  -d '{"note": ""}'
```

## Test Plan

- [x] Lint passes
- [x] TypeScript compilation passes
- [ ] Manual test: update note via admin endpoint
- [ ] Manual test: clear note with empty string
- [ ] Manual test: 404 for non-existent id