### PR TITLE
fix: return full API path for avatar field

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -460,7 +460,8 @@ export class UserService {
   }
 
   private removeAvatarFile(avatarPath: string) {
-    const fullPath = path.join(process.cwd(), avatarPath);
+    const filename = path.basename(avatarPath);
+    const fullPath = path.join(AVATAR_DIR, filename);
     if (fs.existsSync(fullPath)) {
       fs.unlinkSync(fullPath);
     }
@@ -504,7 +505,7 @@ export class UserService {
     this.ensureAvatarDir();
 
     const filename = `${userGuid}.webp`;
-    const relativePath = `avatars/${filename}`;
+    const relativePath = `/api/avatars/${filename}`;
     const fullPath = path.join(AVATAR_DIR, filename);
 
     await sharp(file.buffer)


### PR DESCRIPTION
## Summary

Fix avatar field to return full API path () instead of relative path (), since the client concatenates the avatar value directly with the API base URL.

## Changes
- Change avatar path from  to 
- Fix  to extract filename from full path for correct file deletion