### PR TITLE
feat(oidc): add token storage to localStorage/sessionStorage for web frontend

### DIFF
--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -107,7 +107,7 @@ export class OidcController {
    * OIDC提供商授权完成后重定向到此端点
    * 交换授权码获取令牌，更新授权状态
    * - 客户端登录：返回成功页面
-   * - Web前端登录：设置HttpOnly Cookie并重定向到前端
+   * - Web前端登录：重定向到callback-success页面，前端存储后跳转
    *
    * @param req Express请求对象
    * @param res Express响应对象
@@ -127,19 +127,15 @@ export class OidcController {
       const result = await this.oidcService.handleCallback(callbackUrl);
 
       if (result.isWebLogin) {
-        // Web前端登录：设置HttpOnly Cookie并重定向
-        const cookieOptions = {
-          httpOnly: true,
-          secure: this.configService.get<string>('NODE_ENV') === 'production',
-          sameSite: 'lax' as const,
-          maxAge: 7 * 24 * 60 * 60 * 1000, // 7天
-          path: '/',
-        };
+        // Web前端登录：重定向到callback-success页面
+        // 前端JavaScript会存储token到localStorage/sessionStorage，然后跳转
+        const redirectUrl = encodeURIComponent(result.frontendRedirectUrl!);
+        const token = encodeURIComponent(result.accessToken!);
+        const rememberMe = result.rememberMe ? 'true' : 'false';
 
-        res.cookie('access_token', result.accessToken!, cookieOptions);
+        const callbackSuccessUrl = `/api/oidc/callback-success?token=${token}&remember_me=${rememberMe}&redirect_url=${redirectUrl}`;
 
-        // 重定向到前端
-        res.redirect(result.frontendRedirectUrl!);
+        res.redirect(callbackSuccessUrl);
       } else {
         // 客户端登录：返回成功页面
         res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -157,5 +153,20 @@ export class OidcController {
         .status(400)
         .send(this.errorHtml.replace('{{message}}', escapeHtml(message)));
     }
+  }
+
+  /**
+   * OIDC登录成功页面
+   * Web前端登录成功后显示此页面
+   * 前端JavaScript会从URL参数读取token，存储到localStorage/sessionStorage，然后跳转
+   *
+   * @param req Express请求对象
+   * @param res Express响应对象
+   */
+  @Public()
+  @Get('oidc/callback-success')
+  handleCallbackSuccess(@Req() req: Request, @Res() res: Response) {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.send(this.successHtml);
   }
 }

--- a/src/modules/oidc/dto/oidc.dto.ts
+++ b/src/modules/oidc/dto/oidc.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsOptional, IsUrl, ValidateNested } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsUrl,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 /**
@@ -40,4 +46,8 @@ export class OidcAuthRequestDto {
     require_protocol: true,
   })
   callbackUrl?: string; // Web前端回调URL（可选）
+
+  @IsOptional()
+  @IsBoolean()
+  rememberMe?: boolean; // 是否记住登录（可选，Web前端登录时使用）
 }

--- a/src/modules/oidc/entities/oidc-auth-state.entity.ts
+++ b/src/modules/oidc/entities/oidc-auth-state.entity.ts
@@ -139,6 +139,14 @@ export class OidcAuthState {
   frontendRedirectUrl: string | null;
 
   /**
+   * 是否记住登录
+   * Web前端登录时，用于决定 token 存储位置
+   * true: localStorage, false: sessionStorage
+   */
+  @Column({ type: 'boolean', nullable: true })
+  rememberMe: boolean | null;
+
+  /**
    * 过期时间
    * 授权码的过期时间（默认3分钟）
    */

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -75,6 +75,8 @@ export interface OidcCallbackResult {
   frontendRedirectUrl?: string;
   /** 访问令牌 */
   accessToken?: string;
+  /** 是否记住登录（仅Web前端登录时有值） */
+  rememberMe?: boolean;
   /** 用户信息 */
   user?: {
     username: string;
@@ -194,7 +196,7 @@ export class OidcService {
   async requestAuth(
     authRequest: OidcAuthRequestDto,
   ): Promise<OidcAuthUrlResponse> {
-    const { op, id, uuid, deviceInfo, callbackUrl } = authRequest;
+    const { op, id, uuid, deviceInfo, callbackUrl, rememberMe } = authRequest;
 
     const providerName = op.replace(/^(oidc|oauth2)\//, '');
 
@@ -208,8 +210,9 @@ export class OidcService {
       );
     }
 
-    // 验证并保存前端回调URL
+    // 验证并保存前端回调URL和rememberMe
     let frontendRedirectUrl: string | null = null;
+    let rememberMeValue: boolean | null = null;
     if (callbackUrl) {
       if (!this.isCallbackUrlAllowed(callbackUrl)) {
         throw new BadRequestException(
@@ -217,6 +220,7 @@ export class OidcService {
         );
       }
       frontendRedirectUrl = callbackUrl;
+      rememberMeValue = rememberMe ?? false;
     }
 
     // 生成授权码（用于客户端轮询）
@@ -254,6 +258,7 @@ export class OidcService {
       nonce: nonce ?? undefined,
       codeVerifier,
       frontendRedirectUrl,
+      rememberMe: rememberMeValue,
       status: OidcAuthStatus.PENDING,
       expiresAt,
     });
@@ -402,6 +407,7 @@ export class OidcService {
           isWebLogin: true,
           frontendRedirectUrl: authState.frontendRedirectUrl!,
           accessToken,
+          rememberMe: authState.rememberMe ?? false,
           user: {
             username: user.username,
             email: user.email || undefined,

--- a/src/modules/oidc/templates/callback-success.html
+++ b/src/modules/oidc/templates/callback-success.html
@@ -36,13 +36,65 @@
       margin: 0;
       font-size: 14px;
     }
+    .loading {
+      color: #999;
+      margin-top: 16px;
+    }
   </style>
 </head>
 <body>
   <div class="container">
     <div class="icon">&#10003;</div>
     <h1>认证成功</h1>
-    <p>您已成功登录，可以关闭此窗口返回应用。</p>
+    <p>正在跳转...</p>
+    <p class="loading" id="loading-text">正在处理登录信息</p>
   </div>
+  <script>
+    (function() {
+      const TOKEN_KEY = 'rustdesk_access_token';
+      const REMEMBER_ME_KEY = 'rememberMe';
+      
+      function setToken(token, rememberMe) {
+        if (rememberMe) {
+          localStorage.setItem(TOKEN_KEY, token);
+          localStorage.setItem(REMEMBER_ME_KEY, '1');
+          sessionStorage.removeItem(TOKEN_KEY);
+        } else {
+          sessionStorage.setItem(TOKEN_KEY, token);
+          localStorage.setItem(REMEMBER_ME_KEY, '0');
+          localStorage.removeItem(TOKEN_KEY);
+        }
+      }
+      
+      function getRedirectUrl() {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get('redirect_url') || '/';
+      }
+      
+      function getParamsFromUrl() {
+        const urlParams = new URLSearchParams(window.location.search);
+        return {
+          token: urlParams.get('token'),
+          rememberMe: urlParams.get('remember_me') === 'true'
+        };
+      }
+      
+      function main() {
+        const params = getParamsFromUrl();
+        const redirectUrl = getRedirectUrl();
+        
+        if (params.token) {
+          setToken(params.token, params.rememberMe);
+          document.getElementById('loading-text').textContent = '登录信息已保存';
+        }
+        
+        setTimeout(function() {
+          window.location.href = redirectUrl;
+        }, 500);
+      }
+      
+      main();
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This PR adds token storage functionality for web frontend OIDC login. After successful authentication, the token is stored in localStorage or sessionStorage based on the rememberMe parameter.

### Changes

1. **Add rememberMe parameter**
   - Add to OidcAuthRequestDto
   - Add to OidcAuthState entity
   - Save and return in oidc.service.ts

2. **Modify callback-success.html template**
   - Add JavaScript storage logic
   - Read token, rememberMe, and redirect_url from URL params
   - Store token: localStorage if rememberMe=true, sessionStorage otherwise
   - Redirect to frontend callback URL after storage

3. **Add new endpoint**
   - GET /api/oidc/callback-success - renders success page with token params

### Web Frontend Login Flow

1. POST /api/oidc/auth with rememberMe parameter
2. OIDC provider authentication
3. Callback to /api/oidc/callback
4. Redirect to /api/oidc/callback-success?token=xxx&remember_me=true&redirect_url=xxx
5. Frontend JavaScript stores token
6. Redirect to frontend callback URL

### Storage Logic

| rememberMe | Storage Location |
|------------|-----------------|
| true | localStorage |
| false | sessionStorage |

### Example Request

POST /api/oidc/auth:
{
  "op": "oidc/google",
  "deviceInfo": { "os": "Linux", "type": "browser", "name": "Chrome" },
  "callbackUrl": "http://localhost:5173/login/callback",
  "rememberMe": true
}