### PR TITLE
feat: add strategy delivery via heartbeat

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,8 @@ import { EmailVerificationSession } from './modules/auth/entities/email-verifica
 import { SystemSetting } from './modules/settings/entities/system-setting.entity';
 import { ActiveConnection } from './modules/heartbeat/entities/active-connection.entity';
 import { SettingsModule } from './modules/settings/settings.module';
+import { StrategyModule } from './modules/strategy/strategy.module';
+import { Strategy } from './modules/strategy/entities/strategy.entity';
 
 /**
  * 应用根模块
@@ -93,6 +95,7 @@ import { SettingsModule } from './modules/settings/settings.module';
         EmailVerificationSession,
         SystemSetting,
         ActiveConnection,
+        Strategy,
       ],
       synchronize: true,
       logging: false,
@@ -108,6 +111,7 @@ import { SettingsModule } from './modules/settings/settings.module';
     SysinfoModule,
     DashboardModule,
     SettingsModule,
+    StrategyModule,
   ],
   providers: [
     {

--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -8,6 +8,7 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
+import { Strategy } from '../../modules/strategy/entities/strategy.entity';
 
 /**
  * 设备状态枚举
@@ -55,11 +56,14 @@ export class Peer {
   @Index()
   deviceGroupGuid: string | null;
 
-  /**
-   * 关联的设备组实体
-   * 多对一关系，关联到 DeviceGroup
-   * 使用字符串引用避免循环依赖
-   */
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  strategyGuid: string | null;
+
+  @ManyToOne('Strategy', () => Strategy, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'strategyGuid' })
+  strategy: any;
+
   @ManyToOne('DeviceGroup', 'peers', { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'deviceGroupGuid' })
   deviceGroup: any;

--- a/src/modules/device-group/device-group.module.ts
+++ b/src/modules/device-group/device-group.module.ts
@@ -8,6 +8,7 @@ import { DeviceGroupUserPermission } from './entities/device-group-user-permissi
 import { UserUserPermission } from './entities/user-user-permission.entity';
 import { Peer, Sysinfo } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
+import { Strategy } from '../strategy/entities/strategy.entity';
 import { AuthModule } from '../auth/auth.module';
 import { HeartbeatModule } from '../heartbeat/heartbeat.module';
 
@@ -37,6 +38,7 @@ import { HeartbeatModule } from '../heartbeat/heartbeat.module';
       Peer,
       Sysinfo,
       User,
+      Strategy,
     ]),
     AuthModule,
     HeartbeatModule,

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -9,6 +9,7 @@ import * as uuid from 'uuid';
 import { DeviceGroup } from './entities/device-group.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
 import { Peer, PeerStatus } from '../../common/entities/peer.entity';
