### PR TITLE
feat: add force disconnect connection via heartbeat response

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { UserUserPermission } from './modules/device-group/entities/user-user-pe
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 import { EmailVerificationSession } from './modules/auth/entities/email-verification-session.entity';
 import { SystemSetting } from './modules/settings/entities/system-setting.entity';
+import { ActiveConnection } from './modules/heartbeat/entities/active-connection.entity';
 import { SettingsModule } from './modules/settings/settings.module';
 
 /**
@@ -89,6 +90,7 @@ import { SettingsModule } from './modules/settings/settings.module';
         UserUserPermission,
         EmailVerificationSession,
         SystemSetting,
+        ActiveConnection,
       ],
       synchronize: true,
       logging: false,

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
+  NotFoundException,
 } from '@nestjs/common';
 import { DeviceGroupService } from './device-group.service';
 import { PeerService } from './peer.service';
@@ -21,6 +22,8 @@ import {
   UpdateDeviceStatusDto,
   DeviceOperationResult,
 } from './dto/device-status.dto';
+import { DisconnectDto } from './dto/disconnect.dto';
+import { DisconnectStoreService } from '../heartbeat/services/disconnect-store.service';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AdminGuard } from '../../common/guards/admin.guard';
 
@@ -38,6 +41,7 @@ export class DeviceGroupController {
   constructor(
     private readonly deviceGroupService: DeviceGroupService,
     private readonly peerService: PeerService,
+    private readonly disconnectStoreService: DisconnectStoreService,
   ) {}
 
   // ============ 客户端 API 接口 ============
@@ -351,5 +355,36 @@ export class DeviceGroupController {
   ) {
     await this.deviceGroupService.assignDevice(guid, body.type, body.value);
     return { message: '设备属性已分配' };
+  }
+
+  /**
+   * 强制断开设备连接
+   * 管理员可以强制断开指定设备的活跃连接
+   * 断开指令将在设备下次心跳时下发给客户端执行
+   *
+   * @param uuid 设备UUID
+   * @param dto 断开连接请求，包含需要断开的连接ID列表
+   * @returns 操作结果
+   */
+  @Post('devices/:uuid/disconnect')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async disconnectDevice(
+    @Param('uuid') uuid: string,
+    @Body() dto: DisconnectDto,
+  ) {
+    const peer = await this.peerService.findByUuid(uuid);
+    if (!peer) {
+      throw new NotFoundException('设备不存在');
+    }
+
+    this.disconnectStoreService.addPendingDisconnects(uuid, dto.connIds);
+    return {
+      message: '断开指令已提交，将在设备下次心跳时下发',
+      data: {
+        uuid,
+        pending_disconnect_count: dto.connIds.length,
+      },
+    };
   }
 }

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
 import { DeviceGroupService } from './device-group.service';
 import { PeerService } from './peer.service';
@@ -24,6 +25,7 @@ import {
 } from './dto/device-status.dto';
 import { DisconnectDto } from './dto/disconnect.dto';
 import { DisconnectStoreService } from '../heartbeat/services/disconnect-store.service';
+import { HeartbeatService } from '../heartbeat/heartbeat.service';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AdminGuard } from '../../common/guards/admin.guard';
 
@@ -42,6 +44,7 @@ export class DeviceGroupController {
     private readonly deviceGroupService: DeviceGroupService,
     private readonly peerService: PeerService,
     private readonly disconnectStoreService: DisconnectStoreService,
+    private readonly heartbeatService: HeartbeatService,
   ) {}
 
   // ============ 客户端 API 接口 ============
