### PR TITLE
feat: add admin users API for management-side user queries

### DIFF
--- a/src/modules/user/admin-user.controller.ts
+++ b/src/modules/user/admin-user.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  Param,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -17,10 +16,5 @@ export class AdminUserController {
   @Get()
   async getAdminUsers(@Query() query: AdminUserQueryDto) {
     return this.adminUserService.getAdminUsers(query);
-  }
-
-  @Get(':guid')
-  async getAdminUser(@Param('guid') guid: string) {
-    return this.adminUserService.getAdminUser(guid);
   }
 }

--- a/src/modules/user/admin-user.controller.ts
+++ b/src/modules/user/admin-user.controller.ts
@@ -1,0 +1,26 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminUserService } from './admin-user.service';
+import { AdminGuard } from '../../common/guards/admin.guard';
+import { AdminUserQueryDto } from './dto/admin-user.dto';
+
+@Controller('admin/users')
+@UseGuards(AdminGuard)
+export class AdminUserController {
+  constructor(private readonly adminUserService: AdminUserService) {}
+
+  @Get()
+  async getAdminUsers(@Query() query: AdminUserQueryDto) {
+    return this.adminUserService.getAdminUsers(query);
+  }
+
+  @Get(':guid')
+  async getAdminUser(@Param('guid') guid: string) {
+    return this.adminUserService.getAdminUser(guid);
+  }
+}

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
@@ -92,36 +92,6 @@ export class AdminUserService {
         updated_at: u.updatedAt,
       })),
       total,
