### PR TITLE
refactor(strategy): remove modifiedAt, simplify list response, support batch assign/unassign

### DIFF
--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -103,13 +103,13 @@ export class HeartbeatService {
         return null;
       }
 
-      if (strategy.modifiedAt > clientModifiedAt) {
+      if (strategy.updatedAt.getTime() > clientModifiedAt) {
         const configOptions: Record<string, string> = JSON.parse(
           strategy.configOptions || '{}',
         ) as Record<string, string>;
         return {
           config_options: configOptions,
-          modified_at: strategy.modifiedAt,
+          modified_at: strategy.updatedAt.getTime(),
         };
       }
 

--- a/src/modules/strategy/dto/strategy.dto.ts
+++ b/src/modules/strategy/dto/strategy.dto.ts
@@ -6,6 +6,8 @@ import {
   IsNumber,
   Min,
   IsInt,
+  IsArray,
+  ArrayMaxSize,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -42,9 +44,10 @@ export class AssignStrategyDto {
   @IsNotEmpty()
   target_type: 'device' | 'user' | 'device_group';
 
-  @IsString()
+  @IsArray()
   @IsNotEmpty()
-  target_guid: string;
+  @ArrayMaxSize(200)
+  target_guids: string[];
 }
 
 export class StrategyQueryDto {

--- a/src/modules/strategy/entities/strategy.entity.ts
+++ b/src/modules/strategy/entities/strategy.entity.ts
@@ -22,9 +22,6 @@ export class Strategy {
   @Column({ type: 'text', nullable: true })
   configOptions: string;
 
-  @Column({ type: 'bigint', default: 0 })
-  modifiedAt: number;
-
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/modules/strategy/strategy.controller.ts
+++ b/src/modules/strategy/strategy.controller.ts
@@ -71,7 +71,7 @@ export class StrategyController {
     return this.strategyService.assignStrategy(
       guid,
       dto.target_type,
-      dto.target_guid,
+      dto.target_guids,
     );
   }
 
@@ -81,7 +81,7 @@ export class StrategyController {
   async unassignStrategy(@Body() dto: AssignStrategyDto) {
     return this.strategyService.unassignStrategy(
       dto.target_type,
-      dto.target_guid,
+      dto.target_guids,
     );
   }
 }

--- a/src/modules/strategy/strategy.service.ts
+++ b/src/modules/strategy/strategy.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import * as uuid from 'uuid';
 import { Strategy } from './entities/strategy.entity';
 import { Peer } from '../../common/entities/peer.entity';
@@ -47,7 +47,6 @@ export class StrategyService {
     strategy.configOptions = dto.config_options
       ? JSON.stringify(dto.config_options)
       : '';
-    strategy.modifiedAt = Date.now();
 
     await this.strategyRepository.save(strategy);
 
@@ -56,7 +55,7 @@ export class StrategyService {
       name: strategy.name,
       note: strategy.note,
       config_options: dto.config_options || {},
-      modified_at: strategy.modifiedAt,
+      updated_at: strategy.updatedAt,
     };
   }
 
@@ -86,8 +85,6 @@ export class StrategyService {
       strategy.configOptions = JSON.stringify(dto.config_options);
     }
 
-    strategy.modifiedAt = Date.now();
-
     await this.strategyRepository.save(strategy);
 
     const configOptions: Record<string, string> = dto.config_options
@@ -99,7 +96,7 @@ export class StrategyService {
       name: strategy.name,
       note: strategy.note,
       config_options: configOptions,
-      modified_at: strategy.modifiedAt,
+      updated_at: strategy.updatedAt,
     };
   }
 
@@ -137,12 +134,6 @@ export class StrategyService {
         guid: s.guid,
         name: s.name,
         note: s.note || '',
-        config_options: JSON.parse(s.configOptions || '{}') as Record<
-          string,
-          string
-        >,
-        modified_at: s.modifiedAt,
-        created_at: s.createdAt,
         updated_at: s.updatedAt,
       })),
       total,
@@ -165,8 +156,6 @@ export class StrategyService {
         string,
         string
       >,
-      modified_at: strategy.modifiedAt,
-      created_at: strategy.createdAt,
       updated_at: strategy.updatedAt,
     };
   }