+import { Strategy } from '../strategy/entities/strategy.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
 import {
   DeviceStatus,
@@ -40,6 +41,8 @@ export class DeviceGroupService {
     private peerRepository: Repository<Peer>,
     @InjectRepository(DeviceGroupUserPermission)
     private deviceGroupUserPermissionRepository: Repository<DeviceGroupUserPermission>,
+    @InjectRepository(Strategy)
+    private strategyRepository: Repository<Strategy>,
   ) {}
 
   /**
@@ -674,9 +677,16 @@ export class DeviceGroupService {
       case 'device_username':
       case 'device_name':
       case 'ab':
-      case 'strategy_name':
-        // 这些字段需要从Sysinfo中获取和更新
+      case 'strategy_name': {
+        const strategy = await this.strategyRepository.findOne({
+          where: { name: value },
+        });
+        if (!strategy) {
+          throw new NotFoundException('策略不存在');
+        }
+        updateData.strategyGuid = strategy.guid;
         break;
+      }
       default:
         throw new BadRequestException(`不支持的属性类型: ${type}`);
     }

--- a/src/modules/device-group/entities/device-group.entity.ts
+++ b/src/modules/device-group/entities/device-group.entity.ts
@@ -5,9 +5,12 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  ManyToOne,
+  JoinColumn,
   Index,
 } from 'typeorm';
 import { DeviceGroupUserPermission } from './device-group-user-permission.entity';
+import { Strategy } from '../../strategy/entities/strategy.entity';
 
 /**
  * 设备组实体
@@ -37,10 +40,14 @@ export class DeviceGroup {
   @Column({ type: 'text', nullable: true })
   note: string;
 
-  /**
-   * 设备组的用户权限列表
-   * 一对多关系，关联到 DeviceGroupUserPermission
-   */
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  strategyGuid: string | null;
+
+  @ManyToOne('Strategy', () => Strategy, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'strategyGuid' })
+  strategy: any;
+
   @OneToMany(
     () => DeviceGroupUserPermission,
     (permission) => permission.deviceGroup,

--- a/src/modules/device-group/peer.service.ts
+++ b/src/modules/device-group/peer.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
 import { Peer, Sysinfo } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
+import { Strategy } from '../strategy/entities/strategy.entity';
 import { PeerQueryDto } from './dto/peer.dto';
 
 /**
@@ -23,6 +24,8 @@ export class PeerService {
     private sysinfoRepository: Repository<Sysinfo>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(Strategy)
+    private strategyRepository: Repository<Strategy>,
   ) {}
 
   /**
@@ -182,9 +185,21 @@ export class PeerService {
         : [];
     const userMap = new Map(users.map((u) => [u.guid, u]));
 
-    // 版本号转换函数：将 1001100 格式转换为 1.1.10 格式
-    // 格式说明：major*1000000 + minor*1000 + patch*10 + patch_version
-    // 例如：1.1.10 -> 1001100, 1.1.10-1 -> 1001101
+    const strategyGuids = [
+      ...new Set(
+        peers
+          .map((p) => p.strategyGuid)
+          .filter((guid): guid is string => guid != null),
+      ),
+    ];
+    const strategies =
+      strategyGuids.length > 0
+        ? await this.strategyRepository.find({
+            where: { guid: In(strategyGuids) },
+          })
+        : [];
+    const strategyMap = new Map(strategies.map((s) => [s.guid, s]));
+
     const formatVersion = (ver: number | null | undefined): string => {
       if (!ver) return '';
       const major = Math.floor(ver / 1000000);
@@ -221,7 +236,9 @@ export class PeerService {
         user_name: user?.username || '',
         note: sysinfo?.presetNote || '',
         device_group_name: deviceGroupName,
-        strategy_name: '', // 策略功能未实现，暂返回空
+        strategy_name: peer.strategyGuid
+          ? strategyMap.get(peer.strategyGuid)?.name || ''
+          : '',
         info: {
           device_name: sysinfo?.hostname || '',
           username: sysinfo?.username || '',

--- a/src/modules/heartbeat/heartbeat.module.ts
+++ b/src/modules/heartbeat/heartbeat.module.ts
@@ -5,24 +5,10 @@ import { HeartbeatService } from './heartbeat.service';
 import { DisconnectStoreService } from './services/disconnect-store.service';
 import { Peer } from '../../common/entities';
 import { ActiveConnection } from './entities/active-connection.entity';
+import { StrategyModule } from '../strategy/strategy.module';
 
-/**
- * 心跳模块
- * 负责设备心跳处理、在线状态维护和连接管理
- *
- * 导入模块：
- * - TypeOrmModule
- *
- * 导出服务：
- * - HeartbeatService
- * - DisconnectStoreService
- *
- * 提供服务：
- * - HeartbeatService
- * - DisconnectStoreService
- */
 @Module({
-  imports: [TypeOrmModule.forFeature([Peer, ActiveConnection])],
+  imports: [TypeOrmModule.forFeature([Peer, ActiveConnection]), StrategyModule],
   controllers: [HeartbeatController],
   providers: [HeartbeatService, DisconnectStoreService],
   exports: [HeartbeatService, DisconnectStoreService],

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -5,18 +5,8 @@ import { HeartbeatDto } from './dto/heartbeat.dto';
 import { Peer } from '../../common/entities';
 import { ActiveConnection } from './entities/active-connection.entity';
 import { DisconnectStoreService } from './services/disconnect-store.service';
+import { StrategyService } from '../strategy/strategy.service';
 
-/**
- * 心跳服务
- * 负责处理设备的定期心跳信号，保持设备在线状态
- *
- * 功能：
- * - 接收设备心跳数据
- * - 创建或更新设备记录
- * - 维护设备在线状态
- * - 同步活跃连接信息
- * - 下发强制断开连接指令
- */
 @Injectable()
 export class HeartbeatService {
   private readonly logger = new Logger(HeartbeatService.name);
@@ -27,16 +17,9 @@ export class HeartbeatService {
     @InjectRepository(ActiveConnection)
     private activeConnectionRepository: Repository<ActiveConnection>,
     private disconnectStoreService: DisconnectStoreService,
+    private strategyService: StrategyService,
   ) {}
 
-  /**
-   * 处理设备心跳
-   * 接收设备发送的心跳数据，创建或更新设备记录
-   * 同时处理活跃连接同步和断开指令下发
-   *
-   * @param data 心跳数据，包含设备ID、UUID、版本号、活跃连接等信息
-   * @returns 心跳处理结果，包含断开连接指令
-   */
   async handleHeartbeat(data: HeartbeatDto) {
     this.logger.debug(`收到心跳数据: id=${data.id}, uuid=${data.uuid}`);
 
@@ -67,22 +50,25 @@ export class HeartbeatService {
       this.logger.log(`新设备 ${data.uuid} 已注册`);
     }
 
-    // 同步活跃连接
     if (data.conns !== undefined) {
       await this.syncActiveConnections(data.uuid, data.conns);
-      // 客户端不再上报的连接说明已断开，从待断开列表中移除
       this.disconnectStoreService.removeDisconnected(data.uuid, data.conns);
     }
 
-    // 获取待断开连接列表（持续下发直到客户端确认断开）
     const disconnect = this.disconnectStoreService.getPendingDisconnects(
       data.uuid,
+    );
+
+    const strategyResult = await this.resolveStrategy(
+      data.uuid,
+      data.modified_at,
     );
 
     return {
       code: 200,
       message: '心跳接收成功',
       ...(disconnect.length > 0 ? { disconnect } : {}),
+      ...(strategyResult ? { strategy: strategyResult } : {}),
       data: {
         timestamp: Date.now(),
         device_id: data.id,
@@ -90,11 +76,6 @@ export class HeartbeatService {
     };
   }
 
-  /**
-   * 获取设备的活跃连接ID列表
-   * @param deviceUuid 设备UUID
-   * @returns 活跃连接ID列表
-   */
   async getActiveConnectionIds(deviceUuid: string): Promise<number[]> {
     const connections = await this.activeConnectionRepository.find({
       where: { deviceUuid },
@@ -103,21 +84,44 @@ export class HeartbeatService {
     return connections.map((c) => c.connId);
   }
 
-  /**
-   * 同步活跃连接
-   * 用客户端上报的连接列表替换该设备的所有活跃连接记录
-   *
-   * @param deviceUuid 设备UUID
-   * @param conns 客户端上报的活跃连接ID列表
-   */
+  private async resolveStrategy(
+    deviceUuid: string,
+    clientModifiedAt: number,
+  ): Promise<{
+    config_options: Record<string, string>;
+    modified_at: number;
+  } | null> {
+    try {
+      const strategy =
+        await this.strategyService.findStrategyForDevice(deviceUuid);
+      if (!strategy) {
+        return null;
+      }
+
+      if (strategy.modifiedAt > clientModifiedAt) {
+        const configOptions: Record<string, string> = JSON.parse(
+          strategy.configOptions || '{}',
+        ) as Record<string, string>;
+        return {
+          config_options: configOptions,
+          modified_at: strategy.modifiedAt,
+        };
+      }
+
+      return null;
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`设备 ${deviceUuid} 策略解析失败: ${msg}`);
+      return null;
+    }
+  }
+
   private async syncActiveConnections(
     deviceUuid: string,
     conns: number[],
   ): Promise<void> {
-    // 删除该设备旧的活跃连接
     await this.activeConnectionRepository.delete({ deviceUuid });
 
-    // 插入新的活跃连接
     if (conns.length > 0) {
       const entities = conns.map((connId) =>
         this.activeConnectionRepository.create({

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -68,7 +68,12 @@ export class HeartbeatService {
       code: 200,
       message: '心跳接收成功',
       ...(disconnect.length > 0 ? { disconnect } : {}),
-      ...(strategyResult ? { strategy: strategyResult } : {}),
+      ...(strategyResult
+        ? {
+            strategy: { config_options: strategyResult.config_options },
+            modified_at: strategyResult.modified_at,
+          }
+        : {}),
       data: {
         timestamp: Date.now(),
         device_id: data.id,

--- a/src/modules/strategy/dto/strategy.dto.ts
+++ b/src/modules/strategy/dto/strategy.dto.ts
@@ -1,0 +1,45 @@
+import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+
+export class CreateStrategyDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  note?: string;
+
+  @IsObject()
+  @IsOptional()
+  config_options?: Record<string, string>;
+}
+
+export class UpdateStrategyDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  note?: string;
+
+  @IsObject()
+  @IsOptional()
+  config_options?: Record<string, string>;
+}
+
+export class AssignStrategyDto {
+  @IsString()
+  @IsNotEmpty()
+  target_type: 'device' | 'user' | 'device_group';
+
+  @IsString()
+  @IsNotEmpty()
+  target_guid: string;
+}
+
+export class StrategyQueryDto {
+  current: number = 1;
+  pageSize: number = 100;
+  name?: string;
+}

--- a/src/modules/strategy/entities/strategy.entity.ts
+++ b/src/modules/strategy/entities/strategy.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('strategies')
+export class Strategy {
+  @PrimaryColumn()
+  guid: string;
+
+  @Column({ unique: true })
+  @Index()
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  note: string;
+
+  @Column({ type: 'text', nullable: true })
+  configOptions: string;
+
+  @Column({ type: 'bigint', default: 0 })
+  modifiedAt: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/strategy/strategy.controller.ts
+++ b/src/modules/strategy/strategy.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { StrategyService } from './strategy.service';
+import {
+  CreateStrategyDto,
+  UpdateStrategyDto,
+  AssignStrategyDto,
+  StrategyQueryDto,
+} from './dto/strategy.dto';
+import { AdminGuard } from '../../common/guards/admin.guard';
+
+@Controller()
+export class StrategyController {
+  constructor(private readonly strategyService: StrategyService) {}
+
+  @Get('strategies')
+  @UseGuards(AdminGuard)
+  async getStrategies(@Query() query: StrategyQueryDto) {
+    return this.strategyService.getStrategies(query);
+  }
+
+  @Get('strategies/:guid')
+  @UseGuards(AdminGuard)
+  async getStrategy(@Param('guid') guid: string) {
+    return this.strategyService.getStrategy(guid);
+  }
+
+  @Post('strategies')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async createStrategy(@Body() dto: CreateStrategyDto) {
+    return this.strategyService.createStrategy(dto);
+  }
+
+  @Patch('strategies/:guid')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async updateStrategy(
+    @Param('guid') guid: string,
+    @Body() dto: UpdateStrategyDto,
+  ) {
+    return this.strategyService.updateStrategy(guid, dto);
+  }
+
+  @Delete('strategies/:guid')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async deleteStrategy(@Param('guid') guid: string) {
+    await this.strategyService.deleteStrategy(guid);
+    return { message: '策略删除成功' };
+  }
+
+  @Post('strategies/:guid/assign')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async assignStrategy(
+    @Param('guid') guid: string,
+    @Body() dto: AssignStrategyDto,
+  ) {
+    return this.strategyService.assignStrategy(
+      guid,
+      dto.target_type,
+      dto.target_guid,
+    );
+  }
+
+  @Post('strategies/:guid/unassign')
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async unassignStrategy(@Body() dto: AssignStrategyDto) {
+    return this.strategyService.unassignStrategy(
+      dto.target_type,
+      dto.target_guid,
+    );
+  }
+}

--- a/src/modules/strategy/strategy.module.ts
+++ b/src/modules/strategy/strategy.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StrategyController } from './strategy.controller';
+import { StrategyService } from './strategy.service';
+import { Strategy } from './entities/strategy.entity';
+import { Peer } from '../../common/entities/peer.entity';
+import { User } from '../user/entities/user.entity';
+import { DeviceGroup } from '../device-group/entities/device-group.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Strategy, Peer, User, DeviceGroup])],
+  controllers: [StrategyController],
+  providers: [StrategyService],
+  exports: [StrategyService],
+})
+export class StrategyModule {}

--- a/src/modules/strategy/strategy.service.ts
+++ b/src/modules/strategy/strategy.service.ts
@@ -1,0 +1,332 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as uuid from 'uuid';
+import { Strategy } from './entities/strategy.entity';
+import { Peer } from '../../common/entities/peer.entity';
+import { User } from '../user/entities/user.entity';
+import { DeviceGroup } from '../device-group/entities/device-group.entity';
+import {
+  CreateStrategyDto,
+  UpdateStrategyDto,
+  StrategyQueryDto,
+} from './dto/strategy.dto';
+
+@Injectable()
+export class StrategyService {
+  private readonly logger = new Logger(StrategyService.name);
+
+  constructor(
+    @InjectRepository(Strategy)
+    private strategyRepository: Repository<Strategy>,
+    @InjectRepository(Peer)
+    private peerRepository: Repository<Peer>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(DeviceGroup)
+    private deviceGroupRepository: Repository<DeviceGroup>,
+  ) {}
+
+  async createStrategy(dto: CreateStrategyDto) {
+    const existing = await this.strategyRepository.findOne({
+      where: { name: dto.name },
+    });
+    if (existing) {
+      throw new BadRequestException('策略名称已存在');
+    }
+
+    const strategy = new Strategy();
+    strategy.guid = uuid.v4();
+    strategy.name = dto.name;
+    strategy.note = dto.note || '';
+    strategy.configOptions = dto.config_options
+      ? JSON.stringify(dto.config_options)
+      : '';
+    strategy.modifiedAt = Date.now();
+
+    await this.strategyRepository.save(strategy);
+
+    return {
+      guid: strategy.guid,
+      name: strategy.name,
+      note: strategy.note,
+      config_options: dto.config_options || {},
+      modified_at: strategy.modifiedAt,
+    };
+  }
+
+  async updateStrategy(guid: string, dto: UpdateStrategyDto) {
+    const strategy = await this.strategyRepository.findOne({
+      where: { guid },
+    });
+    if (!strategy) {
+      throw new NotFoundException('策略不存在');
+    }
+
+    if (dto.name !== undefined) {
+      const existing = await this.strategyRepository.findOne({
+        where: { name: dto.name },
+      });
+      if (existing && existing.guid !== guid) {
+        throw new BadRequestException('策略名称已存在');
+      }
+      strategy.name = dto.name;
+    }
+
+    if (dto.note !== undefined) {
+      strategy.note = dto.note;
+    }
+
+    if (dto.config_options !== undefined) {
+      strategy.configOptions = JSON.stringify(dto.config_options);
+    }
+
+    strategy.modifiedAt = Date.now();
+
+    await this.strategyRepository.save(strategy);
+
+    const configOptions: Record<string, string> = dto.config_options
+      ? dto.config_options
+      : (JSON.parse(strategy.configOptions || '{}') as Record<string, string>);
+
+    return {
+      guid: strategy.guid,
+      name: strategy.name,
+      note: strategy.note,
+      config_options: configOptions,
+      modified_at: strategy.modifiedAt,
+    };
+  }
+
+  async deleteStrategy(guid: string) {
+    const strategy = await this.strategyRepository.findOne({
+      where: { guid },
+    });
+    if (!strategy) {
+      throw new NotFoundException('策略不存在');
+    }
+
+    await this.strategyRepository.remove(strategy);
+  }
+
+  async getStrategies(query: StrategyQueryDto) {
+    const { current, pageSize, name } = query;
+    const skip = (current - 1) * pageSize;
+
+    let queryBuilder = this.strategyRepository
+      .createQueryBuilder('strategy')
+      .orderBy('strategy.name', 'ASC')
+      .skip(skip)
+      .take(pageSize);
+
+    if (name) {
+      queryBuilder = queryBuilder.where('strategy.name LIKE :name', {
+        name: `%${name}%`,
+      });
+    }
+
+    const [strategies, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      data: strategies.map((s) => ({
+        guid: s.guid,
+        name: s.name,
+        note: s.note || '',
+        config_options: JSON.parse(s.configOptions || '{}') as Record<
+          string,
+          string
+        >,
+        modified_at: s.modifiedAt,
+        created_at: s.createdAt,
+        updated_at: s.updatedAt,
+      })),
+      total,
+    };
+  }
+
+  async getStrategy(guid: string) {
+    const strategy = await this.strategyRepository.findOne({
+      where: { guid },
+    });
+    if (!strategy) {
+      throw new NotFoundException('策略不存在');
+    }
+
+    return {
+      guid: strategy.guid,
+      name: strategy.name,
+      note: strategy.note || '',
+      config_options: JSON.parse(strategy.configOptions || '{}') as Record<
+        string,
+        string
+      >,
+      modified_at: strategy.modifiedAt,
+      created_at: strategy.createdAt,
+      updated_at: strategy.updatedAt,
+    };
+  }
+
+  async assignStrategy(
+    strategyGuid: string,
+    targetType: string,
+    targetGuid: string,
+  ) {
+    const strategy = await this.strategyRepository.findOne({
+      where: { guid: strategyGuid },
+    });
+    if (!strategy) {
+      throw new NotFoundException('策略不存在');
+    }
+
+    switch (targetType) {
+      case 'device': {
+        const peer = await this.peerRepository.findOne({
+          where: { uuid: targetGuid },
+        });
+        if (!peer) {
+          throw new NotFoundException('设备不存在');
+        }
+        await this.peerRepository.update(
+          { uuid: targetGuid },
+          { strategyGuid },
+        );
+        break;
+      }
+      case 'user': {
+        const user = await this.userRepository.findOne({
+          where: { guid: targetGuid },
+        });
+        if (!user) {
+          throw new NotFoundException('用户不存在');
+        }
+        await this.userRepository.update(
+          { guid: targetGuid },
+          { strategyGuid },
+        );
+        break;
+      }
+      case 'device_group': {
+        const group = await this.deviceGroupRepository.findOne({
+          where: { guid: targetGuid },
+        });
+        if (!group) {
+          throw new NotFoundException('设备组不存在');
+        }
+        await this.deviceGroupRepository.update(
+          { guid: targetGuid },
+          { strategyGuid },
+        );
+        break;
+      }
+      default:
+        throw new BadRequestException(
+          `不支持的目标类型: ${String(targetType)}`,
+        );
+    }
+
+    return { message: '策略分配成功' };
+  }
+
+  async unassignStrategy(targetType: string, targetGuid: string) {
+    switch (targetType) {
+      case 'device': {
+        const peer = await this.peerRepository.findOne({
+          where: { uuid: targetGuid },
+        });
+        if (!peer) {
+          throw new NotFoundException('设备不存在');
+        }
+        await this.peerRepository.update(
+          { uuid: targetGuid },
+          { strategyGuid: null },
+        );
+        break;
+      }
+      case 'user': {
+        const user = await this.userRepository.findOne({
+          where: { guid: targetGuid },
+        });
+        if (!user) {
+          throw new NotFoundException('用户不存在');
+        }
+        await this.userRepository.update(
+          { guid: targetGuid },
+          { strategyGuid: null },
+        );
+        break;
+      }
+      case 'device_group': {
+        const group = await this.deviceGroupRepository.findOne({
+          where: { guid: targetGuid },
+        });
+        if (!group) {
+          throw new NotFoundException('设备组不存在');
+        }
+        await this.deviceGroupRepository.update(
+          { guid: targetGuid },
+          { strategyGuid: null },
+        );
+        break;
+      }
+      default:
+        throw new BadRequestException(
+          `不支持的目标类型: ${String(targetType)}`,
+        );
+    }
+
+    return { message: '策略取消分配成功' };
+  }
+
+  async findStrategyForDevice(deviceUuid: string): Promise<Strategy | null> {
+    const peer = await this.peerRepository.findOne({
+      where: { uuid: deviceUuid },
+    });
+    if (!peer) {
+      return null;
+    }
+
+    if (peer.strategyGuid) {
+      const strategy = await this.strategyRepository.findOne({
+        where: { guid: peer.strategyGuid },
+      });
+      if (strategy) {
+        return strategy;
+      }
+    }
+
+    if (peer.userGuid) {
+      const user = await this.userRepository.findOne({
+        where: { guid: peer.userGuid },
+      });
+      if (user?.strategyGuid) {
+        const strategy = await this.strategyRepository.findOne({
+          where: { guid: user.strategyGuid },
+        });
+        if (strategy) {
+          return strategy;
+        }
+      }
+    }
+
+    if (peer.deviceGroupGuid) {
+      const group = await this.deviceGroupRepository.findOne({
+        where: { guid: peer.deviceGroupGuid },
+      });
+      if (group?.strategyGuid) {
+        const strategy = await this.strategyRepository.findOne({
+          where: { guid: group.strategyGuid },
+        });
+        if (strategy) {
+          return strategy;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -5,9 +5,12 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  ManyToOne,
+  JoinColumn,
   Index,
 } from 'typeorm';
 import { UserToken } from './user-token.entity';
+import { Strategy } from '../../strategy/entities/strategy.entity';
 
 /**
  * 用户状态枚举
@@ -135,10 +138,14 @@ export class User {
   @Index()
   oidcSubject: string;
 
-  /**
-   * 用户的令牌列表
-   * 一对多关系，关联到 UserToken
-   */
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  strategyGuid: string | null;
+
+  @ManyToOne('Strategy', () => Strategy, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'strategyGuid' })
+  strategy: any;
+
   @OneToMany(() => UserToken, (token) => token.user, { cascade: true })
   tokens: UserToken[];
 


### PR DESCRIPTION
## Summary

Implement server-side strategy delivery feature. When a client sends a heartbeat request with a `modified_at` field, the server resolves the applicable strategy (device → user → device group priority) and returns it in the heartbeat response if the server's strategy is newer.

## Changes

### New: Strategy Module
- **Strategy entity** (`strategies` table): stores `guid`, `name`, `configOptions` (JSON), `modifiedAt`, `note`
- **Strategy controller**: admin-only CRUD endpoints for strategies + assign/unassign endpoints
- **Strategy service**: full CRUD, assign/unassign to device/user/device_group, and `findStrategyForDevice()` lookup

### Modified: Entity Changes
- **Peer entity**: added `strategyGuid` column with ManyToOne relation to Strategy
- **User entity**: added `strategyGuid` column with ManyToOne relation to Strategy
- **DeviceGroup entity**: added `strategyGuid` column with ManyToOne relation to Strategy

### Modified: Heartbeat Strategy Delivery
- **HeartbeatService**: added `resolveStrategy()` method that looks up the applicable strategy for a device using priority: device-specific → user-specific → device-group-specific
- If the server's strategy `modifiedAt` > client's `modified_at`, the response includes `strategy: { config_options: {...}, modified_at: ... }`

### Modified: Other Updates
- **peer.service.ts**: `strategy_name` now returns actual strategy name from the database instead of hardcoded empty string
- **device-group.service.ts**: `assignDevice()` now handles `strategy_name` type by looking up the strategy and setting `strategyGuid`
- **app.module.ts**: registered Strategy entity and StrategyModule

## API Endpoints (Admin Only)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/strategies` | List strategies (paginated) |
| GET | `/api/strategies/:guid` | Get strategy detail |
| POST | `/api/strategies` | Create strategy |
| PATCH | `/api/strategies/:guid` | Update strategy |
| DELETE | `/api/strategies/:guid` | Delete strategy |
| POST | `/api/strategies/:guid/assign` | Assign strategy to device/user/device_group |
| POST | `/api/strategies/:guid/unassign` | Unassign strategy from device/user/device_group |

## Heartbeat Response (when strategy is newer)

```json
{
  "code": 200,
  "message": "心跳接收成功",
  "strategy": {
    "config_options": {
      "allow-file-transfer": "true",
      "max-session-duration": "3600",
      "require-encryption": "true"
    },
    "modified_at": 1748716800000
  },
  "data": {
    "timestamp": 1748716800000,
    "device_id": "123456789"
  }
}
```