### PR TITLE
feat: add change password API for current user

### DIFF
--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -7,6 +7,7 @@ import {
   IsNumber,
   Min,
   IsInt,
+  MinLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { UserStatus } from '../entities/user.entity';
@@ -146,4 +147,13 @@ export class BatchSessionsDto {
   @IsArray()
   @IsString({ each: true })
   user_guids: string[];
+}
+
+export class ChangePasswordDto {
+  @IsString()
+  current_password: string;
+
+  @IsString()
+  @MinLength(6)
+  new_password: string;
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -29,6 +29,7 @@ import {
   BatchStatusDto,
   BatchSecurityDto,
   BatchSessionsDto,
+  ChangePasswordDto,
 } from './dto/user.dto';
 
 @Controller()
@@ -58,6 +59,16 @@ export class UserController {
     @Body() dto: UpdateCurrentUserDto,
   ) {
     return this.userService.updateCurrentUser(userId, dto);
+  }
+
+  @Patch('users/me/password')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @HttpCode(HttpStatus.OK)
+  async changePassword(
+    @CurrentUser('id') userId: string,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    return this.userService.changePassword(userId, dto);
   }
 
   @Post('users/me/avatar')

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -22,6 +22,7 @@ import {
   UpdateCurrentUserDto,
   BatchStatusDto,
   BatchSecurityDto,
+  ChangePasswordDto,
 } from './dto/user.dto';
 
 const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
@@ -329,6 +330,40 @@ export class UserService {
     await this.userRepository.save(user);
 
     return { message: '用户信息已更新' };
+  }
+
+  async changePassword(userId: string, dto: ChangePasswordDto) {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userId })
+      .addSelect('user.password')
+      .addSelect('user.thirdAuthType')
+      .getOne();
+
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    if (user.thirdAuthType) {
+      throw new BadRequestException('第三方登录用户不支持修改密码');
+    }
+
+    if (!user.password) {
+      throw new BadRequestException('当前账户未设置密码，请联系管理员');
+    }
+
+    const isPasswordValid = await bcrypt.compare(
+      dto.current_password,
+      user.password,
+    );
+    if (!isPasswordValid) {
+      throw new BadRequestException('当前密码错误');
+    }
+
+    user.password = await bcrypt.hash(dto.new_password, 10);
+    await this.userRepository.save(user);
+
+    return { message: '密码修改成功' };
   }
 
   async updateUserSecurity(guid: string, dto: UpdateUserSecurityDto) {


### PR DESCRIPTION
## Summary

Add `PATCH /api/users/me/password` endpoint that allows authenticated users to change their own password.

## Details

- **New DTO**: `ChangePasswordDto` with `current_password` (required) and `new_password` (required, min 6 chars)
- **New endpoint**: `PATCH /api/users/me/password` — rate-limited to 5 requests/minute
- **Security checks**:
  - Verifies current password before allowing change
  - Rejects third-party auth (OIDC) users
  - Rejects users without a password set
- **Password hashing**: Uses bcrypt with 10 salt rounds (consistent with existing code)

## Files Changed

- `src/modules/user/dto/user.dto.ts` — Added `ChangePasswordDto`
- `src/modules/user/user.service.ts` — Added `changePassword` method
- `src/modules/user/user.controller.ts` — Added `PATCH users/me/password` endpoint