### PR TITLE
feat(oidc): add admin CRUD API for OIDC provider management

### DIFF
--- a/src/modules/oidc/controllers/oidc-admin.controller.ts
+++ b/src/modules/oidc/controllers/oidc-admin.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminGuard } from '../../../common/guards/admin.guard';
+import { OidcAdminService } from '../services/oidc-admin.service';
+import {
+  CreateOidcProviderDto,
+  UpdateOidcProviderDto,
+  ToggleOidcProviderDto,
+  OidcProviderQueryDto,
+} from '../dto/oidc-provider.dto';
+
+@Controller('oidc-providers')
+@UseGuards(AdminGuard)
+export class OidcAdminController {
+  constructor(private readonly oidcAdminService: OidcAdminService) {}
+
+  @Get()
+  async findAll(@Query() query: OidcProviderQueryDto) {
+    return this.oidcAdminService.findAll(query);
+  }
+
+  @Get(':guid')
+  async findOne(@Param('guid') guid: string) {
+    return this.oidcAdminService.findOne(guid);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async create(@Body() dto: CreateOidcProviderDto) {
+    return this.oidcAdminService.create(dto);
+  }
+
+  @Patch(':guid')
+  @HttpCode(HttpStatus.OK)
+  async update(
+    @Param('guid') guid: string,
+    @Body() dto: UpdateOidcProviderDto,
+  ) {
+    return this.oidcAdminService.update(guid, dto);
+  }
+
+  @Delete(':guid')
+  @HttpCode(HttpStatus.OK)
+  async remove(@Param('guid') guid: string) {
+    await this.oidcAdminService.remove(guid);
+    return { message: 'OIDC 提供商已删除' };
+  }
+
+  @Patch(':guid/toggle')
+  @HttpCode(HttpStatus.OK)
+  async toggle(
+    @Param('guid') guid: string,
+    @Body() dto: ToggleOidcProviderDto,
+  ) {
+    return this.oidcAdminService.toggle(guid, dto.enabled);
+  }
+
+  @Post(':guid/test')
+  @HttpCode(HttpStatus.OK)
+  async testConnection(@Param('guid') guid: string) {
+    return this.oidcAdminService.testConnection(guid);
+  }
+}

--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -13,9 +13,9 @@ import { ConfigService } from '@nestjs/config';
 import type { Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
-import { OidcService } from './oidc.service';
-import { OidcAuthRequestDto } from './dto/oidc.dto';
-import { Public } from '../auth/decorators/public.decorator';
+import { OidcService } from '../services/oidc.service';
+import { OidcAuthRequestDto } from '../dto/oidc.dto';
+import { Public } from '../../auth/decorators/public.decorator';
 
 /**
  * HTML特殊字符转义，防止XSS攻击

--- a/src/modules/oidc/dto/oidc-provider.dto.ts
+++ b/src/modules/oidc/dto/oidc-provider.dto.ts
@@ -1,0 +1,140 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  IsInt,
+  Min,
+  IsUrl,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateOidcProviderDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  issuer: string;
+
+  @IsString()
+  @IsNotEmpty()
+  clientId: string;
+
+  @IsString()
+  @IsOptional()
+  clientSecret?: string;
+
+  @IsString()
+  @IsOptional()
+  scope?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  authorizationEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  tokenEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  userinfoEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  jwksUri?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  priority?: number;
+}
+
+export class UpdateOidcProviderDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  issuer?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  clientId?: string;
+
+  @IsString()
+  @IsOptional()
+  clientSecret?: string;
+
+  @IsString()
+  @IsOptional()
+  scope?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  authorizationEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  tokenEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  userinfoEndpoint?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsUrl({ require_tld: false, require_protocol: true })
+  jwksUri?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  priority?: number;
+}
+
+export class ToggleOidcProviderDto {
+  @IsBoolean()
+  @IsNotEmpty()
+  enabled: boolean;
+}
+
+export class OidcProviderQueryDto {
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  current: number;
+
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  pageSize: number;
+
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/src/modules/oidc/oidc.module.ts
+++ b/src/modules/oidc/oidc.module.ts
@@ -1,35 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { OidcController } from './oidc.controller';
-import { OidcService } from './oidc.service';
-import { OidcAuthStateCleanupService } from './oidc-auth-state-cleanup.service';
+import { OidcController } from './controllers/oidc.controller';
+import { OidcAdminController } from './controllers/oidc-admin.controller';
+import { OidcService } from './services/oidc.service';
+import { OidcAdminService } from './services/oidc-admin.service';
+import { OidcAuthStateCleanupService } from './services/oidc-auth-state-cleanup.service';
 import { OidcProvider } from './entities/oidc-provider.entity';
 import { OidcAuthState } from './entities/oidc-auth-state.entity';
 import { User } from '../user/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
 
-/**
- * OIDC模块
- * 负责OpenID Connect第三方登录集成
- *
- * 导入模块：
- * - TypeOrmModule
- * - AuthModule（提供AuthTokenService）
- *
- * 导出服务：
- * - OidcService
- *
- * 提供服务：
- * - OidcService
- * - OidcAuthStateCleanupService（定时清理过期授权状态）
- */
 @Module({
   imports: [
     TypeOrmModule.forFeature([OidcProvider, OidcAuthState, User]),
     AuthModule,
   ],
-  controllers: [OidcController],
-  providers: [OidcService, OidcAuthStateCleanupService],
+  controllers: [OidcController, OidcAdminController],
+  providers: [OidcService, OidcAdminService, OidcAuthStateCleanupService],
   exports: [OidcService],
 })
 export class OidcModule {}

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -1,0 +1,234 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import * as client from 'openid-client';
+import { OidcProvider } from '../entities/oidc-provider.entity';
+import { OidcService } from './oidc.service';
+import {
+  CreateOidcProviderDto,
+  UpdateOidcProviderDto,
+  OidcProviderQueryDto,
+} from '../dto/oidc-provider.dto';
+
+@Injectable()
+export class OidcAdminService {
+  private readonly logger = new Logger(OidcAdminService.name);
+
+  constructor(
+    @InjectRepository(OidcProvider)
+    private providerRepository: Repository<OidcProvider>,
+    private readonly oidcService: OidcService,
+  ) {}
+
+  async findAll(query: OidcProviderQueryDto) {
+    const { current, pageSize, name } = query;
+    const skip = (current - 1) * pageSize;
+
+    const queryBuilder = this.providerRepository
+      .createQueryBuilder('provider')
+      .orderBy('provider.priority', 'ASC')
+      .addOrderBy('provider.name', 'ASC')
+      .skip(skip)
+      .take(pageSize);
+
+    if (name) {
+      queryBuilder.andWhere('provider.name LIKE :name', {
+        name: `%${name}%`,
+      });
+    }
+
+    const [data, total] = await queryBuilder.getManyAndCount();
+    return { data, total };
+  }
+
+  async findOne(guid: string): Promise<OidcProvider> {
+    const provider = await this.providerRepository
+      .createQueryBuilder('provider')
+      .where('provider.guid = :guid', { guid })
+      .addSelect('provider.clientSecret')
+      .getOne();
+
+    if (!provider) {
+      throw new NotFoundException(`OIDC 提供商 "${guid}" 不存在`);
+    }
+
+    return provider;
+  }
+
+  async create(dto: CreateOidcProviderDto): Promise<OidcProvider> {
+    const existing = await this.providerRepository.findOne({
+      where: { name: dto.name },
+    });
+
+    if (existing) {
+      throw new BadRequestException(`OIDC 提供商名称 "${dto.name}" 已存在`);
+    }
+
+    const provider = new OidcProvider();
+    provider.guid = uuidv4();
+    provider.name = dto.name;
+    provider.issuer = dto.issuer;
+    provider.clientId = dto.clientId;
+    provider.clientSecret = (dto.clientSecret || null) as string;
+    provider.scope = dto.scope || 'openid email profile';
+    provider.authorizationEndpoint = (dto.authorizationEndpoint ||
+      null) as string;
+    provider.tokenEndpoint = (dto.tokenEndpoint || null) as string;
+    provider.userinfoEndpoint = (dto.userinfoEndpoint || null) as string;
+    provider.jwksUri = (dto.jwksUri || null) as string;
+    provider.enabled = dto.enabled !== undefined ? dto.enabled : true;
+    provider.priority = dto.priority || 0;
+
+    await this.providerRepository.save(provider);
+    this.logger.log(`OIDC 提供商创建成功: ${dto.name}`);
+    return provider;
+  }
+
+  async update(
+    guid: string,
+    dto: UpdateOidcProviderDto,
+  ): Promise<OidcProvider> {
+    const provider = await this.providerRepository.findOne({
+      where: { guid },
+    });
+
+    if (!provider) {
+      throw new NotFoundException(`OIDC 提供商 "${guid}" 不存在`);
+    }
+
+    if (dto.name && dto.name !== provider.name) {
+      const existing = await this.providerRepository.findOne({
+        where: { name: dto.name },
+      });
+      if (existing) {
+        throw new BadRequestException(`OIDC 提供商名称 "${dto.name}" 已存在`);
+      }
+    }
+
+    const oldIssuer = provider.issuer;
+
+    Object.assign(provider, {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.issuer !== undefined && { issuer: dto.issuer }),
+      ...(dto.clientId !== undefined && { clientId: dto.clientId }),
+      ...(dto.clientSecret !== undefined && { clientSecret: dto.clientSecret }),
+      ...(dto.scope !== undefined && { scope: dto.scope }),
+      ...(dto.authorizationEndpoint !== undefined && {
+        authorizationEndpoint: dto.authorizationEndpoint,
+      }),
+      ...(dto.tokenEndpoint !== undefined && {
+        tokenEndpoint: dto.tokenEndpoint,
+      }),
+      ...(dto.userinfoEndpoint !== undefined && {
+        userinfoEndpoint: dto.userinfoEndpoint,
+      }),
+      ...(dto.jwksUri !== undefined && { jwksUri: dto.jwksUri }),
+      ...(dto.enabled !== undefined && { enabled: dto.enabled }),
+      ...(dto.priority !== undefined && { priority: dto.priority }),
+    });
+
+    await this.providerRepository.save(provider);
+
+    if (dto.issuer !== undefined && dto.issuer !== oldIssuer) {
+      this.oidcService.clearConfigCache(oldIssuer);
+    }
+    this.oidcService.clearConfigCache(provider.issuer);
+
+    this.logger.log(`OIDC 提供商更新成功: ${provider.name}`);
+    return provider;
+  }
+
+  async remove(guid: string): Promise<void> {
+    const provider = await this.providerRepository.findOne({
+      where: { guid },
+    });
+
+    if (!provider) {
+      throw new NotFoundException(`OIDC 提供商 "${guid}" 不存在`);
+    }
+
+    this.oidcService.clearConfigCache(provider.issuer);
+    await this.providerRepository.remove(provider);
+    this.logger.log(`OIDC 提供商删除成功: ${provider.name}`);
+  }
+
+  async toggle(guid: string, enabled: boolean): Promise<OidcProvider> {
+    const provider = await this.providerRepository.findOne({
+      where: { guid },
+    });
+
+    if (!provider) {
+      throw new NotFoundException(`OIDC 提供商 "${guid}" 不存在`);
+    }
+
+    provider.enabled = enabled;
+    await this.providerRepository.save(provider);
+    this.logger.log(
+      `OIDC 提供商 ${provider.name} 已${enabled ? '启用' : '禁用'}`,
+    );
+    return provider;
+  }
+
+  async testConnection(guid: string): Promise<{
+    success: boolean;
+    message: string;
+    endpoints?: Record<string, string>;
+  }> {
+    const provider = await this.providerRepository
+      .createQueryBuilder('provider')
+      .where('provider.guid = :guid', { guid })
+      .addSelect('provider.clientSecret')
+      .getOne();
+
+    if (!provider) {
+      throw new NotFoundException(`OIDC 提供商 "${guid}" 不存在`);
+    }
+
+    try {
+      const config = await client.discovery(
+        new URL(provider.issuer),
+        provider.clientId,
+        provider.clientSecret || undefined,
+      );
+
+      const metadata = config.serverMetadata();
+      const endpoints: Record<string, string> = {};
+
+      if (metadata.authorization_endpoint) {
+        endpoints.authorization_endpoint = metadata.authorization_endpoint;
+      }
+      if (metadata.token_endpoint) {
+        endpoints.token_endpoint = metadata.token_endpoint;
+      }
+      if (metadata.userinfo_endpoint) {
+        endpoints.userinfo_endpoint = metadata.userinfo_endpoint;
+      }
+      if (metadata.jwks_uri) {
+        endpoints.jwks_uri = metadata.jwks_uri;
+      }
+
+      this.oidcService.clearConfigCache(provider.issuer);
+
+      return {
+        success: true,
+        message: `Discovery 验证成功，已发现 ${Object.keys(endpoints).length} 个端点`,
+        endpoints,
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `OIDC Discovery 测试失败 for ${provider.name}: ${message}`,
+      );
+      return {
+        success: false,
+        message: `Discovery 验证失败: ${message}`,
+      };
+    }
+  }
+}

--- a/src/modules/oidc/services/oidc-auth-state-cleanup.service.ts
+++ b/src/modules/oidc/services/oidc-auth-state-cleanup.service.ts
@@ -5,7 +5,7 @@ import { Repository, LessThan, In } from 'typeorm';
 import {
   OidcAuthState,
   OidcAuthStatus,
-} from './entities/oidc-auth-state.entity';
+} from '../entities/oidc-auth-state.entity';
 
 @Injectable()
 /**

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -9,15 +9,15 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as client from 'openid-client';
-import { OidcProvider } from './entities/oidc-provider.entity';
+import { OidcProvider } from '../entities/oidc-provider.entity';
 import {
   OidcAuthState,
   OidcAuthStatus,
-} from './entities/oidc-auth-state.entity';
-import { User, UserStatus } from '../user/entities/user.entity';
-import { OidcAuthRequestDto } from './dto/oidc.dto';
-import { LoginResponse } from '../../common/interfaces';
-import { AuthTokenService } from '../auth/services/auth-token.service';
+} from '../entities/oidc-auth-state.entity';
+import { User, UserStatus } from '../../user/entities/user.entity';
+import { OidcAuthRequestDto } from '../dto/oidc.dto';
+import { LoginResponse } from '../../../common/interfaces';
+import { AuthTokenService } from '../../auth/services/auth-token.service';
 
 /**
  * OIDC配置接口
@@ -428,6 +428,20 @@ export class OidcService {
         third_auth_type: user.thirdAuthType || undefined,
       },
     };
+  }
+
+  /**
+   * 清除指定issuer的OIDC配置缓存
+   * 当管理员修改提供商配置时调用
+   */
+  clearConfigCache(issuer?: string): void {
+    if (issuer) {
+      this.configCache.delete(issuer);
+      this.configCacheTimestamp.delete(issuer);
+    } else {
+      this.configCache.clear();
+      this.configCacheTimestamp.clear();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Add RESTful admin CRUD API for managing OIDC providers, enabling the admin panel to configure OIDC login options.

## New Endpoints

All endpoints require admin authentication (`AdminGuard`).

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/oidc-providers` | List providers (paginated, with name search) |
| `GET` | `/api/oidc-providers/:guid` | Get provider details (including clientSecret) |
| `POST` | `/api/oidc-providers` | Create a new provider |
| `PATCH` | `/api/oidc-providers/:guid` | Update provider config |
| `DELETE` | `/api/oidc-providers/:guid` | Delete provider |
| `PATCH` | `/api/oidc-providers/:guid/toggle` | Enable/disable provider |
| `POST` | `/api/oidc-providers/:guid/test` | Test provider connection (OIDC Discovery) |

## Module Restructure

Reorganized OIDC module file structure for clarity:

```
src/modules/oidc/
├── controllers/
│   ├── oidc.controller.ts          # Client login endpoints (@Public)
│   └── oidc-admin.controller.ts    # Admin management endpoints (@UseGuards(AdminGuard))
├── services/
│   ├── oidc.service.ts             # Client login logic
│   ├── oidc-admin.service.ts       # Admin CRUD logic
│   └── oidc-auth-state-cleanup.service.ts
├── dto/
│   ├── oidc.dto.ts                 # Client DTOs
│   └── oidc-provider.dto.ts        # Admin CRUD DTOs
├── entities/
└── oidc.module.ts
```

## Key Features

- **Cache invalidation**: Provider create/update/delete automatically clears OIDC config cache
- **Connection testing**: Test endpoint validates OIDC Discovery and returns discovered endpoints
- **Quick toggle**: Enable/disable providers without full update
- **Pagination**: List endpoint supports `current`/`pageSize` pagination with name search
- **Security**: clientSecret excluded from list endpoint, only shown in detail endpoint

## Testing

- Build successful ✅
- Lint passed ✅