-    };
-  }
-
-  async getAdminUser(guid: string) {
-    const user = await this.userRepository.findOne({ where: { guid } });
-    if (!user) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    let strategyName = '';
-    if (user.strategyGuid) {
-      const strategy = await this.strategyRepository.findOne({
-        where: { guid: user.strategyGuid },
-      });
-      strategyName = strategy?.name || '';
-    }
-
-    return {
-      guid: user.guid,
-      name: user.username,
-      email: user.email || '',
-      note: user.note || '',
-      status: user.status,
-      is_admin: user.isAdmin,
-      third_auth_type: user.thirdAuthType || '',
-      strategy_guid: user.strategyGuid || '',
-      strategy_name: strategyName,
-      avatar: user.avatar || '',
-      created_at: user.createdAt,
-      updated_at: user.updatedAt,
     };
   }
 }

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -1,0 +1,127 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+import { Strategy } from '../strategy/entities/strategy.entity';
+import { AdminUserQueryDto } from './dto/admin-user.dto';
+
+@Injectable()
+export class AdminUserService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(Strategy)
+    private strategyRepository: Repository<Strategy>,
+  ) {}
+
+  async getAdminUsers(
+    query: AdminUserQueryDto,
+  ): Promise<{ data: any[]; total: number }> {
+    const { current, pageSize, status, name, email, is_admin, third_auth_type, strategy_name } = query;
+    const skip = (current - 1) * pageSize;
+
+    const queryBuilder = this.userRepository.createQueryBuilder('user');
+
+    if (status !== undefined) {
+      queryBuilder.andWhere('user.status = :status', { status });
+    }
+
+    if (name) {
+      queryBuilder.andWhere('user.username LIKE :name', { name: `%${name}%` });
+    }
+
+    if (email) {
+      queryBuilder.andWhere('user.email LIKE :email', { email: `%${email}%` });
+    }
+
+    if (is_admin !== undefined) {
+      queryBuilder.andWhere('user.isAdmin = :isAdmin', { isAdmin: is_admin });
+    }
+
+    if (third_auth_type) {
+      queryBuilder.andWhere('user.thirdAuthType = :thirdAuthType', {
+        thirdAuthType: third_auth_type,
+      });
+    }
+
+    if (strategy_name) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM strategies s
+          WHERE s.guid = user.strategyGuid AND s.name LIKE :strategyName
+        )`,
+        { strategyName: `%${strategy_name}%` },
+      );
+    }
+
+    const [users, total] = await queryBuilder
+      .orderBy('user.createdAt', 'DESC')
+      .skip(skip)
+      .take(pageSize)
+      .getManyAndCount();
+
+    // Batch load strategy names
+    const strategyGuids = [
+      ...new Set(
+        users
+          .map((u) => u.strategyGuid)
+          .filter((g): g is string => g != null),
+      ),
+    ];
+    const strategies =
+      strategyGuids.length > 0
+        ? await this.strategyRepository.find({
+            where: strategyGuids.map((guid) => ({ guid })),
+          })
+        : [];
+    const strategyMap = new Map(strategies.map((s) => [s.guid, s.name]));
+
+    return {
+      data: users.map((u) => ({
+        guid: u.guid,
+        name: u.username,
+        email: u.email || '',
+        note: u.note || '',
+        status: u.status,
+        is_admin: u.isAdmin,
+        third_auth_type: u.thirdAuthType || '',
+        strategy_guid: u.strategyGuid || '',
+        strategy_name: u.strategyGuid ? strategyMap.get(u.strategyGuid) || '' : '',
+        avatar: u.avatar || '',
+        created_at: u.createdAt,
+        updated_at: u.updatedAt,
+      })),
+      total,
+    };
+  }
+
+  async getAdminUser(guid: string) {
+    const user = await this.userRepository.findOne({ where: { guid } });
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    let strategyName = '';
+    if (user.strategyGuid) {
+      const strategy = await this.strategyRepository.findOne({
+        where: { guid: user.strategyGuid },
+      });
+      strategyName = strategy?.name || '';
+    }
+
+    return {
+      guid: user.guid,
+      name: user.username,
+      email: user.email || '',
+      note: user.note || '',
+      status: user.status,
+      is_admin: user.isAdmin,
+      third_auth_type: user.thirdAuthType || '',
+      strategy_guid: user.strategyGuid || '',
+      strategy_name: strategyName,
+      avatar: user.avatar || '',
+      created_at: user.createdAt,
+      updated_at: user.updatedAt,
+    };
+  }
+}

--- a/src/modules/user/dto/admin-user.dto.ts
+++ b/src/modules/user/dto/admin-user.dto.ts
@@ -1,0 +1,51 @@
+import {
+  IsString,
+  IsNumber,
+  Min,
+  IsInt,
+  IsOptional,
+  IsBoolean,
+  IsEnum,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { UserStatus } from '../entities/user.entity';
+
+export class AdminUserQueryDto {
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  current: number;
+
+  @IsNumber()
+  @Min(1)
+  @IsInt()
+  @Type(() => Number)
+  pageSize: number;
+
+  @IsEnum(UserStatus)
+  @IsOptional()
+  @Type(() => Number)
+  status?: UserStatus;
+
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  email?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @Type(() => Boolean)
+  is_admin?: boolean;
+
+  @IsString()
+  @IsOptional()
+  third_auth_type?: string;
+
+  @IsString()
+  @IsOptional()
+  strategy_name?: string;
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -2,7 +2,9 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserController } from './user.controller';
 import { AvatarController } from './avatar.controller';
+import { AdminUserController } from './admin-user.controller';
 import { UserService } from './user.service';
+import { AdminUserService } from './admin-user.service';
 import { User } from './entities/user.entity';
 import { UserToken } from './entities/user-token.entity';
 import { Peer, Sysinfo } from '../../common/entities';
@@ -10,6 +12,7 @@ import { AuthModule } from '../auth/auth.module';
 import { DeviceGroup } from '../device-group/entities/device-group.entity';
 import { DeviceGroupUserPermission } from '../device-group/entities/device-group-user-permission.entity';
 import { UserUserPermission } from '../device-group/entities/user-user-permission.entity';
+import { Strategy } from '../strategy/entities/strategy.entity';
 
 @Module({
   imports: [
@@ -21,11 +24,12 @@ import { UserUserPermission } from '../device-group/entities/user-user-permissio
       DeviceGroup,
       DeviceGroupUserPermission,
       UserUserPermission,
+      Strategy,
     ]),
     AuthModule,
   ],
-  controllers: [UserController, AvatarController],
-  providers: [UserService],
+  controllers: [UserController, AvatarController, AdminUserController],
+  providers: [UserService, AdminUserService],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary

Add dedicated admin endpoints for management-side user queries, separating them from the client-side `/users` endpoint.

## Changes

- **New endpoint**: `GET /admin/users` — Paginated user list with extended filters
- **New endpoint**: `GET /admin/users/:guid` — Single user detail
- **AdminUserQueryDto**: Supports filtering by `status`, `name`, `email`, `is_admin`, `third_auth_type`, `strategy_name`
- **AdminUserService**: Admin-only query logic without client permission checks
- **AdminUserController**: Class-level `AdminGuard`, consistent with project patterns
- **Extended response fields**: `third_auth_type`, `strategy_guid`, `strategy_name`, `avatar`, `created_at`, `updated_at`
- **Return format**: `{ data, total }` consistent with `/peers` endpoint

## API Reference

### GET /admin/users

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| current | number | Yes | Page number (min 1) |
| pageSize | number | Yes | Page size (min 1) |
| status | number | No | User status (-1/0/1) |
| name | string | No | Username fuzzy search |
| email | string | No | Email fuzzy search |
| is_admin | boolean | No | Admin filter |
| third_auth_type | string | No | Third-party auth type exact match |
| strategy_name | string | No | Strategy name fuzzy search |

### GET /admin/users/:guid

Returns full user detail with strategy name resolved.

## Notes

- The existing `GET /users` endpoint remains unchanged for client use
- No migration of other admin operations (create, update, delete) at this time