@@ -376,6 +379,16 @@ export class DeviceGroupController {
     const peer = await this.peerService.findByUuid(uuid);
     if (!peer) {
       throw new NotFoundException('设备不存在');
+    }
+
+    // 验证请求断开的连接ID是否为该设备的活跃连接
+    const activeConnIds = await this.heartbeatService.getActiveConnectionIds(uuid);
+    const activeConnIdSet = new Set(activeConnIds);
+    const invalidConnIds = dto.connIds.filter((id) => !activeConnIdSet.has(id));
+    if (invalidConnIds.length > 0) {
+      throw new BadRequestException(
+        `以下连接ID不存在或不属于该设备: ${invalidConnIds.join(', ')}`,
+      );
     }
 
     this.disconnectStoreService.addPendingDisconnects(uuid, dto.connIds);

--- a/src/modules/device-group/device-group.module.ts
+++ b/src/modules/device-group/device-group.module.ts
@@ -9,6 +9,7 @@ import { UserUserPermission } from './entities/user-user-permission.entity';
 import { Peer, Sysinfo } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
+import { HeartbeatModule } from '../heartbeat/heartbeat.module';
 
 /**
  * 设备组模块
@@ -16,6 +17,8 @@ import { AuthModule } from '../auth/auth.module';
  *
  * 导入模块：
  * - TypeOrmModule
+ * - AuthModule
+ * - HeartbeatModule
  *
  * 导出服务：
  * - DeviceGroupService
@@ -36,6 +39,7 @@ import { AuthModule } from '../auth/auth.module';
       User,
     ]),
     AuthModule,
+    HeartbeatModule,
   ],
   controllers: [DeviceGroupController],
   providers: [DeviceGroupService, PeerService],

--- a/src/modules/device-group/dto/disconnect.dto.ts
+++ b/src/modules/device-group/dto/disconnect.dto.ts
@@ -1,0 +1,15 @@
+import { IsArray, ArrayNotEmpty, IsNumber } from 'class-validator';
+
+/**
+ * 断开连接DTO
+ * 用于管理员强制断开指定设备的连接
+ */
+export class DisconnectDto {
+  /**
+   * 需要强制断开的连接ID列表
+   */
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  connIds: number[];
+}

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -236,4 +236,13 @@ export class PeerService {
 
     return { data, total };
   }
+
+  /**
+   * 根据UUID查找设备
+   * @param uuid 设备UUID
+   * @returns 设备实体或null
+   */
+  async findByUuid(uuid: string): Promise<Peer | null> {
+    return this.peerRepository.findOne({ where: { uuid } });
+  }
 }

--- a/src/modules/heartbeat/dto/heartbeat.dto.ts
+++ b/src/modules/heartbeat/dto/heartbeat.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNumber, IsNotEmpty } from 'class-validator';
+import { IsString, IsNumber, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
 
 /**
  * HeartbeatDto
@@ -20,4 +20,12 @@ export class HeartbeatDto {
   @IsNumber()
   @IsNotEmpty()
   modified_at: number;
+
+  /**
+   * 当前活跃连接ID列表
+   * 客户端上报当前持有的活跃连接，服务端据此维护连接状态
+   */
+  @IsOptional()
+  @IsArray()
+  conns?: number[];
 }

--- a/src/modules/heartbeat/entities/active-connection.entity.ts
+++ b/src/modules/heartbeat/entities/active-connection.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+/**
+ * 活跃连接实体
+ * 存储客户端心跳上报的当前活跃连接
+ */
+@Entity('active_connections')
+export class ActiveConnection {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  /**
+   * 连接ID
+   * 客户端上报的连接唯一标识
+   */
+  @Column({ type: 'integer' })
+  @Index()
+  connId: number;
+
+  /**
+   * 设备UUID
+   * 关联到 peers 表的 uuid 字段
+   */
+  @Column({ type: 'text' })
+  @Index()
+  deviceUuid: string;
+
+  /**
+   * 关联的设备实体
+   */
+  @ManyToOne('Peer', undefined, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'deviceUuid' })
+  device: any;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/heartbeat/heartbeat.module.ts
+++ b/src/modules/heartbeat/heartbeat.module.ts
@@ -2,25 +2,29 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HeartbeatController } from './heartbeat.controller';
 import { HeartbeatService } from './heartbeat.service';
+import { DisconnectStoreService } from './services/disconnect-store.service';
 import { Peer } from '../../common/entities';
