### PR TITLE
feat(strategy): add assignments query API

### DIFF
--- a/src/modules/strategy/dto/strategy.dto.ts
+++ b/src/modules/strategy/dto/strategy.dto.ts
@@ -8,6 +8,7 @@ import {
   IsInt,
   IsArray,
   ArrayMaxSize,
+  IsIn,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -66,4 +67,23 @@ export class StrategyQueryDto {
   @IsString()
   @IsOptional()
   name?: string;
+}
+
+export class AssignmentQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['device', 'user', 'device_group'])
+  target_type: 'device' | 'user' | 'device_group';
+
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  current: number;
+
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  pageSize: number;
 }

--- a/src/modules/strategy/strategy.controller.ts
+++ b/src/modules/strategy/strategy.controller.ts
@@ -17,6 +17,7 @@ import {
   UpdateStrategyDto,
   AssignStrategyDto,
   StrategyQueryDto,
+  AssignmentQueryDto,
 } from './dto/strategy.dto';
 import { AdminGuard } from '../../common/guards/admin.guard';
 
@@ -34,6 +35,15 @@ export class StrategyController {
   @UseGuards(AdminGuard)
   async getStrategy(@Param('guid') guid: string) {
     return this.strategyService.getStrategy(guid);
+  }
+
+  @Get('strategies/:guid/assignments')
+  @UseGuards(AdminGuard)
+  async getStrategyAssignments(
+    @Param('guid') guid: string,
+    @Query() query: AssignmentQueryDto,
+  ) {
+    return this.strategyService.getStrategyAssignments(guid, query);
   }
 
   @Post('strategies')

--- a/src/modules/strategy/strategy.service.ts
+++ b/src/modules/strategy/strategy.service.ts
@@ -15,6 +15,7 @@ import {
   CreateStrategyDto,
   UpdateStrategyDto,
   StrategyQueryDto,
+  AssignmentQueryDto,
 } from './dto/strategy.dto';
 
 @Injectable()
@@ -311,6 +312,78 @@ export class StrategyService {
     }
 
     return { success, errors };
+  }
+
+  async getStrategyAssignments(guid: string, query: AssignmentQueryDto) {
+    const strategy = await this.strategyRepository.findOne({
+      where: { guid },
+    });
+    if (!strategy) {
+      throw new NotFoundException('策略不存在');
+    }
+
+    const { target_type, current, pageSize } = query;
+    const skip = (current - 1) * pageSize;
+
+    switch (target_type) {
+      case 'device': {
+        const [peers, total] = await this.peerRepository.findAndCount({
+          where: { strategyGuid: guid },
+          select: ['uuid', 'id', 'status'],
+          skip,
+          take: pageSize,
+          order: { id: 'ASC' },
+        });
+        return {
+          data: peers.map((p) => ({
+            uuid: p.uuid,
+            id: p.id,
+            status: p.status,
+          })),
+          total,
+        };
+      }
+      case 'user': {
+        const [users, total] = await this.userRepository.findAndCount({
+          where: { strategyGuid: guid },
+          select: ['guid', 'username', 'email', 'status', 'isAdmin'],
+          skip,
+          take: pageSize,
+          order: { username: 'ASC' },
+        });
+        return {
+          data: users.map((u) => ({
+            guid: u.guid,
+            username: u.username,
+            email: u.email,
+            status: u.status,
+            is_admin: u.isAdmin,
+          })),
+          total,
+        };
+      }
+      case 'device_group': {
+        const [groups, total] = await this.deviceGroupRepository.findAndCount({
+          where: { strategyGuid: guid },
+          select: ['guid', 'name', 'note'],
+          skip,
+          take: pageSize,
+          order: { name: 'ASC' },
+        });
+        return {
+          data: groups.map((g) => ({
+            guid: g.guid,
+            name: g.name,
+            note: g.note || '',
+          })),
+          total,
+        };
+      }
+      default:
+        throw new BadRequestException(
+          `不支持的目标类型: ${String(target_type)}`,
+        );
+    }
   }
 
   async findStrategyForDevice(deviceUuid: string): Promise<Strategy | null> {


### PR DESCRIPTION
## Summary

Add a dedicated API endpoint to query which devices, users, and device groups a strategy has been assigned to.

### New Endpoint

**`GET /strategies/:guid/assignments`**

Query parameters:
- `target_type` (required): `device` | `user` | `device_group`
- `current` (required): page number, starting from 1
- `pageSize` (required): items per page

Response varies by `target_type`:

**device:**
```json
{ "data": [{ "uuid": "...", "id": "...", "status": 1 }], "total": 100 }
```

**user:**
```json
{ "data": [{ "guid": "...", "username": "...", "email": "...", "status": 1, "is_admin": false }], "total": 50 }
```

**device_group:**
```json
{ "data": [{ "guid": "...", "name": "...", "note": "..." }], "total": 10 }
```

### Design Decisions
- Separate API from `GET /strategies/:guid` to keep strategy detail response lightweight
- `target_type` is required to ensure consistent pagination per type
- Returns only essential fields per target type (no large JSON blobs)
- Frontend can make parallel requests for each type if needed