### PR TITLE
fix(user): specify varchar type for avatar column

### DIFF
--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -138,7 +138,7 @@ export class User {
   @Index()
   oidcSubject: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   avatar: string | null;
 
   @Column({ type: 'varchar', nullable: true })


### PR DESCRIPTION
## Problem
SQLite database does not support `Object` type. The `avatar` column in User entity was missing explicit type definition, causing TypeORM to infer an unsupported type.

## Solution
Explicitly set the `avatar` column type to `varchar` to ensure SQLite compatibility.

## Changes
- Added `type: 'varchar'` to the `@Column` decorator for the `avatar` field in `user.entity.ts`