### PR TITLE
feat(auth): implement complete 2FA user setup flow and remove tfa_url

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import {
   LoginDto,
   CurrentUserDto,
   LogoutDto,
+  SetupTfaDto,
   VerifyTfaDto,
   DisableTfaDto,
 } from './dto/auth.dto';
@@ -63,8 +64,8 @@ export class AuthController {
 
   @Post('2fa/setup')
   @HttpCode(HttpStatus.OK)
-  async setupTfa(@CurrentUser('id') userId: string) {
-    return this.tfaService.setupTfa(userId);
+  async setupTfa(@CurrentUser('id') userId: string, @Body() dto: SetupTfaDto) {
+    return this.tfaService.setupTfa(userId, dto.current_code);
   }
 
   @Post('2fa/verify')

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Post,
+  Delete,
   Body,
   HttpCode,
   HttpStatus,
@@ -8,37 +9,25 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './services';
-import { LoginDto, CurrentUserDto, LogoutDto } from './dto/auth.dto';
+import { AuthTfaService } from './services/auth-tfa.service';
+import {
+  LoginDto,
+  CurrentUserDto,
+  LogoutDto,
+  VerifyTfaDto,
+  DisableTfaDto,
+} from './dto/auth.dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import type { Request } from 'express';
 
-/**
- * 认证控制器
- * 负责处理用户认证相关的HTTP请求，包括登录、登出和获取当前用户信息
- *
- * 端点数量：3个
- * - POST /api/login - 用户登录
- * - POST /api/logout - 用户登出
- * - POST /api/currentUser - 获取当前用户信息
- */
 @Controller()
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly tfaService: AuthTfaService,
+  ) {}
 
-  /**
-   * 用户登录
-   * 验证用户凭证并返回访问令牌
-   *
-   * 安全措施：
-   * - 使用@Public装饰器，无需认证即可访问
-   * - 启用限流保护：每分钟最多5次请求
-   * - 返回HTTP 200状态码
-   *
-   * @param loginDto 登录数据传输对象，包含用户名和密码
-   * @returns 登录成功返回访问令牌和用户信息
-   * @throws UnauthorizedException 用户名或密码错误
-   */
   @Public()
   @Throttle({ default: { limit: 5, ttl: 60000 } })
   @Post('login')
@@ -47,21 +36,6 @@ export class AuthController {
     return this.authService.login(loginDto);
   }
 
-  /**
-   * 用户登出
-   * 撤销用户的访问令牌，清除会话状态
-   *
-   * 功能说明：
-   * - 从请求头提取Bearer令牌
-   * - 将令牌添加到撤销列表
-   * - 清除相关的会话数据
-   *
-   * @param userId 当前用户ID（从JWT令牌中提取）
-   * @param logoutDto 登出数据传输对象，包含设备信息
-   * @param req Express请求对象，用于访问请求头
-   * @returns 登出成功消息
-   * @throws UnauthorizedException 令牌无效或已过期
-   */
   @Post('logout')
   @HttpCode(HttpStatus.OK)
   async logout(
@@ -69,7 +43,6 @@ export class AuthController {
     @Body() logoutDto: LogoutDto,
     @Req() req: Request,
   ) {
-    // 从请求头获取 token
     const authHeader = req.headers.authorization;
     const token = authHeader?.startsWith('Bearer ')
       ? authHeader.substring(7)
@@ -79,20 +52,6 @@ export class AuthController {
     return { message: '登出成功' };
   }
 
-  /**
-   * 获取当前用户信息
-   * 根据JWT令牌获取当前登录用户的详细信息
-   *
-   * 功能说明：
-   * - 验证JWT令牌的有效性
-   * - 返回用户的完整信息
-   * - 支持设备信息更新
-   *
-   * @param userId 当前用户ID（从JWT令牌中提取）
-   * @param currentUserDto 用户数据传输对象，包含设备信息
-   * @returns 当前用户的详细信息
-   * @throws UnauthorizedException 令牌无效或已过期
-   */
   @Post('currentUser')
   @HttpCode(HttpStatus.OK)
   async getCurrentUser(
@@ -100,5 +59,29 @@ export class AuthController {
     @Body() currentUserDto: CurrentUserDto,
   ): Promise<Record<string, unknown>> {
     return this.authService.getCurrentUser(userId, currentUserDto);
+  }
+
+  @Post('2fa/setup')
+  @HttpCode(HttpStatus.OK)
+  async setupTfa(@CurrentUser('id') userId: string) {
+    return this.tfaService.setupTfa(userId);
+  }
+
+  @Post('2fa/verify')
+  @HttpCode(HttpStatus.OK)
+  async verifyAndBindTfa(
+    @CurrentUser('id') userId: string,
+    @Body() dto: VerifyTfaDto,
+  ) {
+    return this.tfaService.verifyAndBindTfa(userId, dto.code);
+  }
+
+  @Delete('2fa')
+  @HttpCode(HttpStatus.OK)
+  async disableTfa(
+    @CurrentUser('id') userId: string,
+    @Body() dto: DisableTfaDto,
+  ) {
+    return this.tfaService.disableTfa(userId, dto.code);
   }
 }

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -99,3 +99,13 @@ export class LogoutDto {
   @IsString()
   uuid?: string;
 }
+
+export class VerifyTfaDto {
+  @IsString()
+  code: string;
+}
+
+export class DisableTfaDto {
+  @IsString()
+  code: string;
+}

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -100,6 +100,12 @@ export class LogoutDto {
   uuid?: string;
 }
 
+export class SetupTfaDto {
+  @IsOptional()
+  @IsString()
+  current_code?: string;
+}
+
 export class VerifyTfaDto {
   @IsString()
   code: string;

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -35,6 +35,7 @@ export class AuthTfaService {
 
   async setupTfa(
     userGuid: string,
+    currentCode?: string,
   ): Promise<{ secret: string; otpauth_url: string }> {
     const user = await this.userRepository
       .createQueryBuilder('user')
@@ -47,14 +48,29 @@ export class AuthTfaService {
       throw new NotFoundException('用户不存在');
     }
 
+    const userInfo = user.getUserInfo();
+    const isEnforced = !!userInfo?.other?.tfa_enforce;
+
     if (user.tfaSecret) {
-      throw new BadRequestException('2FA已启用，如需重新设置请先禁用');
+      if (!isEnforced) {
+        throw new BadRequestException('2FA已启用，如需重新设置请先禁用');
+      }
+
+      if (!currentCode) {
+        throw new BadRequestException(
+          '2FA已启用且为强制模式，重设需提供当前验证码',
+        );
+      }
+
+      const isValid = this.verifyTfaCode(user.tfaSecret, currentCode);
+      if (!isValid) {
+        throw new UnauthorizedException('当前验证码错误');
+      }
     }
 
     const secret = authenticator.generateSecret();
     const otpauthUrl = authenticator.keyuri(user.username, 'RustDesk', secret);
 
-    const userInfo = user.getUserInfo();
     userInfo.other = userInfo.other || {};
     userInfo.other.tfa_pending_secret = secret;
     user.setUserInfo(userInfo);
@@ -82,11 +98,13 @@ export class AuthTfaService {
       throw new NotFoundException('用户不存在');
     }
 
-    if (user.tfaSecret) {
+    const userInfo = user.getUserInfo();
+    const isEnforced = !!userInfo?.other?.tfa_enforce;
+
+    if (user.tfaSecret && !isEnforced) {
       throw new BadRequestException('2FA已启用');
     }
 
-    const userInfo = user.getUserInfo();
     const other = userInfo.other || {};
     const pendingSecret = other.tfa_pending_secret as string | undefined;
 

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   UnauthorizedException,
   BadRequestException,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -12,16 +13,6 @@ import { LoginDto } from '../dto/auth.dto';
 import { LoginResponse } from '../../../common/interfaces';
 
 @Injectable()
-/**
- * AuthTfaService
- * 负责双因素认证的子服务
- *
- * 与主服务关系：
- * 被AuthService委托处理TFA相关操作
- *
- * 调用上下文：
- * 包括TFA密钥生成、验证和启用/禁用
- */
 export class AuthTfaService {
   private readonly logger = new Logger(AuthTfaService.name);
 
@@ -30,14 +21,6 @@ export class AuthTfaService {
     private userRepository: Repository<User>,
   ) {}
 
-  /**
-   * 验证TFA验证码
-   * 使用TOTP算法验证用户输入的验证码是否正确
-   *
-   * @param secret TFA密钥
-   * @param code 用户输入的验证码
-   * @returns 验证是否成功
-   */
   verifyTfaCode(secret: string, code: string): boolean {
     try {
       return authenticator.verify({
@@ -50,17 +33,118 @@ export class AuthTfaService {
     }
   }
 
-  /**
-   * 双因素认证登录
-   * 验证TFA验证码并完成登录流程
-   *
-   * @param loginDto 登录信息
-   * @param generateToken Token生成函数
-   * @param createOrUpdateDevice 设备创建/更新函数（可选）
-   * @returns 登录响应
-   * @throws BadRequestException 当TFA参数不完整时抛出
-   * @throws UnauthorizedException 当验证失败或用户状态异常时抛出
-   */
+  async setupTfa(
+    userGuid: string,
+  ): Promise<{ secret: string; otpauth_url: string }> {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userGuid })
+      .addSelect('user.tfaSecret')
+      .addSelect('user.info')
+      .getOne();
+
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    if (user.tfaSecret) {
+      throw new BadRequestException('2FA已启用，如需重新设置请先禁用');
+    }
+
+    const secret = authenticator.generateSecret();
+    const otpauthUrl = authenticator.keyuri(user.username, 'RustDesk', secret);
+
+    const userInfo = user.getUserInfo();
+    userInfo.other = userInfo.other || {};
+    userInfo.other.tfa_pending_secret = secret;
+    user.setUserInfo(userInfo);
+
+    await this.userRepository.save(user);
+
+    return {
+      secret,
+      otpauth_url: otpauthUrl,
+    };
+  }
+
+  async verifyAndBindTfa(
+    userGuid: string,
+    code: string,
+  ): Promise<{ message: string }> {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userGuid })
+      .addSelect('user.tfaSecret')
+      .addSelect('user.info')
+      .getOne();
+
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    if (user.tfaSecret) {
+      throw new BadRequestException('2FA已启用');
+    }
+
+    const userInfo = user.getUserInfo();
+    const other = userInfo.other || {};
+    const pendingSecret = other.tfa_pending_secret as string | undefined;
+
+    if (!pendingSecret) {
+      throw new BadRequestException('请先调用setup接口生成2FA密钥');
+    }
+
+    const isValid = this.verifyTfaCode(pendingSecret, code);
+    if (!isValid) {
+      throw new UnauthorizedException('验证码错误，请重试');
+    }
+
+    user.tfaSecret = pendingSecret;
+
+    delete other.tfa_pending_secret;
+    userInfo.other = other;
+    user.setUserInfo(userInfo);
+
+    await this.userRepository.save(user);
+
+    return { message: '2FA绑定成功' };
+  }
+
+  async disableTfa(
+    userGuid: string,
+    code: string,
+  ): Promise<{ message: string }> {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userGuid })
+      .addSelect('user.tfaSecret')
+      .addSelect('user.info')
+      .getOne();
+
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    if (!user.tfaSecret) {
+      throw new BadRequestException('2FA未启用');
+    }
+
+    const userInfo = user.getUserInfo();
+    if (userInfo?.other?.tfa_enforce) {
+      throw new BadRequestException('管理员已强制要求开启2FA，无法禁用');
+    }
+
+    const isValid = this.verifyTfaCode(user.tfaSecret, code);
+    if (!isValid) {
+      throw new UnauthorizedException('验证码错误');
+    }
+
+    user.tfaSecret = '';
+    await this.userRepository.save(user);
+
+    return { message: '2FA已禁用' };
+  }
+
   async handleTfaLogin(
     loginDto: LoginDto,
     generateToken: (
@@ -77,18 +161,15 @@ export class AuthTfaService {
   ): Promise<LoginResponse> {
     const { username, tfaCode, secret, id, uuid, deviceInfo } = loginDto;
 
-    // 验证参数完整性
     if (!tfaCode || !secret) {
       throw new BadRequestException({ error: '双因素认证参数不完整' });
     }
 
-    // 验证TFA代码
     const isValidTfa = this.verifyTfaCode(secret, tfaCode);
     if (!isValidTfa) {
       throw new UnauthorizedException({ error: '双因素认证验证码错误' });
     }
 
-    // 查找用户
     const user = await this.userRepository
       .createQueryBuilder('user')
       .where('user.username = :username OR user.email = :email', {
@@ -104,23 +185,18 @@ export class AuthTfaService {
       throw new UnauthorizedException({ error: '用户不存在' });
     }
 
-    // 验证secret是否与用户的tfaSecret匹配
     if (user.tfaSecret !== secret) {
       throw new UnauthorizedException({ error: '双因素认证参数无效' });
     }
 
-    // 检查用户状态
     if (user.status === UserStatus.DISABLED) {
-      // UserStatus.DISABLED
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
 
-    // 创建设备记录
     if (createOrUpdateDevice && (id || uuid)) {
       await createOrUpdateDevice(user.guid, id, uuid, deviceInfo);
     }
 
-    // 生成Token
     const token = await generateToken(user, id, uuid);
 
     this.logger.log(`用户 ${username} TFA认证成功，已登录`);

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -200,7 +200,6 @@ export class AuthService {
     // 检查是否需要双因素认证
     if (user.tfaSecret) {
       if (!tfaCode) {
-        // 返回TFA验证提示
         return {
           type: 'tfa_check',
           tfa_type: 'tfa_check',
@@ -216,11 +215,23 @@ export class AuthService {
           },
         };
       }
-      // 验证TFA代码
       const isValidTfa = this.tfaService.verifyTfaCode(user.tfaSecret, tfaCode);
       if (!isValidTfa) {
         throw new UnauthorizedException({ error: '双因素认证验证码错误' });
       }
+    } else if (userInfo?.other?.tfa_enforce) {
+      return {
+        type: 'enforce_tfa',
+        user: {
+          name: user.username,
+          email: user.email || undefined,
+          note: user.note || undefined,
+          status: user.status,
+          info: user.getUserInfo(),
+          is_admin: user.isAdmin,
+          third_auth_type: user.thirdAuthType || undefined,
+        },
+      };
     }
 
     // 创建或更新设备记录

--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -74,10 +74,6 @@ export class UpdateUserSecurityDto {
   @IsOptional()
   tfa_enforce?: boolean;
 
-  @IsString()
-  @IsOptional()
-  tfa_url?: string;
-
   @IsBoolean()
   @IsOptional()
   email_verification?: boolean;
@@ -140,10 +136,6 @@ export class BatchSecurityDto {
   @IsBoolean()
   @IsOptional()
   tfa_enforce?: boolean;
-
-  @IsString()
-  @IsOptional()
-  tfa_url?: string;
 
   @IsBoolean()
   @IsOptional()

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -325,10 +325,6 @@ export class UserService {
       userInfo.other.tfa_enforce = dto.tfa_enforce;
     }
 
-    if (dto.tfa_url !== undefined) {
-      userInfo.other.tfa_url = dto.tfa_url;
-    }
-
     if (dto.email_verification !== undefined) {
       userInfo.email_verification = dto.email_verification;
     }
@@ -408,7 +404,7 @@ export class UserService {
   }
 
   async batchUpdateSecurity(dto: BatchSecurityDto) {
-    const { user_guids, tfa_enforce, tfa_url, email_verification } = dto;
+    const { user_guids, tfa_enforce, email_verification } = dto;
     const users = await this.userRepository.find({
       where: { guid: In(user_guids) },
     });
@@ -423,10 +419,6 @@ export class UserService {
 
       if (tfa_enforce !== undefined) {
         userInfo.other.tfa_enforce = tfa_enforce;
-      }
-
-      if (tfa_url !== undefined) {
-        userInfo.other.tfa_url = tfa_url;
       }
 
       if (email_verification !== undefined) {


### PR DESCRIPTION
## Summary

Implement a complete, secure 2FA setup flow where users generate and bind their own TOTP secrets, and remove the insecure `tfa_url` field.

## Security Issues Fixed

1. **Removed `tfa_url`** — Admin-specified URL was stored but never used, and posed potential open-redirect risk
2. **`tfa_enforce` now actually works** — Previously stored but never read during login; now returns `enforce_tfa` response when user has no `tfaSecret`
3. **2FA setup is user-controlled** — Users generate their own TOTP secret and bind it via verification, following the principle that the second factor must be owned by the user

## New Endpoints

| Method | Path | Description | Auth |
|--------|------|-------------|------|
| `POST` | `/2fa/setup` | Generate TOTP secret + otpauth URL | Any authenticated user |
| `POST` | `/2fa/verify` | Verify TOTP code and bind secret | Any authenticated user |
| `DELETE` | `/2fa` | Disable 2FA (blocked if enforced) | Any authenticated user |

## 2FA Setup Flow

```
1. POST /2fa/setup → { secret, otpauth_url }
   - Generates TOTP secret using otplib
   - Stores as tfa_pending_secret in user.info (NOT yet active)
   - Returns otpauth URL for QR code generation

2. User scans QR code with authenticator app

3. POST /2fa/verify { code } → { message: "2FA绑定成功" }
   - Verifies the TOTP code against pending secret
   - Moves pending secret to user.tfaSecret (now active)
   - Clears tfa_pending_secret

4. DELETE /2fa { code } → { message: "2FA已禁用" }
   - Requires current TOTP code verification
   - Blocked if tfa_enforce is active (admin-forced)
```

## Login Flow Enhancement

When `tfa_enforce=true` but user has no `tfaSecret`:
```json
{
  "type": "enforce_tfa",
  "user": { "name": "...", ... }
}
```
Frontend should redirect user to 2FA setup page.

## Removed

- `tfa_url` field from `UpdateUserSecurityDto` and `BatchSecurityDto`
- `tfa_url` storage logic from `UserService.updateUserSecurity()` and `batchUpdateSecurity()`

## Test Plan
- [ ] Setup 2FA: generate secret, scan QR, verify and bind
- [ ] Login with 2FA: tfa_check flow works correctly
- [ ] Enforce 2FA: admin sets tfa_enforce, user gets enforce_tfa on login
- [ ] Disable 2FA: works when not enforced, blocked when enforced
- [ ] Verify tfa_url is completely removed from all DTOs and services