### PR TITLE
fix: unify login response type field to email_check for client compatibility

### DIFF
--- a/src/modules/auth/services/auth-email.service.ts
+++ b/src/modules/auth/services/auth-email.service.ts
@@ -79,7 +79,9 @@ export class AuthEmailService {
     // 发送验证码邮件
     const sent = await this.emailService.sendVerificationCode(user.email, code);
     if (!sent) {
-      throw new BadRequestException({ error: '发送验证码邮件失败，请稍后重试' });
+      throw new BadRequestException({
+        error: '发送验证码邮件失败，请稍后重试',
+      });
     }
 
     this.logger.log(
@@ -145,7 +147,9 @@ export class AuthEmailService {
     });
 
     if (!session) {
-      throw new UnauthorizedException({ error: '验证码已过期或无效，请重新登录' });
+      throw new UnauthorizedException({
+        error: '验证码已过期或无效，请重新登录',
+      });
     }
 
     // 验证验证码

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -204,9 +204,9 @@ export class AuthService {
     if (user.tfaSecret) {
       if (!tfaCode) {
         return {
-        type: 'email_check',
-        tfa_type: 'tfa_check',
-        secret: user.tfaSecret,
+          type: 'email_check',
+          tfa_type: 'tfa_check',
+          secret: user.tfaSecret,
           user: {
             name: user.username,
             email: user.email || undefined,

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -204,9 +204,9 @@ export class AuthService {
     if (user.tfaSecret) {
       if (!tfaCode) {
         return {
-          type: 'tfa_check',
-          tfa_type: 'tfa_check',
-          secret: user.tfaSecret,
+        type: 'email_check',
+        tfa_type: 'tfa_check',
+        secret: user.tfaSecret,
           user: {
             name: user.username,
             email: user.email || undefined,


### PR DESCRIPTION
## Summary
- Fix login response to ensure backward compatibility with legacy clients
- The `type` field in login response now always returns `'email_check'` regardless of `tfa_type` value

## Changes
- Modified `/login` endpoint response in `auth.service.ts`
- Changed `type` field from `'tfa_check'` to `'email_check'` when TFA verification is required
- The `tfa_type` field still correctly indicates `'tfa_check'` or `'email_check'` for server-side logic

## Reason
Due to legacy client issues, the `type` field should always be `'email_check'` for client compatibility, while `tfa_type` can be used to distinguish the actual verification type on the server side.