### PR TITLE
fix(oidc): support OAuth2 providers like GitHub that don't return ID tokens

### DIFF
--- a/src/modules/oidc/oidc.service.ts
+++ b/src/modules/oidc/oidc.service.ts
@@ -260,38 +260,48 @@ export class OidcService {
     }
 
     try {
-      // 获取OIDC配置
       const oidcConfig = await this.getOidcConfig(provider);
 
-      // 使用openid-client交换授权码获取令牌
-      // 该方法会自动验证ID Token的签名、nonce、audience等
       const tokens = await client.authorizationCodeGrant(
         oidcConfig,
         new URL(callbackUrl),
         {
           pkceCodeVerifier: authState.codeVerifier,
           expectedState: authState.state,
-          expectedNonce: authState.nonce,
         },
       );
 
-      // 从ID Token中获取用户声明
       const claims = tokens.claims();
-      let userInfo: OidcUserInfo = {
-        sub: claims?.sub ?? '',
-        email: claims?.email as string | undefined,
-        email_verified: claims?.email_verified as boolean | undefined,
-        name: claims?.name as string | undefined,
-        preferred_username: claims?.preferred_username as string | undefined,
-      };
+      let userInfo: OidcUserInfo;
 
-      // 如果ID Token中没有足够的用户信息，尝试从userinfo端点获取
-      if (!userInfo.email && oidcConfig.serverMetadata().userinfo_endpoint) {
+      if (claims) {
+        if (authState.nonce && claims.nonce !== authState.nonce) {
+          throw new UnauthorizedException('OIDC nonce 验证失败');
+        }
+        userInfo = {
+          sub: claims.sub ?? '',
+          email: claims.email as string | undefined,
+          email_verified: claims.email_verified as boolean | undefined,
+          name: claims.name as string | undefined,
+          preferred_username: claims.preferred_username as string | undefined,
+        };
+      } else {
+        userInfo = await this.fetchOAuth2UserInfo(
+          provider,
+          tokens.access_token,
+        );
+      }
+
+      if (
+        !userInfo.email &&
+        claims &&
+        oidcConfig.serverMetadata().userinfo_endpoint
+      ) {
         try {
           const fetchedUserInfo = await client.fetchUserInfo(
             oidcConfig,
             tokens.access_token,
-            claims?.sub ?? '',
+            claims.sub ?? '',
           );
           userInfo = {
             ...userInfo,
@@ -302,7 +312,7 @@ export class OidcService {
           };
         } catch (err: unknown) {
           this.logger.warn(
-            `Failed to fetch userinfo: ${err instanceof Error ? err.message : String(err)}`,
+            `Failed to fetch OIDC userinfo: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       }
@@ -602,6 +612,57 @@ export class OidcService {
     throw new Error(
       `Failed to create OIDC user after ${maxRetries} attempts due to username conflicts`,
     );
+  }
+
+  private async fetchOAuth2UserInfo(
+    provider: OidcProvider,
+    accessToken: string,
+  ): Promise<OidcUserInfo> {
+    const userinfoEndpoint = provider.userinfoEndpoint;
+    if (!userinfoEndpoint) {
+      throw new BadRequestException(
+        'OAuth2 提供商未配置用户信息端点，无法获取用户信息',
+      );
+    }
+
+    try {
+      const response = await fetch(userinfoEndpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+          'User-Agent': 'rustdesk-console',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `UserInfo request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const data = (await response.json()) as Record<string, unknown>;
+
+      return {
+        sub: String(
+          (data.id as string | number) ??
+            (data.sub as string) ??
+            (data.login as string) ??
+            '',
+        ),
+        email: data.email as string | undefined,
+        email_verified:
+          (data.email_verified as boolean | undefined) ?? !!data.email,
+        name: (data.name as string) ?? data.login,
+        preferred_username:
+          (data.login as string) ??
+          (data.username as string) ??
+          (data.name as string),
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`OAuth2 userinfo fetch error: ${message}`);
+      throw new UnauthorizedException('获取用户信息失败');
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

OIDC callback authentication fails when using OAuth2-only providers like GitHub. The callback page shows "认证失败" after GitHub redirects back with the authorization code.

## Root Cause

The `handleCallback` method assumed all providers are OIDC-compliant and return ID tokens. GitHub is an **OAuth2 provider**, not OIDC — it does not return ID tokens.

Specific issues:
1. `expectedNonce` in `authorizationCodeGrant` **requires** an ID token in the response — GitHub doesn't return one, causing the library to throw an error
2. `tokens.claims()` returns `undefined` when no ID token is present, causing `sub` to be empty
3. `fetchUserInfo` requires a `sub` claim from the ID token, which doesn't exist for OAuth2 providers
4. GitHub's userinfo endpoint (`api.github.com/user`) is not OIDC-compliant — it returns `{id, login, email, ...}` instead of `{sub, preferred_username, ...}`

## Fix

- Remove `expectedNonce` from `authorizationCodeGrant` checks — let the library work without requiring an ID token
- Manually validate nonce only when ID token claims are present (OIDC providers)
- Add `fetchOAuth2UserInfo` method for OAuth2 providers that don't return ID tokens
- Directly call the userinfo endpoint with Bearer token for OAuth2 providers
- Map provider-specific response fields to OIDC format:
  - GitHub: `id` → `sub`, `login` → `preferred_username`

## Configuration Note

For GitHub OAuth2, make sure the provider is configured with:
- `issuer`: `https://github.com` (or any URL, since discovery will fail anyway)
- `authorization_endpoint`: `https://github.com/login/oauth/authorize`
- `token_endpoint`: `https://github.com/login/oauth/access_token`
- `userinfo_endpoint`: `https://api.github.com/user`
- `scope`: `read:user user:email`

## Testing

- Build successful ✅
- Lint passed ✅
