### PR TITLE
fix(oidc): make id, uuid and deviceInfo optional for web frontend login

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -61,6 +61,6 @@ import { EmailModule } from '../email/email.module';
     TokenCleanupService,
     JwtStrategy,
   ],
-  exports: [AuthService, AuthTokenService, JwtModule],
+  exports: [AuthService, AuthTokenService, AuthDeviceService, JwtModule],
 })
 export class AuthModule {}

--- a/src/modules/oidc/dto/oidc.dto.ts
+++ b/src/modules/oidc/dto/oidc.dto.ts
@@ -22,15 +22,18 @@ export class OidcAuthRequestDto {
   @IsString()
   op: string; // OIDC 提供商标识，如 oidc/google
 
+  @IsOptional()
   @IsString()
-  id: string; // 设备ID
+  id?: string; // 设备ID（客户端登录必填，Web前端登录可选）
 
+  @IsOptional()
   @IsString()
-  uuid: string; // 设备UUID
+  uuid?: string; // 设备UUID（客户端登录必填，Web前端登录可选）
 
+  @IsOptional()
   @ValidateNested()
   @Type(() => DeviceInfoDto)
-  deviceInfo: DeviceInfoDto; // 设备信息
+  deviceInfo?: DeviceInfoDto; // 设备信息（可选）
 
   @IsOptional()
   @IsUrl({

--- a/src/modules/oidc/dto/oidc.dto.ts
+++ b/src/modules/oidc/dto/oidc.dto.ts
@@ -24,16 +24,15 @@ export class OidcAuthRequestDto {
 
   @IsOptional()
   @IsString()
-  id?: string; // 设备ID（客户端登录必填，Web前端登录可选）
+  id?: string; // 设备ID（客户端特有字段）
 
   @IsOptional()
   @IsString()
-  uuid?: string; // 设备UUID（客户端登录必填，Web前端登录可选）
+  uuid?: string; // 设备UUID（客户端特有字段）
 
-  @IsOptional()
   @ValidateNested()
   @Type(() => DeviceInfoDto)
-  deviceInfo?: DeviceInfoDto; // 设备信息（可选）
+  deviceInfo: DeviceInfoDto; // 设备信息（必填）
 
   @IsOptional()
   @IsUrl({

--- a/src/modules/oidc/entities/oidc-auth-state.entity.ts
+++ b/src/modules/oidc/entities/oidc-auth-state.entity.ts
@@ -57,16 +57,16 @@ export class OidcAuthState {
 
   /**
    * 设备ID
-   * RustDesk 客户端的设备标识
+   * RustDesk 客户端的设备标识（客户端特有字段）
    */
-  @Column()
+  @Column({ nullable: true })
   deviceId: string;
 
   /**
    * 设备UUID
-   * 设备的唯一标识符
+   * 设备的唯一标识符（客户端特有字段）
    */
-  @Column()
+  @Column({ nullable: true })
   deviceUuid: string;
 
   /**

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -21,6 +21,7 @@ import { User, UserStatus } from '../../user/entities/user.entity';
 import { OidcAuthRequestDto } from '../dto/oidc.dto';
 import { LoginResponse } from '../../../common/interfaces';
 import { AuthTokenService } from '../../auth/services/auth-token.service';
+import { AuthDeviceService } from '../../auth/services/auth-device.service';
 
 /**
  * OIDC配置接口
@@ -118,6 +119,7 @@ export class OidcService {
     @InjectRepository(User)
     private userRepository: Repository<User>,
     private authTokenService: AuthTokenService,
+    private deviceService: AuthDeviceService,
     private configService: ConfigService,
   ) {}
 
@@ -215,11 +217,6 @@ export class OidcService {
         );
       }
       frontendRedirectUrl = callbackUrl;
-    } else {
-      // 客户端登录必须提供 id 和 uuid
-      if (!id || !uuid) {
-        throw new BadRequestException('客户端登录必须提供 id 和 uuid 参数');
-      }
     }
 
     // 生成授权码（用于客户端轮询）
@@ -249,12 +246,12 @@ export class OidcService {
       code,
       op,
       providerType: provider.type,
-      deviceId: id || 'web',
-      deviceUuid: uuid || 'web',
-      deviceInfo: deviceInfo ? JSON.stringify(deviceInfo) : undefined,
+      deviceId: id ?? undefined,
+      deviceUuid: uuid ?? undefined,
+      deviceInfo: JSON.stringify(deviceInfo),
       redirectUri,
       state,
-      nonce: nonce ?? null,
+      nonce: nonce ?? undefined,
       codeVerifier,
       frontendRedirectUrl,
       status: OidcAuthStatus.PENDING,
@@ -366,6 +363,18 @@ export class OidcService {
 
       // 查找或创建本地用户
       const user = await this.findOrCreateUser(userInfo, providerName);
+
+      // 创建或更新设备记录（参考 auth.service.ts 实现）
+      if (authState.deviceId || authState.deviceUuid) {
+        await this.deviceService.createOrUpdateDevice(
+          user.guid,
+          authState.deviceId,
+          authState.deviceUuid,
+          authState.deviceInfo
+            ? (JSON.parse(authState.deviceInfo) as Record<string, unknown>)
+            : undefined,
+        );
+      }
 
       // 生成JWT Token
       const accessToken = await this.generateTokenForUser(

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -215,6 +215,11 @@ export class OidcService {
         );
       }
       frontendRedirectUrl = callbackUrl;
+    } else {
+      // 客户端登录必须提供 id 和 uuid
+      if (!id || !uuid) {
+        throw new BadRequestException('客户端登录必须提供 id 和 uuid 参数');
+      }
     }
 
     // 生成授权码（用于客户端轮询）
@@ -244,9 +249,9 @@ export class OidcService {
       code,
       op,
       providerType: provider.type,
-      deviceId: id,
-      deviceUuid: uuid,
-      deviceInfo: JSON.stringify(deviceInfo),
+      deviceId: id || 'web',
+      deviceUuid: uuid || 'web',
+      deviceInfo: deviceInfo ? JSON.stringify(deviceInfo) : undefined,
       redirectUri,
       state,
       nonce: nonce ?? null,


### PR DESCRIPTION
## Summary

This PR makes uid=1000(yuzhiyuan) gid=1000(yuzhiyuan) groups=1000(yuzhiyuan),65534(nogroup) and  fields optional in the OIDC auth request to support web frontend login, and adds device binding logic after OIDC login.

### Changes

1. **Modify OidcAuthRequestDto**
   - Keep  as required field (both client and web frontend send it)
   - Make uid=1000(yuzhiyuan) gid=1000(yuzhiyuan) groups=1000(yuzhiyuan),65534(nogroup) and  optional (client-specific fields)

2. **Modify OidcAuthState entity**
   - Make  and  nullable columns

3. **Update oidc.service.ts**
   - Do not fill default values, use undefined for optional fields
   - Add device binding logic after OIDC login (reference: auth.service.ts)
   - Add AuthDeviceService injection for device management
   - Device binding only performed when id or uuid is provided

### Use Cases

| Login Type | id | uuid | deviceInfo | callbackUrl | Device Binding |
|------------|----|----|------------|-------------|----------------|
| Client | Provided | Provided | Required | Not provided | Yes |
| Web Frontend | Optional | Optional | Required | Required | No (unless provided) |

### Reference

The device binding logic follows auth.service.ts implementation:
- Only create/update device when id or uuid is provided
- Call deviceService.createOrUpdateDevice after user creation

### Example Request

**Web Frontend Login:**
```json
{
  "op": "oidc/google",
  "deviceInfo": { "os": "Linux", "type": "browser", "name": "Chrome" },
  "callbackUrl": "http://localhost:5173/login/callback"
}
```

**Client Login:**
```json
{
  "op": "oidc/google",
  "id": "device-123",
  "uuid": "uuid-456",
  "deviceInfo": { "os": "Windows", "type": "client", "name": "My Device" }
}
```