### PR TITLE
fix: add validation decorators to StrategyQueryDto

### DIFF
--- a/src/modules/strategy/dto/strategy.dto.ts
+++ b/src/modules/strategy/dto/strategy.dto.ts
@@ -1,4 +1,13 @@
-import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsObject,
+  IsNumber,
+  Min,
+  IsInt,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class CreateStrategyDto {
   @IsString()
@@ -39,7 +48,19 @@ export class AssignStrategyDto {
 }
 
 export class StrategyQueryDto {
-  current: number = 1;
-  pageSize: number = 100;
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  current: number;
+
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  pageSize: number;
+
+  @IsString()
+  @IsOptional()
   name?: string;
 }


### PR DESCRIPTION
## Problem

Request to `/api/strategies?current=1&pageSize=20` returned 400 error:
```json
{
  "message": [
    "property current should not exist",
    "property pageSize should not exist",
    "property name should not exist"  
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

## Solution

Add validation decorators to `StrategyQueryDto` following the pattern used in `DeviceGroupQueryDto`:
- `@IsNumber()`, `@Min(1)`, `@IsInt()`, `@Type(() => Number)` for `current` and `pageSize`
- `@IsString()`, `@IsOptional()` for `name`

## Changes

- `src/modules/strategy/dto/strategy.dto.ts`: Add proper validation decorators to `StrategyQueryDto`