### PR TITLE
feat(oidc): add dual protocol support for OIDC and OAuth2 providers

### DIFF
--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -208,13 +208,13 @@ export class AddressBookLegacyService {
     // 创建新标签
     const tagNameToGuid: Record<string, string> = {};
     const dangerousProperties = ['__proto__', 'constructor', 'prototype'];
-    
+
     if (parsedData.tags && parsedData.tags.length > 0) {
       for (const tagName of parsedData.tags) {
         if (dangerousProperties.includes(tagName)) {
           continue;
         }
-        
+
         const tagGuid = uuidv4();
         const tag = this.addressBookTagRepository.create({
           guid: tagGuid,

--- a/src/modules/address-book/services/address-book-rule.service.ts
+++ b/src/modules/address-book/services/address-book-rule.service.ts
@@ -141,7 +141,7 @@ export class AddressBookRuleService {
     }
 
     const existingRule = await this.ruleRepository.findOne({
-      where: whereClause as Partial<AddressBookRule>,
+      where: whereClause,
     });
 
     if (existingRule) {

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -382,7 +382,8 @@ export class DeviceGroupController {
     }
 
     // 验证请求断开的连接ID是否为该设备的活跃连接
-    const activeConnIds = await this.heartbeatService.getActiveConnectionIds(uuid);
+    const activeConnIds =
+      await this.heartbeatService.getActiveConnectionIds(uuid);
     const activeConnIdSet = new Set(activeConnIds);
     const invalidConnIds = dto.connIds.filter((id) => !activeConnIdSet.has(id));
     if (invalidConnIds.length > 0) {

--- a/src/modules/heartbeat/dto/heartbeat.dto.ts
+++ b/src/modules/heartbeat/dto/heartbeat.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsNumber, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+} from 'class-validator';
 
 /**
  * HeartbeatDto

--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -92,7 +92,7 @@ export class OidcController {
    * @param deviceUuid 设备UUID
    */
   @Public()
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Throttle({ default: { limit: 120, ttl: 60000 } })
   @Get('oidc/auth-query')
   async queryAuth(
     @Query('code') code: string,

--- a/src/modules/oidc/dto/oidc-provider.dto.ts
+++ b/src/modules/oidc/dto/oidc-provider.dto.ts
@@ -7,10 +7,16 @@ import {
   IsInt,
   Min,
   IsUrl,
+  IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { OidcProviderType } from '../entities/oidc-provider.entity';
 
 export class CreateOidcProviderDto {
+  @IsEnum(OidcProviderType)
+  @IsOptional()
+  type?: OidcProviderType;
+
   @IsString()
   @IsNotEmpty()
   name: string;
@@ -62,6 +68,10 @@ export class CreateOidcProviderDto {
 }
 
 export class UpdateOidcProviderDto {
+  @IsEnum(OidcProviderType)
+  @IsOptional()
+  type?: OidcProviderType;
+
   @IsString()
   @IsNotEmpty()
   @IsOptional()

--- a/src/modules/oidc/entities/oidc-auth-state.entity.ts
+++ b/src/modules/oidc/entities/oidc-auth-state.entity.ts
@@ -22,6 +22,8 @@ export enum OidcAuthStatus {
  * OIDC 授权状态实体
  * 管理 OIDC 授权流程的临时状态
  */
+import { OidcProviderType } from './oidc-provider.entity';
+
 @Entity('oidc_auth_states')
 export class OidcAuthState {
   /**
@@ -46,6 +48,12 @@ export class OidcAuthState {
   @Column()
   @Index()
   op: string;
+
+  @Column({
+    type: 'text',
+    default: OidcProviderType.OIDC,
+  })
+  providerType: OidcProviderType;
 
   /**
    * 设备ID
@@ -121,7 +129,7 @@ export class OidcAuthState {
    * 用于防止重放攻击，验证 ID Token 的合法性
    */
   @Column({ type: 'text', nullable: true })
-  nonce: string;
+  nonce: string | null;
 
   /**
    * 过期时间

--- a/src/modules/oidc/entities/oidc-provider.entity.ts
+++ b/src/modules/oidc/entities/oidc-provider.entity.ts
@@ -11,6 +11,11 @@ import {
  * OIDC 提供商实体
  * 管理 OpenID Connect 身份提供商配置
  */
+export enum OidcProviderType {
+  OIDC = 'oidc',
+  OAUTH2 = 'oauth2',
+}
+
 @Entity('oidc_providers')
 export class OidcProvider {
   /**
@@ -27,6 +32,12 @@ export class OidcProvider {
   @Column()
   @Index()
   name: string;
+
+  @Column({
+    type: 'text',
+    default: OidcProviderType.OIDC,
+  })
+  type: OidcProviderType;
 
   /**
    * 发行者 URL

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -8,7 +8,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as client from 'openid-client';
-import { OidcProvider } from '../entities/oidc-provider.entity';
+import {
+  OidcProvider,
+  OidcProviderType,
+} from '../entities/oidc-provider.entity';
 import { OidcService } from './oidc.service';
 import {
   CreateOidcProviderDto,
@@ -72,11 +75,16 @@ export class OidcAdminService {
 
     const provider = new OidcProvider();
     provider.guid = uuidv4();
+    provider.type = dto.type || OidcProviderType.OIDC;
     provider.name = dto.name;
     provider.issuer = dto.issuer;
     provider.clientId = dto.clientId;
     provider.clientSecret = (dto.clientSecret || null) as string;
-    provider.scope = dto.scope || 'openid email profile';
+    provider.scope =
+      dto.scope ||
+      (provider.type === OidcProviderType.OAUTH2
+        ? 'read:user user:email'
+        : 'openid email profile');
     provider.authorizationEndpoint = (dto.authorizationEndpoint ||
       null) as string;
     provider.tokenEndpoint = (dto.tokenEndpoint || null) as string;
@@ -114,6 +122,7 @@ export class OidcAdminService {
     const oldIssuer = provider.issuer;
 
     Object.assign(provider, {
+      ...(dto.type !== undefined && { type: dto.type }),
       ...(dto.name !== undefined && { name: dto.name }),
       ...(dto.issuer !== undefined && { issuer: dto.issuer }),
       ...(dto.clientId !== undefined && { clientId: dto.clientId }),

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -525,7 +525,7 @@ export class OidcService {
     });
 
     if (!user) {
-      throw new UnauthorizedException('User not found');
+      throw new UnauthorizedException({ error: 'User not found' });
     }
 
     // 清理授权状态

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -117,9 +117,7 @@ export class OidcService {
     const options: string[] = [];
 
     for (const provider of providers) {
-      const prefix =
-        provider.type === OidcProviderType.OAUTH2 ? 'oauth2' : 'oidc';
-      options.push(`${prefix}/${provider.name}`);
+      options.push(`oidc/${provider.name}`);
     }
 
     return options;

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -270,7 +270,7 @@ export class OidcService {
 
     try {
       const oidcConfig = await this.getOidcConfig(provider);
-      const isOidc = authState.providerType === OidcProviderType.OIDC;
+      const isOidc = provider.type === OidcProviderType.OIDC;
 
       let userInfo: OidcUserInfo;
 

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -493,22 +493,22 @@ export class OidcService {
       });
 
       if (!authState || authState.status === OidcAuthStatus.PENDING) {
-        throw new UnauthorizedException('No authed oidc is found');
+        throw new UnauthorizedException({ error: 'No authed oidc is found' });
       }
 
       if (authState.status === OidcAuthStatus.EXPIRED) {
-        throw new UnauthorizedException('Authorization expired');
+        throw new UnauthorizedException({ error: 'Authorization expired' });
       }
 
       if (authState.status === OidcAuthStatus.CANCELLED) {
-        throw new UnauthorizedException('Authorization cancelled');
+        throw new UnauthorizedException({ error: 'Authorization cancelled' });
       }
 
       if (authState.status === OidcAuthStatus.CONSUMED) {
-        throw new UnauthorizedException('Authorization already consumed');
+        throw new UnauthorizedException({ error: 'Authorization already consumed' });
       }
 
-      throw new UnauthorizedException('No authed oidc is found');
+      throw new UnauthorizedException({ error: 'No authed oidc is found' });
     }
 
     // 查询已标记为CONSUMED的记录
@@ -517,7 +517,7 @@ export class OidcService {
     });
 
     if (!authState || !authState.accessToken) {
-      throw new UnauthorizedException('No authed oidc is found');
+      throw new UnauthorizedException({ error: 'No authed oidc is found' });
     }
 
     const user = await this.userRepository.findOne({

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -9,7 +9,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as client from 'openid-client';
-import { OidcProvider } from '../entities/oidc-provider.entity';
+import {
+  OidcProvider,
+  OidcProviderType,
+} from '../entities/oidc-provider.entity';
 import {
   OidcAuthState,
   OidcAuthStatus,
@@ -114,7 +117,9 @@ export class OidcService {
     const options: string[] = [];
 
     for (const provider of providers) {
-      options.push(`oidc/${provider.name}`);
+      const prefix =
+        provider.type === OidcProviderType.OAUTH2 ? 'oauth2' : 'oidc';
+      options.push(`${prefix}/${provider.name}`);
     }
 
     return options;
@@ -133,7 +138,7 @@ export class OidcService {
   ): Promise<OidcAuthUrlResponse> {
     const { op, id, uuid, deviceInfo } = authRequest;
 
-    const providerName = op.replace('oidc/', '');
+    const providerName = op.replace(/^(oidc|oauth2)\//, '');
 
     // 使用getProviderWithSecret获取包含clientSecret的完整配置
     // 确保缓存的OIDC配置包含clientSecret，避免handleCallback获取到不完整的缓存
@@ -154,7 +159,8 @@ export class OidcService {
 
     // 生成OIDC state和nonce参数
     const state = client.randomState();
-    const nonce = client.randomNonce();
+    const isOidc = provider.type === OidcProviderType.OIDC;
+    const nonce = isOidc ? client.randomNonce() : undefined;
 
     // 计算过期时间
     const expiresAt = new Date();
@@ -170,12 +176,13 @@ export class OidcService {
       guid: uuidv4(),
       code,
       op,
+      providerType: provider.type,
       deviceId: id,
       deviceUuid: uuid,
       deviceInfo: JSON.stringify(deviceInfo),
       redirectUri,
       state,
-      nonce,
+      nonce: nonce ?? null,
       codeVerifier,
       status: OidcAuthStatus.PENDING,
       expiresAt,
@@ -185,7 +192,11 @@ export class OidcService {
 
     // 获取OIDC配置并构建授权URL
     const oidcConfig = await this.getOidcConfig(provider);
-    const scope = provider.scope || 'openid email profile';
+    const defaultScope =
+      provider.type === OidcProviderType.OAUTH2
+        ? 'read:user user:email'
+        : 'openid email profile';
+    const scope = provider.scope || defaultScope;
 
     const url = client.buildAuthorizationUrl(oidcConfig, {
       redirect_uri: redirectUri,
@@ -194,7 +205,7 @@ export class OidcService {
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       state,
-      nonce,
+      ...(nonce && { nonce }),
     });
 
     this.logger.log(`OIDC auth requested: code=${code}, op=${op}`);
@@ -252,7 +263,7 @@ export class OidcService {
     }
 
     // 获取OIDC提供商配置（包含clientSecret）
-    const providerName = authState.op.replace('oidc/', '');
+    const providerName = authState.op.replace(/^(oidc|oauth2)\//, '');
     const provider = await this.getProviderWithSecret(providerName);
 
     if (!provider) {
@@ -260,51 +271,23 @@ export class OidcService {
     }
 
     try {
-      // 获取OIDC配置
       const oidcConfig = await this.getOidcConfig(provider);
+      const isOidc = authState.providerType === OidcProviderType.OIDC;
 
-      // 使用openid-client交换授权码获取令牌
-      // 该方法会自动验证ID Token的签名、nonce、audience等
-      const tokens = await client.authorizationCodeGrant(
-        oidcConfig,
-        new URL(callbackUrl),
-        {
-          pkceCodeVerifier: authState.codeVerifier,
-          expectedState: authState.state,
-          expectedNonce: authState.nonce,
-        },
-      );
+      let userInfo: OidcUserInfo;
 
-      // 从ID Token中获取用户声明
-      const claims = tokens.claims();
-      let userInfo: OidcUserInfo = {
-        sub: claims?.sub ?? '',
-        email: claims?.email as string | undefined,
-        email_verified: claims?.email_verified as boolean | undefined,
-        name: claims?.name as string | undefined,
-        preferred_username: claims?.preferred_username as string | undefined,
-      };
-
-      // 如果ID Token中没有足够的用户信息，尝试从userinfo端点获取
-      if (!userInfo.email && oidcConfig.serverMetadata().userinfo_endpoint) {
-        try {
-          const fetchedUserInfo = await client.fetchUserInfo(
-            oidcConfig,
-            tokens.access_token,
-            claims?.sub ?? '',
-          );
-          userInfo = {
-            ...userInfo,
-            email: fetchedUserInfo.email,
-            email_verified: fetchedUserInfo.email_verified,
-            name: fetchedUserInfo.name,
-            preferred_username: fetchedUserInfo.preferred_username,
-          };
-        } catch (err: unknown) {
-          this.logger.warn(
-            `Failed to fetch userinfo: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+      if (isOidc) {
+        userInfo = await this.handleOidcCallback(
+          oidcConfig,
+          callbackUrl,
+          authState,
+        );
+      } else {
+        userInfo = await this.handleOAuth2Callback(
+          oidcConfig,
+          callbackUrl,
+          authState,
+        );
       }
 
       // 查找或创建本地用户
@@ -335,6 +318,141 @@ export class OidcService {
       this.logger.error(`OIDC callback error: ${message}`, stack);
       // 不向客户端暴露内部错误详情
       throw new UnauthorizedException('OIDC 认证失败，请重试');
+    }
+  }
+
+  private async handleOidcCallback(
+    oidcConfig: client.Configuration,
+    callbackUrl: string,
+    authState: OidcAuthState,
+  ): Promise<OidcUserInfo> {
+    const tokens = await client.authorizationCodeGrant(
+      oidcConfig,
+      new URL(callbackUrl),
+      {
+        pkceCodeVerifier: authState.codeVerifier,
+        expectedState: authState.state,
+        expectedNonce: authState.nonce ?? undefined,
+      },
+    );
+
+    const claims = tokens.claims();
+    let userInfo: OidcUserInfo = {
+      sub: claims?.sub ?? '',
+      email: claims?.email as string | undefined,
+      email_verified: claims?.email_verified as boolean | undefined,
+      name: claims?.name as string | undefined,
+      preferred_username: claims?.preferred_username as string | undefined,
+    };
+
+    if (!userInfo.email && oidcConfig.serverMetadata().userinfo_endpoint) {
+      try {
+        const fetchedUserInfo = await client.fetchUserInfo(
+          oidcConfig,
+          tokens.access_token,
+          claims?.sub ?? '',
+        );
+        userInfo = {
+          ...userInfo,
+          email: fetchedUserInfo.email,
+          email_verified: fetchedUserInfo.email_verified,
+          name: fetchedUserInfo.name,
+          preferred_username: fetchedUserInfo.preferred_username,
+        };
+      } catch (err: unknown) {
+        this.logger.warn(
+          `Failed to fetch OIDC userinfo: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return userInfo;
+  }
+
+  private async handleOAuth2Callback(
+    oidcConfig: client.Configuration,
+    callbackUrl: string,
+    authState: OidcAuthState,
+  ): Promise<OidcUserInfo> {
+    const tokens = await client.authorizationCodeGrant(
+      oidcConfig,
+      new URL(callbackUrl),
+      {
+        pkceCodeVerifier: authState.codeVerifier,
+        expectedState: authState.state,
+        idTokenExpected: false,
+      },
+    );
+
+    const accessToken = tokens.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedException(
+        'OAuth2 令牌交换失败：未获取到 access_token',
+      );
+    }
+
+    const providerName = authState.op.replace(/^(oidc|oauth2)\//, '');
+    const provider = await this.getProviderWithSecret(providerName);
+
+    if (!provider) {
+      throw new BadRequestException(`OAuth2 提供商 "${providerName}" 不存在`);
+    }
+
+    return this.fetchOAuth2UserInfo(accessToken, provider);
+  }
+
+  private async fetchOAuth2UserInfo(
+    accessToken: string,
+    provider: OidcProvider,
+  ): Promise<OidcUserInfo> {
+    const userinfoEndpoint = provider.userinfoEndpoint;
+
+    if (!userinfoEndpoint) {
+      throw new BadRequestException(
+        'OAuth2 提供商未配置用户信息端点，无法获取用户信息',
+      );
+    }
+
+    try {
+      const response = await fetch(userinfoEndpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+          'User-Agent': 'rustdesk-console',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `UserInfo request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const data = (await response.json()) as Record<string, unknown>;
+
+      return {
+        sub: String(
+          (data.id as string | number | undefined) ??
+            (data.sub as string | undefined) ??
+            (data.login as string | undefined) ??
+            '',
+        ),
+        email: data.email as string | undefined,
+        email_verified:
+          (data.email_verified as boolean | undefined) ?? !!data.email,
+        name:
+          (data.name as string | undefined) ??
+          (data.login as string | undefined),
+        preferred_username:
+          (data.login as string | undefined) ??
+          (data.username as string | undefined) ??
+          (data.name as string | undefined),
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`OAuth2 userinfo fetch error: ${message}`);
+      throw new UnauthorizedException('获取用户信息失败');
     }
   }
 
@@ -468,7 +586,10 @@ export class OidcService {
     }
 
     try {
-      // 尝试OIDC Discovery
+      if (provider.type === OidcProviderType.OAUTH2) {
+        throw new Error('OAuth2 provider, skipping OIDC discovery');
+      }
+
       const config = await client.discovery(
         new URL(provider.issuer),
         provider.clientId,


### PR DESCRIPTION
## Summary

Add dual protocol support for OIDC and OAuth2 providers with explicit type field, ensuring each protocol follows its own security best practices.

## Problem

The previous implementation treated all providers as OIDC, causing:
1. GitHub (OAuth2) login failed because `expectedNonce` requires ID Token which OAuth2 providers don't return
2. Removing `expectedNonce` for compatibility weakened OIDC security (no nonce replay protection)

## Solution: Explicit Provider Type

Add `type` field (`oidc` | `oauth2`) to `OidcProvider` entity, routing each provider through its own secure flow.

### OIDC Flow (Best Practices)
```
requestAuth:  state + nonce + PKCE
callback:     authorizationCodeGrant(expectedNonce) → ID Token validation → nonce check → signature verification → audience check
```
Security: **state (CSRF) + PKCE + nonce (replay) + ID Token signature + audience verification**

### OAuth2 Flow (Best Practices)
```
requestAuth:  state + PKCE (no nonce - not applicable)
callback:     authorizationCodeGrant(idTokenExpected=false) → access_token → fetch userinfo via Bearer token
```
Security: **state (CSRF) + PKCE + access_token userinfo verification**

## Changes

### Entity Changes
- `OidcProvider`: Add `type` column (`oidc` | `oauth2`, default `oidc`)
- `OidcAuthState`: Add `providerType` column, change `nonce` to `string | null`

### Service Changes
- `requestAuth()`: Generate nonce only for OIDC providers; set default scope per type
- `handleCallback()`: Route to `handleOidcCallback()` or `handleOAuth2Callback()`
- `handleOidcCallback()`: Full ID Token validation with `expectedNonce`
- `handleOAuth2Callback()`: `idTokenExpected=false`, fetch userinfo via Bearer token
- `getOidcConfig()`: Skip Discovery for OAuth2 providers (use manual endpoints)
- `getLoginOptions()`: Return `oidc/{name}` or `oauth2/{name}` prefix

### DTO Changes
- `CreateOidcProviderDto`: Add `type` field (optional, default `oidc`)
- `UpdateOidcProviderDto`: Add `type` field (optional)

## GitHub OAuth2 Configuration Example

| Field | Value |
|-------|-------|
| type | `oauth2` |
| name | `github` |
| issuer | `https://github.com` |
| clientId | `Ov23li...` |
| clientSecret | `...` |
| authorizationEndpoint | `https://github.com/login/oauth/authorize` |
| tokenEndpoint | `https://github.com/login/oauth/access_token` |
| userinfoEndpoint | `https://api.github.com/user` |
| scope | `read:user user:email` |

## Testing

- Build successful ✅
- Lint passed ✅