+import { ActiveConnection } from './entities/active-connection.entity';
 
 /**
  * 心跳模块
- * 负责设备心跳处理和在线状态维护
+ * 负责设备心跳处理、在线状态维护和连接管理
  *
  * 导入模块：
  * - TypeOrmModule
  *
  * 导出服务：
  * - HeartbeatService
+ * - DisconnectStoreService
  *
  * 提供服务：
  * - HeartbeatService
+ * - DisconnectStoreService
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([Peer])],
+  imports: [TypeOrmModule.forFeature([Peer, ActiveConnection])],
   controllers: [HeartbeatController],
-  providers: [HeartbeatService],
-  exports: [HeartbeatService],
+  providers: [HeartbeatService, DisconnectStoreService],
+  exports: [HeartbeatService, DisconnectStoreService],
 })
 export class HeartbeatModule {}

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { Peer } from '../../common/entities';
+import { ActiveConnection } from './entities/active-connection.entity';
+import { DisconnectStoreService } from './services/disconnect-store.service';
 
 /**
  * 心跳服务
@@ -12,6 +14,8 @@ import { Peer } from '../../common/entities';
  * - 接收设备心跳数据
  * - 创建或更新设备记录
  * - 维护设备在线状态
+ * - 同步活跃连接信息
+ * - 下发强制断开连接指令
  */
 @Injectable()
 export class HeartbeatService {
@@ -20,14 +24,18 @@ export class HeartbeatService {
   constructor(
     @InjectRepository(Peer)
     private peerRepository: Repository<Peer>,
+    @InjectRepository(ActiveConnection)
+    private activeConnectionRepository: Repository<ActiveConnection>,
+    private disconnectStoreService: DisconnectStoreService,
   ) {}
 
   /**
    * 处理设备心跳
    * 接收设备发送的心跳数据，创建或更新设备记录
+   * 同时处理活跃连接同步和断开指令下发
    *
-   * @param data 心跳数据，包含设备ID、UUID、版本号等信息
-   * @returns 心跳处理结果，包含响应码和设备信息
+   * @param data 心跳数据，包含设备ID、UUID、版本号、活跃连接等信息
+   * @returns 心跳处理结果，包含断开连接指令
    */
   async handleHeartbeat(data: HeartbeatDto) {
     this.logger.debug(`收到心跳数据: id=${data.id}, uuid=${data.uuid}`);
@@ -37,7 +45,6 @@ export class HeartbeatService {
     });
 
     if (existingPeer) {
-      // 设备已存在，更新记录
       await this.peerRepository.update(
         { uuid: data.uuid },
         {
@@ -49,7 +56,6 @@ export class HeartbeatService {
       );
       this.logger.debug(`设备 ${data.uuid} 心跳已更新`);
     } else {
-      // 设备不存在，创建新记录
       const peer = this.peerRepository.create({
         id: data.id,
         uuid: data.uuid,
@@ -61,13 +67,53 @@ export class HeartbeatService {
       this.logger.log(`新设备 ${data.uuid} 已注册`);
     }
 
+    // 同步活跃连接
+    if (data.conns !== undefined) {
+      await this.syncActiveConnections(data.uuid, data.conns);
+    }
+
+    // 获取待断开连接列表（取走后清空）
+    const disconnect =
+      this.disconnectStoreService.consumePendingDisconnects(data.uuid);
+
     return {
       code: 200,
       message: '心跳接收成功',
       data: {
         timestamp: Date.now(),
         device_id: data.id,
+        ...(disconnect.length > 0 ? { disconnect } : {}),
       },
     };
+  }
+
+  /**
+   * 同步活跃连接
+   * 用客户端上报的连接列表替换该设备的所有活跃连接记录
+   *
+   * @param deviceUuid 设备UUID
+   * @param conns 客户端上报的活跃连接ID列表
+   */
+  private async syncActiveConnections(
+    deviceUuid: string,
+    conns: number[],
+  ): Promise<void> {
+    // 删除该设备旧的活跃连接
+    await this.activeConnectionRepository.delete({ deviceUuid });
+
+    // 插入新的活跃连接
+    if (conns.length > 0) {
+      const entities = conns.map((connId) =>
+        this.activeConnectionRepository.create({
+          connId,
+          deviceUuid,
+        }),
+      );
+      await this.activeConnectionRepository.save(entities);
+    }
+
+    this.logger.debug(
+      `设备 ${deviceUuid} 活跃连接已同步: ${conns.length} 个`,
+    );
   }
 }

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository } from 'typeorm';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { Peer } from '../../common/entities';
 import { ActiveConnection } from './entities/active-connection.entity';
@@ -75,8 +75,9 @@ export class HeartbeatService {
     }
 
     // 获取待断开连接列表（持续下发直到客户端确认断开）
-    const disconnect =
-      this.disconnectStoreService.getPendingDisconnects(data.uuid);
+    const disconnect = this.disconnectStoreService.getPendingDisconnects(
+      data.uuid,
+    );
 
     return {
       code: 200,
@@ -127,8 +128,6 @@ export class HeartbeatService {
       await this.activeConnectionRepository.save(entities);
     }
 
-    this.logger.debug(
-      `设备 ${deviceUuid} 活跃连接已同步: ${conns.length} 个`,
-    );
+    this.logger.debug(`设备 ${deviceUuid} 活跃连接已同步: ${conns.length} 个`);
   }
 }

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -70,21 +70,36 @@ export class HeartbeatService {
     // 同步活跃连接
     if (data.conns !== undefined) {
       await this.syncActiveConnections(data.uuid, data.conns);
+      // 客户端不再上报的连接说明已断开，从待断开列表中移除
+      this.disconnectStoreService.removeDisconnected(data.uuid, data.conns);
     }
 
-    // 获取待断开连接列表（取走后清空）
+    // 获取待断开连接列表（持续下发直到客户端确认断开）
     const disconnect =
-      this.disconnectStoreService.consumePendingDisconnects(data.uuid);
+      this.disconnectStoreService.getPendingDisconnects(data.uuid);
 
     return {
       code: 200,
       message: '心跳接收成功',
+      ...(disconnect.length > 0 ? { disconnect } : {}),
       data: {
         timestamp: Date.now(),
         device_id: data.id,
-        ...(disconnect.length > 0 ? { disconnect } : {}),
       },
     };
+  }
+
+  /**
+   * 获取设备的活跃连接ID列表
+   * @param deviceUuid 设备UUID
+   * @returns 活跃连接ID列表
+   */
+  async getActiveConnectionIds(deviceUuid: string): Promise<number[]> {
+    const connections = await this.activeConnectionRepository.find({
+      where: { deviceUuid },
+      select: ['connId'],
+    });
+    return connections.map((c) => c.connId);
   }
 
   /**

--- a/src/modules/heartbeat/services/disconnect-store.service.ts
+++ b/src/modules/heartbeat/services/disconnect-store.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * 断开连接内存存储服务
+ * 暂存需要强制断开的连接ID，等待客户端下次心跳时取走
+ */
+@Injectable()
+export class DisconnectStoreService {
+  /**
+   * key: 设备UUID, value: 需要断开的连接ID集合
+   */
+  private store = new Map<string, Set<number>>();
+
+  /**
+   * 添加待断开连接
+   * @param deviceUuid 设备UUID
+   * @param connIds 需要断开的连接ID列表
+   */
+  addPendingDisconnects(deviceUuid: string, connIds: number[]): void {
+    if (connIds.length === 0) return;
+
+    const existing = this.store.get(deviceUuid);
+    if (existing) {
+      for (const connId of connIds) {
+        existing.add(connId);
+      }
+    } else {
+      this.store.set(deviceUuid, new Set(connIds));
+    }
+  }
+
+  /**
+   * 获取并清除待断开连接
+   * 客户端心跳时调用，取走后即清空，避免重复下发
+   * @param deviceUuid 设备UUID
+   * @returns 需要断开的连接ID列表，无则返回空数组
+   */
+  consumePendingDisconnects(deviceUuid: string): number[] {
+    const pending = this.store.get(deviceUuid);
+    if (!pending || pending.size === 0) {
+      return [];
+    }
+
+    const result = Array.from(pending);
+    this.store.delete(deviceUuid);
+    return result;
+  }
+
+  /**
+   * 获取设备当前的待断开连接（不清除）
+   * @param deviceUuid 设备UUID
+   */
+  getPendingDisconnects(deviceUuid: string): number[] {
+    const pending = this.store.get(deviceUuid);
+    return pending ? Array.from(pending) : [];
+  }
+}

--- a/src/modules/heartbeat/services/disconnect-store.service.ts
+++ b/src/modules/heartbeat/services/disconnect-store.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 /**
  * 断开连接内存存储服务
- * 暂存需要强制断开的连接ID，等待客户端下次心跳时取走
+ * 暂存需要强制断开的连接ID，持续下发给客户端直到连接确实断开
  */
 @Injectable()
 export class DisconnectStoreService {
@@ -30,28 +30,37 @@ export class DisconnectStoreService {
   }
 
   /**
-   * 获取并清除待断开连接
-   * 客户端心跳时调用，取走后即清空，避免重复下发
+   * 获取待断开连接列表（不清除）
+   * 每次心跳时调用，持续返回直到客户端确认断开（不再上报该connId）
    * @param deviceUuid 设备UUID
    * @returns 需要断开的连接ID列表，无则返回空数组
-   */
-  consumePendingDisconnects(deviceUuid: string): number[] {
-    const pending = this.store.get(deviceUuid);
-    if (!pending || pending.size === 0) {
-      return [];
-    }
-
-    const result = Array.from(pending);
-    this.store.delete(deviceUuid);
-    return result;
-  }
-
-  /**
-   * 获取设备当前的待断开连接（不清除）
-   * @param deviceUuid 设备UUID
    */
   getPendingDisconnects(deviceUuid: string): number[] {
     const pending = this.store.get(deviceUuid);
     return pending ? Array.from(pending) : [];
+  }
+
+  /**
+   * 移除已断开的连接
+   * 客户端心跳上报的 conns 中不再包含的 connId，说明已成功断开，从待断开列表中移除
+   * @param deviceUuid 设备UUID
+   * @param currentConns 客户端当前上报的活跃连接ID列表
+   */
+  removeDisconnected(deviceUuid: string, currentConns: number[]): void {
+    const pending = this.store.get(deviceUuid);
+    if (!pending || pending.size === 0) return;
+
+    const currentSet = new Set(currentConns);
+    for (const connId of pending) {
+      // 客户端不再上报该连接，说明已断开
+      if (!currentSet.has(connId)) {
+        pending.delete(connId);
+      }
+    }
+
+    // 如果待断开列表为空，清理 Map 条目
+    if (pending.size === 0) {
+      this.store.delete(deviceUuid);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implement server-side control to force clients to disconnect specific connections by including a `disconnect` field in the heartbeat response.

## How it works

1. Admin calls `POST /api/devices/:uuid/disconnect` with `{ connIds: [12345, 67890] }`
2. Server stores the disconnect request in memory
3. When the client sends its next heartbeat, the response includes `"disconnect": [12345, 67890]`
4. Client receives the list and terminates the specified connections

## Changes

- **ActiveConnection entity**: Persists client-reported active connections from heartbeat `conns` field
- **HeartbeatDto**: Added optional `conns` field for clients to report active connections
- **DisconnectStoreService**: In-memory service to store pending disconnect requests per device
- **HeartbeatService**: Syncs active connections to DB and returns disconnect list in heartbeat response
- **POST /api/devices/:uuid/disconnect**: Admin-only endpoint to request connection disconnection
- **DisconnectDto**: Request body validation for the disconnect endpoint

## API

### Disconnect device connections
```
POST /api/devices/:uuid/disconnect
Authorization: Bearer <admin-jwt>
Content-Type: application/json

{
  "connIds": [12345, 67890]
}
```

### Heartbeat response (with disconnect instructions)
```json
{
  "code": 200,
  "message": "心跳接收成功",
  "data": {
    "timestamp": 1716537600000,
    "device_id": "123456789",
    "disconnect": [12345, 67890]
  }
}
```