### PR TITLE
fix(oidc): address code review issues from PR #70

### DIFF
--- a/src/modules/oidc/dto/oidc.dto.ts
+++ b/src/modules/oidc/dto/oidc.dto.ts
@@ -1,4 +1,5 @@
-import { IsString, IsObject } from 'class-validator';
+import { IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 /**
  * 设备信息
@@ -27,6 +28,7 @@ export class OidcAuthRequestDto {
   @IsString()
   uuid: string; // 设备UUID
 
-  @IsObject()
+  @ValidateNested()
+  @Type(() => DeviceInfoDto)
   deviceInfo: DeviceInfoDto; // 设备信息
 }

--- a/src/modules/oidc/entities/oidc-auth-state.entity.ts
+++ b/src/modules/oidc/entities/oidc-auth-state.entity.ts
@@ -13,6 +13,7 @@ import {
 export enum OidcAuthStatus {
   PENDING = 'pending', // 等待用户授权
   AUTHORIZED = 'authorized', // 已授权
+  CONSUMED = 'consumed', // 已消费（Token已被客户端取走）
   EXPIRED = 'expired', // 已过期
   CANCELLED = 'cancelled', // 已取消
 }

--- a/src/modules/oidc/entities/oidc-provider.entity.ts
+++ b/src/modules/oidc/entities/oidc-provider.entity.ts
@@ -78,6 +78,13 @@ export class OidcProvider {
   userinfoEndpoint: string;
 
   /**
+   * JWKS 端点
+   * OIDC 提供商的 JSON Web Key Set 端点 URL，用于验证 ID Token 签名
+   */
+  @Column({ nullable: true })
+  jwksUri: string;
+
+  /**
    * 是否启用
    * true - 提供商可用
    * false - 提供商禁用

--- a/src/modules/oidc/oidc-auth-state-cleanup.service.ts
+++ b/src/modules/oidc/oidc-auth-state-cleanup.service.ts
@@ -29,13 +29,14 @@ export class OidcAuthStateCleanupService {
     try {
       const now = new Date();
 
-      // 清理已过期的PENDING/EXPIRED/CANCELLED状态记录
+      // 清理已过期的PENDING/EXPIRED/CANCELLED/CONSUMED状态记录
       const expiredResult = await this.authStateRepository.delete({
         expiresAt: LessThan(now),
         status: In([
           OidcAuthStatus.PENDING,
           OidcAuthStatus.EXPIRED,
           OidcAuthStatus.CANCELLED,
+          OidcAuthStatus.CONSUMED,
         ]),
       });
 

--- a/src/modules/oidc/oidc.service.ts
+++ b/src/modules/oidc/oidc.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan, QueryFailedError } from 'typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as client from 'openid-client';
 import { OidcProvider } from './entities/oidc-provider.entity';
@@ -360,62 +360,81 @@ export class OidcService {
     deviceId: string,
     deviceUuid: string,
   ): Promise<LoginResponse> {
-    const authState = await this.authStateRepository.findOne({
-      where: {
-        code,
-        deviceId,
-        deviceUuid,
-        expiresAt: MoreThan(new Date()),
-      },
-    });
+    // 原子操作：将AUTHORIZED状态标记为CONSUMED，防止并发重复获取Token
+    const updateResult = await this.authStateRepository
+      .createQueryBuilder()
+      .update(OidcAuthState)
+      .set({ status: OidcAuthStatus.CONSUMED })
+      .where(
+        'code = :code AND deviceId = :deviceId AND deviceUuid = :deviceUuid',
+        {
+          code,
+          deviceId,
+          deviceUuid,
+        },
+      )
+      .andWhere('status = :status', { status: OidcAuthStatus.AUTHORIZED })
+      .andWhere('expiresAt > :now', { now: new Date() })
+      .execute();
 
-    if (!authState) {
-      throw new UnauthorizedException('No authed oidc is found');
-    }
-
-    if (authState.status === OidcAuthStatus.PENDING) {
-      throw new UnauthorizedException('No authed oidc is found');
-    }
-
-    if (authState.status === OidcAuthStatus.EXPIRED) {
-      throw new UnauthorizedException('Authorization expired');
-    }
-
-    if (authState.status === OidcAuthStatus.CANCELLED) {
-      throw new UnauthorizedException('Authorization cancelled');
-    }
-
-    if (
-      authState.status === OidcAuthStatus.AUTHORIZED &&
-      authState.accessToken
-    ) {
-      const user = await this.userRepository.findOne({
-        where: { guid: authState.userGuid },
+    if (!updateResult.affected) {
+      // 没有匹配到AUTHORIZED状态，检查其他状态以返回适当的错误信息
+      const authState = await this.authStateRepository.findOne({
+        where: { code, deviceId, deviceUuid },
       });
 
-      if (!user) {
-        throw new UnauthorizedException('User not found');
+      if (!authState || authState.status === OidcAuthStatus.PENDING) {
+        throw new UnauthorizedException('No authed oidc is found');
       }
 
-      // 清理授权状态
-      await this.authStateRepository.remove(authState);
+      if (authState.status === OidcAuthStatus.EXPIRED) {
+        throw new UnauthorizedException('Authorization expired');
+      }
 
-      return {
-        access_token: authState.accessToken,
-        type: 'access_token',
-        user: {
-          name: user.username,
-          email: user.email || undefined,
-          note: user.note || undefined,
-          status: user.status,
-          info: user.getUserInfo(),
-          is_admin: user.isAdmin,
-          third_auth_type: user.thirdAuthType || undefined,
-        },
-      };
+      if (authState.status === OidcAuthStatus.CANCELLED) {
+        throw new UnauthorizedException('Authorization cancelled');
+      }
+
+      if (authState.status === OidcAuthStatus.CONSUMED) {
+        throw new UnauthorizedException('Authorization already consumed');
+      }
+
+      throw new UnauthorizedException('No authed oidc is found');
     }
 
-    throw new UnauthorizedException('No authed oidc is found');
+    // 查询已标记为CONSUMED的记录
+    const authState = await this.authStateRepository.findOne({
+      where: { code, deviceId, deviceUuid, status: OidcAuthStatus.CONSUMED },
+    });
+
+    if (!authState || !authState.accessToken) {
+      throw new UnauthorizedException('No authed oidc is found');
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { guid: authState.userGuid },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    // 清理授权状态
+    await this.authStateRepository.remove(authState);
+
+    return {
+      access_token: authState.accessToken,
+      type: 'access_token',
+      user: {
+        name: user.username,
+        email: user.email || undefined,
+        note: user.note || undefined,
+        status: user.status,
+        info: user.getUserInfo(),
+        is_admin: user.isAdmin,
+        third_auth_type: user.thirdAuthType || undefined,
+      },
+    };
   }
 
   /**
@@ -463,6 +482,7 @@ export class OidcService {
         authorization_endpoint: provider.authorizationEndpoint,
         token_endpoint: provider.tokenEndpoint,
         userinfo_endpoint: provider.userinfoEndpoint,
+        jwks_uri: provider.jwksUri,
       };
 
       const config = new client.Configuration(
@@ -502,8 +522,8 @@ export class OidcService {
    * 根据OIDC用户信息匹配现有用户，不存在则自动创建
    *
    * 策略：
-   * 1. 优先通过邮箱匹配现有用户
-   * 2. 邮箱无匹配时创建新用户
+   * 1. 仅通过OIDC sub + provider匹配已关联的OIDC用户
+   * 2. 不通过邮箱自动关联已有账户（防止账户接管）
    * 3. 新用户设置thirdAuthType为'oidc'
    * 4. 用户名冲突时追加随机后缀，处理并发竞态
    *
@@ -515,19 +535,13 @@ export class OidcService {
     oidcUserInfo: OidcUserInfo,
     providerName: string,
   ): Promise<User> {
-    // 优先通过邮箱查找现有用户（仅当邮箱已验证时）
-    if (oidcUserInfo.email && oidcUserInfo.email_verified) {
-      const existingUser = await this.userRepository.findOne({
-        where: { email: oidcUserInfo.email },
-      });
-      if (existingUser) {
-        // 更新第三方认证类型
-        if (!existingUser.thirdAuthType) {
-          existingUser.thirdAuthType = 'oidc';
-          await this.userRepository.save(existingUser);
-        }
-        return existingUser;
-      }
+    // 通过OIDC sub查找已关联的用户（不通过邮箱关联，防止账户接管）
+    const oidcSubject = `oidc:${providerName}:${oidcUserInfo.sub}`;
+    const existingUser = await this.userRepository.findOne({
+      where: { oidcSubject },
+    });
+    if (existingUser) {
+      return existingUser;
     }
 
     // 生成用户名
@@ -568,6 +582,7 @@ export class OidcService {
         user.isAdmin = false;
         user.note = `OIDC用户 (${providerName})`;
         user.thirdAuthType = 'oidc';
+        user.oidcSubject = oidcSubject;
 
         await this.userRepository.save(user);
         this.logger.log(

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -127,6 +127,15 @@ export class User {
   thirdAuthType: string;
 
   /**
+   * OIDC 主体标识
+   * 格式: oidc:{providerName}:{sub}
+   * 用于关联OIDC提供商中的用户身份，防止账户接管
+   */
+  @Column({ unique: true, nullable: true })
+  @Index()
+  oidcSubject: string;
+
+  /**
    * 用户的令牌列表
    * 一对多关系，关联到 UserToken
    */


### PR DESCRIPTION
## Summary

Address code review issues identified during PR #70 review for the OIDC login feature.

## Changes

### Issue 1: Missing `jwks_uri` in manual OIDC config fallback (Major)
- Added `jwksUri` column to `OidcProvider` entity
- Included `jwks_uri` in the manual `ServerMetadata` fallback when OIDC Discovery fails
- Without this, ID Token signature verification would fail when Discovery is unavailable

### Issue 2: Silent account linking by email (Major)
- Replaced email-based account linking with `oidcSubject`-based lookup
- Added `oidcSubject` column to `User` entity (format: `oidc:{providerName}:{sub}`)
- OIDC users are now only matched by their unique OIDC subject identifier, not by email
- This prevents account takeover if an OIDC provider is compromised or email is reassigned

### Issue 3: Race condition in `queryAuth` (Minor)
- Replaced separate read-then-delete with atomic UPDATE to CONSUMED status
- Added `CONSUMED` status to `OidcAuthStatus` enum
- Only one concurrent request can successfully transition from AUTHORIZED to CONSUMED
- Updated cleanup service to handle CONSUMED status

### Issue 4: DTO nested validation (Minor)
- Replaced `@IsObject()` with `@ValidateNested()` + `@Type(() => DeviceInfoDto)` in `OidcAuthRequestDto`
- Ensures `deviceInfo` nested properties are properly validated

## Test Plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes with no errors
- [ ] Manual testing of OIDC login flow
- [ ] Verify manual config fallback works with `jwksUri`
- [ ] Verify new OIDC users get `oidcSubject` set correctly
- [ ] Verify concurrent `queryAuth` requests only succeed once