### PR TITLE
fix(build): correct OIDC templates path and add to build assets

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "assets": ["modules/email/templates/**/*"],
+    "assets": ["modules/email/templates/**/*", "modules/oidc/templates/**/*"],
     "watchAssets": true
   }
 }

--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -50,11 +50,11 @@ export class OidcController {
     private readonly configService: ConfigService,
   ) {
     this.successHtml = fs.readFileSync(
-      path.join(__dirname, 'templates', 'callback-success.html'),
+      path.join(__dirname, '..', 'templates', 'callback-success.html'),
       'utf-8',
     );
     this.errorHtml = fs.readFileSync(
-      path.join(__dirname, 'templates', 'callback-error.html'),
+      path.join(__dirname, '..', 'templates', 'callback-error.html'),
       'utf-8',
     );
   }


### PR DESCRIPTION
## Problem

OIDC callback templates were not being copied during build, causing runtime errors when the controller tried to read the HTML files.

Two issues:
1. `nest-cli.json` only included `modules/email/templates` in assets, missing OIDC templates
2. Controller path was wrong: `__dirname/templates` expected templates in `controllers/templates` but they are in `templates/` (parent directory)

## Solution

1. Add `modules/oidc/templates/**/*` to `nest-cli.json` assets
2. Fix controller path: `__dirname/../templates` to correctly navigate from `controllers/` to `templates/`

## Verification

Build successful and templates copied to `dist/modules/oidc/templates/` ✅