@@ -174,7 +163,7 @@ export class StrategyService {
   async assignStrategy(
     strategyGuid: string,
     targetType: string,
-    targetGuid: string,
+    targetGuids: string[],
   ) {
     const strategy = await this.strategyRepository.findOne({
       where: { guid: strategyGuid },
@@ -183,44 +172,65 @@ export class StrategyService {
       throw new NotFoundException('策略不存在');
     }
 
+    const success: string[] = [];
+    const errors: { target_guid: string; reason: string }[] = [];
+
     switch (targetType) {
       case 'device': {
-        const peer = await this.peerRepository.findOne({
-          where: { uuid: targetGuid },
+        const peers = await this.peerRepository.find({
+          where: { uuid: In(targetGuids) },
         });
-        if (!peer) {
-          throw new NotFoundException('设备不存在');
+        const foundUuids = new Set(peers.map((p) => p.uuid));
+        for (const targetGuid of targetGuids) {
+          if (!foundUuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '设备不存在' });
+          }
         }
-        await this.peerRepository.update(
-          { uuid: targetGuid },
-          { strategyGuid },
-        );
+        if (peers.length > 0) {
+          await this.peerRepository.update(
+            { uuid: In(peers.map((p) => p.uuid)) },
+            { strategyGuid },
+          );
+          success.push(...peers.map((p) => p.uuid));
+        }
         break;
       }
       case 'user': {
-        const user = await this.userRepository.findOne({
-          where: { guid: targetGuid },
+        const users = await this.userRepository.find({
+          where: { guid: In(targetGuids) },
         });
-        if (!user) {
-          throw new NotFoundException('用户不存在');
+        const foundGuids = new Set(users.map((u) => u.guid));
+        for (const targetGuid of targetGuids) {
+          if (!foundGuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '用户不存在' });
+          }
         }
-        await this.userRepository.update(
-          { guid: targetGuid },
-          { strategyGuid },
-        );
+        if (users.length > 0) {
+          await this.userRepository.update(
+            { guid: In(users.map((u) => u.guid)) },
+            { strategyGuid },
+          );
+          success.push(...users.map((u) => u.guid));
+        }
         break;
       }
       case 'device_group': {
-        const group = await this.deviceGroupRepository.findOne({
-          where: { guid: targetGuid },
+        const groups = await this.deviceGroupRepository.find({
+          where: { guid: In(targetGuids) },
         });
-        if (!group) {
-          throw new NotFoundException('设备组不存在');
+        const foundGuids = new Set(groups.map((g) => g.guid));
+        for (const targetGuid of targetGuids) {
+          if (!foundGuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
+          }
         }
-        await this.deviceGroupRepository.update(
-          { guid: targetGuid },
-          { strategyGuid },
-        );
+        if (groups.length > 0) {
+          await this.deviceGroupRepository.update(
+            { guid: In(groups.map((g) => g.guid)) },
+            { strategyGuid },
+          );
+          success.push(...groups.map((g) => g.guid));
+        }
         break;
       }
       default:
@@ -229,48 +239,69 @@ export class StrategyService {
         );
     }
 
-    return { message: '策略分配成功' };
+    return { success, errors };
   }
 
-  async unassignStrategy(targetType: string, targetGuid: string) {
+  async unassignStrategy(targetType: string, targetGuids: string[]) {
+    const success: string[] = [];
+    const errors: { target_guid: string; reason: string }[] = [];
+
     switch (targetType) {
       case 'device': {
-        const peer = await this.peerRepository.findOne({
-          where: { uuid: targetGuid },
+        const peers = await this.peerRepository.find({
+          where: { uuid: In(targetGuids) },
         });
-        if (!peer) {
-          throw new NotFoundException('设备不存在');
+        const foundUuids = new Set(peers.map((p) => p.uuid));
+        for (const targetGuid of targetGuids) {
+          if (!foundUuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '设备不存在' });
+          }
         }
-        await this.peerRepository.update(
-          { uuid: targetGuid },
-          { strategyGuid: null },
-        );
+        if (peers.length > 0) {
+          await this.peerRepository.update(
+            { uuid: In(peers.map((p) => p.uuid)) },
+            { strategyGuid: null },
+          );
+          success.push(...peers.map((p) => p.uuid));
+        }
         break;
       }
       case 'user': {
-        const user = await this.userRepository.findOne({
-          where: { guid: targetGuid },
+        const users = await this.userRepository.find({
+          where: { guid: In(targetGuids) },
         });
-        if (!user) {
-          throw new NotFoundException('用户不存在');
+        const foundGuids = new Set(users.map((u) => u.guid));
+        for (const targetGuid of targetGuids) {
+          if (!foundGuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '用户不存在' });
+          }
         }
-        await this.userRepository.update(
-          { guid: targetGuid },
-          { strategyGuid: null },
-        );
+        if (users.length > 0) {
+          await this.userRepository.update(
+            { guid: In(users.map((u) => u.guid)) },
+            { strategyGuid: null },
+          );
+          success.push(...users.map((u) => u.guid));
+        }
         break;
       }
       case 'device_group': {
-        const group = await this.deviceGroupRepository.findOne({
-          where: { guid: targetGuid },
+        const groups = await this.deviceGroupRepository.find({
+          where: { guid: In(targetGuids) },
         });
-        if (!group) {
-          throw new NotFoundException('设备组不存在');
+        const foundGuids = new Set(groups.map((g) => g.guid));
+        for (const targetGuid of targetGuids) {
+          if (!foundGuids.has(targetGuid)) {
+            errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
+          }
         }
-        await this.deviceGroupRepository.update(
-          { guid: targetGuid },
-          { strategyGuid: null },
-        );
+        if (groups.length > 0) {
+          await this.deviceGroupRepository.update(
+            { guid: In(groups.map((g) => g.guid)) },
+            { strategyGuid: null },
+          );
+          success.push(...groups.map((g) => g.guid));
+        }
         break;
       }
       default:
@@ -279,7 +310,7 @@ export class StrategyService {
         );
     }
 
-    return { message: '策略取消分配成功' };
+    return { success, errors };
   }
 
   async findStrategyForDevice(deviceUuid: string): Promise<Strategy | null> {


### PR DESCRIPTION
## Summary

This PR refactors the strategy module with the following improvements:

### 1. Remove redundant `modifiedAt` field from Strategy entity
- The `modifiedAt` (bigint, manually maintained) and `updatedAt` (Date, TypeORM auto-managed) fields were semantically identical
- Removed `modifiedAt` column, now using `updatedAt` for all modification time tracking
- Updated heartbeat service to use `strategy.updatedAt.getTime()` for incremental sync comparison
- Heartbeat response still returns `modified_at` (as Unix timestamp) for client compatibility

### 2. Simplify strategy list API response
- `GET /strategies` now returns only basic fields: `guid`, `name`, `note`, `updated_at`
- Removed `config_options` from list response (potentially large JSON, not needed for browsing)
- Removed `created_at` from list response
- Full details available via `GET /strategies/:guid` detail endpoint

### 3. Unify API responses to return `updated_at` only
- All strategy management APIs now return `updated_at` instead of both `modified_at` and `updated_at`
- Eliminates confusion from having two fields with the same meaning

### 4. Support batch operations for assign/unassign
- Changed `AssignStrategyDto.target_guid` (single string) to `target_guids` (string array)
- Added `ArrayMaxSize(200)` validation to prevent excessive batch sizes
- Implemented best-effort batch operations: successful targets in `success` array, failed targets in `errors` array with reason
- Uses TypeORM `In()` operator for efficient batch database queries

## Files Changed
- `src/modules/strategy/entities/strategy.entity.ts` - Removed `modifiedAt` column
- `src/modules/strategy/dto/strategy.dto.ts` - Updated `AssignStrategyDto` for batch support
- `src/modules/strategy/strategy.service.ts` - All service method updates
- `src/modules/strategy/strategy.controller.ts` - Controller updates for new DTO
- `src/modules/heartbeat/heartbeat.service.ts` - Use `updatedAt` instead of `modifiedAt`