### PR TITLE
feat: add MySQL database support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,17 @@ ADMIN_USERNAME=admin
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=admin123
 
-# Database Configuration (SQLite by default)
-# For PostgreSQL or MySQL, modify the TypeORM config in app.module.ts
+# Database Configuration
+# DB_TYPE: sqlite (default) or mysql
+DB_TYPE=sqlite
+# MySQL Configuration (required when DB_TYPE=mysql)
+# DB_HOST=localhost
+# DB_PORT=3306
+# DB_USERNAME=root
+# DB_PASSWORD=
+# DB_DATABASE=rustdesk
+# DB_SYNCHRONIZE=true
+# DB_LOGGING=false
 
 # SMTP Configuration (for email verification)
 SMTP_HOST=smtp.example.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "cookie-parser": "^1.4.7",
         "dotenv": "^17.3.1",
         "handlebars": "^4.7.8",
+        "mysql2": "^3.22.4",
         "nodemailer": "^8.0.1",
         "openid-client": "^6.8.4",
         "otplib": "^12.0.1",
@@ -5118,6 +5119,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
@@ -6428,6 +6438,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -7830,6 +7849,15 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmmirror.com/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8608,6 +8636,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -10201,6 +10235,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmmirror.com/lower-case/-/lower-case-1.1.4.tgz",
@@ -10216,6 +10256,21 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/luxon": {
@@ -11417,6 +11472,40 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.4.tgz",
+      "integrity": "sha512-CtXYlmL7ZamiYKbmqkamQHWJROUHSfm+f3kByzGfknw7kW51mcB2ouMUqYq1XfYxbXmnWo6RhPydx6OCqdgcmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/napi-build-utils": {
@@ -13585,6 +13674,21 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
     },
     "node_modules/sql-highlight": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.3.1",
     "handlebars": "^4.7.8",
+    "mysql2": "^3.22.4",
     "nodemailer": "^8.0.1",
     "openid-client": "^6.8.4",
     "otplib": "^12.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { HeartbeatModule } from './modules/heartbeat/heartbeat.module';
@@ -14,29 +14,10 @@ import { OidcModule } from './modules/oidc/oidc.module';
 import { SysinfoModule } from './modules/sysinfo/sysinfo.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { DatabaseModule } from './database/database.module';
-import { Sysinfo, Peer } from './common/entities';
-import { ConnectionAudit } from './modules/audit/entities/connection-audit.entity';
-import { FileAudit } from './modules/audit/entities/file-audit.entity';
-import { AlarmAudit } from './modules/audit/entities/alarm-audit.entity';
-import { AddressBook } from './modules/address-book/entities/address-book.entity';
-import { AddressBookPeer } from './modules/address-book/entities/address-book-peer.entity';
-import { AddressBookTag } from './modules/address-book/entities/address-book-tag.entity';
-import { AddressBookPeerTag } from './modules/address-book/entities/address-book-peer-tag.entity';
-import { AddressBookRule } from './modules/address-book/entities/address-book-rule.entity';
-import { User } from './modules/user/entities/user.entity';
-import { UserToken } from './modules/user/entities/user-token.entity';
-import { OidcProvider } from './modules/oidc/entities/oidc-provider.entity';
-import { OidcAuthState } from './modules/oidc/entities/oidc-auth-state.entity';
-import { DeviceGroup } from './modules/device-group/entities/device-group.entity';
-import { DeviceGroupUserPermission } from './modules/device-group/entities/device-group-user-permission.entity';
-import { UserUserPermission } from './modules/device-group/entities/user-user-permission.entity';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
-import { EmailVerificationSession } from './modules/auth/entities/email-verification-session.entity';
-import { SystemSetting } from './modules/settings/entities/system-setting.entity';
-import { ActiveConnection } from './modules/heartbeat/entities/active-connection.entity';
 import { SettingsModule } from './modules/settings/settings.module';
 import { StrategyModule } from './modules/strategy/strategy.module';
-import { Strategy } from './modules/strategy/entities/strategy.entity';
+import { getDatabaseConfig } from './database/database.config';
 
 /**
  * 应用根模块
@@ -71,34 +52,10 @@ import { Strategy } from './modules/strategy/entities/strategy.entity';
         limit: 100,
       },
     ]),
-    TypeOrmModule.forRoot({
-      type: 'sqlite',
-      database: 'rustdesk.db',
-      entities: [
-        Sysinfo,
-        Peer,
-        ConnectionAudit,
-        FileAudit,
-        AlarmAudit,
-        AddressBook,
-        AddressBookPeer,
-        AddressBookTag,
-        AddressBookPeerTag,
-        AddressBookRule,
-        User,
-        UserToken,
-        OidcProvider,
-        OidcAuthState,
-        DeviceGroup,
-        DeviceGroupUserPermission,
-        UserUserPermission,
-        EmailVerificationSession,
-        SystemSetting,
-        ActiveConnection,
-        Strategy,
-      ],
-      synchronize: true,
-      logging: false,
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: getDatabaseConfig,
     }),
     DatabaseModule,
     HeartbeatModule,

--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -82,14 +82,14 @@ export class Peer {
    * 版本号
    * 设备信息的版本号
    */
-  @Column()
+  @Column({ type: 'int' })
   ver: number;
 
   /**
    * 修改时间戳
-   * 设备信息最后修改的时间戳
+   * 设备信息最后修改的时间戳（毫秒级Unix时间戳）
    */
-  @Column()
+  @Column({ type: 'bigint' })
   modifiedAt: number;
 
   /**

--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -73,7 +73,7 @@ export class Peer {
    * 1: 正常, 0: 禁用
    */
   @Column({
-    type: 'integer',
+    type: 'int',
     default: PeerStatus.ACTIVE,
   })
   status: PeerStatus;

--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -1,0 +1,90 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import { Sysinfo, Peer } from '../common/entities';
+import { ConnectionAudit } from '../modules/audit/entities/connection-audit.entity';
+import { FileAudit } from '../modules/audit/entities/file-audit.entity';
+import { AlarmAudit } from '../modules/audit/entities/alarm-audit.entity';
+import { AddressBook } from '../modules/address-book/entities/address-book.entity';
+import { AddressBookPeer } from '../modules/address-book/entities/address-book-peer.entity';
+import { AddressBookTag } from '../modules/address-book/entities/address-book-tag.entity';
+import { AddressBookPeerTag } from '../modules/address-book/entities/address-book-peer-tag.entity';
+import { AddressBookRule } from '../modules/address-book/entities/address-book-rule.entity';
+import { User } from '../modules/user/entities/user.entity';
+import { UserToken } from '../modules/user/entities/user-token.entity';
+import { OidcProvider } from '../modules/oidc/entities/oidc-provider.entity';
+import { OidcAuthState } from '../modules/oidc/entities/oidc-auth-state.entity';
+import { DeviceGroup } from '../modules/device-group/entities/device-group.entity';
+import { DeviceGroupUserPermission } from '../modules/device-group/entities/device-group-user-permission.entity';
+import { UserUserPermission } from '../modules/device-group/entities/user-user-permission.entity';
+import { EmailVerificationSession } from '../modules/auth/entities/email-verification-session.entity';
+import { SystemSetting } from '../modules/settings/entities/system-setting.entity';
+import { ActiveConnection } from '../modules/heartbeat/entities/active-connection.entity';
+import { Strategy } from '../modules/strategy/entities/strategy.entity';
+
+const entities = [
+  Sysinfo,
+  Peer,
+  ConnectionAudit,
+  FileAudit,
+  AlarmAudit,
+  AddressBook,
+  AddressBookPeer,
+  AddressBookTag,
+  AddressBookPeerTag,
+  AddressBookRule,
+  User,
+  UserToken,
+  OidcProvider,
+  OidcAuthState,
+  DeviceGroup,
+  DeviceGroupUserPermission,
+  UserUserPermission,
+  EmailVerificationSession,
+  SystemSetting,
+  ActiveConnection,
+  Strategy,
+];
+
+export const getDatabaseConfig = (
+  configService: ConfigService,
+): TypeOrmModuleOptions => {
+  const dbType = configService.get<string>('DB_TYPE', 'sqlite');
+
+  if (dbType === 'mysql') {
+    return {
+      type: 'mysql',
+      host: configService.get<string>('DB_HOST', 'localhost'),
+      port: configService.get<number>('DB_PORT', 3306),
+      username: configService.get<string>('DB_USERNAME', 'root'),
+      password: configService.get<string>('DB_PASSWORD', ''),
+      database: configService.get<string>('DB_DATABASE', 'rustdesk'),
+      entities,
+      synchronize:
+        configService.get<string>('DB_SYNCHRONIZE', 'true') === 'true',
+      logging: configService.get<string>('DB_LOGGING', 'false') === 'true',
+      charset: 'utf8mb4',
+    };
+  }
+
+  // Default: SQLite
+  return {
+    type: 'sqlite',
+    database: configService.get<string>('DB_DATABASE', 'rustdesk.db'),
+    entities,
+    synchronize: true,
+    logging: false,
+  };
+};
+
+// For TypeORM CLI migrations
+export default new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '3306', 10),
+  username: process.env.DB_USERNAME || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_DATABASE || 'rustdesk',
+  entities,
+  migrations: ['src/database/migrations/*.ts'],
+});

--- a/src/modules/audit/entities/alarm-audit.entity.ts
+++ b/src/modules/audit/entities/alarm-audit.entity.ts
@@ -13,7 +13,7 @@ export class AlarmAudit {
   @Column({ type: 'varchar', length: 255 })
   deviceId: string;
 
-  @Column({ type: 'text' })
+  @Column({ type: 'varchar', length: 36 })
   deviceUuid: string;
 
   @Column({ type: 'int' })

--- a/src/modules/audit/entities/connection-audit.entity.ts
+++ b/src/modules/audit/entities/connection-audit.entity.ts
@@ -25,7 +25,7 @@ export class ConnectionAudit {
   @Column({ type: 'varchar', length: 255 })
   deviceId: string;
 
-  @Column({ type: 'text' })
+  @Column({ type: 'varchar', length: 36 })
   deviceUuid: string;
 
   @Column({ type: 'varchar', length: 255, nullable: true })

--- a/src/modules/audit/entities/file-audit.entity.ts
+++ b/src/modules/audit/entities/file-audit.entity.ts
@@ -23,13 +23,13 @@ export class FileAudit {
   @Column({ type: 'varchar', length: 255 })
   deviceId: string;
 
-  @Column({ type: 'text' })
+  @Column({ type: 'varchar', length: 36 })
   deviceUuid: string;
 
   @Column({ type: 'varchar', length: 255 })
   peerId: string;
 
-  @Column({ type: 'int' }) // SQLite 使用 int，其他数据库可以用 enum
+  @Column({ type: 'int' })
   type: number;
 
   @Column({ type: 'text', nullable: true })

--- a/src/modules/auth/entities/email-verification-session.entity.ts
+++ b/src/modules/auth/entities/email-verification-session.entity.ts
@@ -25,7 +25,6 @@ export class EmailVerificationSession {
    * 用于关联验证请求的唯一密钥
    */
   @Column({ unique: true })
-  @Index()
   secret: string;
 
   /**

--- a/src/modules/device-group/entities/device-group.entity.ts
+++ b/src/modules/device-group/entities/device-group.entity.ts
@@ -30,7 +30,6 @@ export class DeviceGroup {
    * 用于显示和区分不同的设备组
    */
   @Column({ unique: true })
-  @Index()
   name: string;
 
   /**

--- a/src/modules/heartbeat/entities/active-connection.entity.ts
+++ b/src/modules/heartbeat/entities/active-connection.entity.ts
@@ -21,7 +21,7 @@ export class ActiveConnection {
    * 连接ID
    * 客户端上报的连接唯一标识
    */
-  @Column({ type: 'integer' })
+  @Column({ type: 'int' })
   @Index()
   connId: number;
 
@@ -29,7 +29,7 @@ export class ActiveConnection {
    * 设备UUID
    * 关联到 peers 表的 uuid 字段
    */
-  @Column({ type: 'text' })
+  @Column({ type: 'varchar', length: 36 })
   @Index()
   deviceUuid: string;
 

--- a/src/modules/oidc/entities/oidc-auth-state.entity.ts
+++ b/src/modules/oidc/entities/oidc-auth-state.entity.ts
@@ -50,7 +50,8 @@ export class OidcAuthState {
   op: string;
 
   @Column({
-    type: 'text',
+    type: 'varchar',
+    length: 20,
     default: OidcProviderType.OIDC,
   })
   providerType: OidcProviderType;
@@ -98,7 +99,8 @@ export class OidcAuthState {
    * cancelled - 已取消
    */
   @Column({
-    type: 'text',
+    type: 'varchar',
+    length: 20,
     default: OidcAuthStatus.PENDING,
   })
   status: OidcAuthStatus;

--- a/src/modules/oidc/entities/oidc-provider.entity.ts
+++ b/src/modules/oidc/entities/oidc-provider.entity.ts
@@ -34,7 +34,8 @@ export class OidcProvider {
   name: string;
 
   @Column({
-    type: 'text',
+    type: 'varchar',
+    length: 20,
     default: OidcProviderType.OIDC,
   })
   type: OidcProviderType;

--- a/src/modules/strategy/entities/strategy.entity.ts
+++ b/src/modules/strategy/entities/strategy.entity.ts
@@ -4,7 +4,6 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
-  Index,
 } from 'typeorm';
 
 @Entity('strategies')
@@ -13,7 +12,6 @@ export class Strategy {
   guid: string;
 
   @Column({ unique: true })
-  @Index()
   name: string;
 
   @Column({ type: 'text', nullable: true })

--- a/src/modules/user/admin-user.controller.ts
+++ b/src/modules/user/admin-user.controller.ts
@@ -1,9 +1,4 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { AdminUserService } from './admin-user.service';
 import { AdminGuard } from '../../common/guards/admin.guard';
 import { AdminUserQueryDto } from './dto/admin-user.dto';

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -17,7 +17,16 @@ export class AdminUserService {
   async getAdminUsers(
     query: AdminUserQueryDto,
   ): Promise<{ data: any[]; total: number }> {
-    const { current, pageSize, status, name, email, is_admin, third_auth_type, strategy_name } = query;
+    const {
+      current,
+      pageSize,
+      status,
+      name,
+      email,
+      is_admin,
+      third_auth_type,
+      strategy_name,
+    } = query;
     const skip = (current - 1) * pageSize;
 
     const queryBuilder = this.userRepository.createQueryBuilder('user');
@@ -63,9 +72,7 @@ export class AdminUserService {
     // Batch load strategy names
     const strategyGuids = [
       ...new Set(
-        users
-          .map((u) => u.strategyGuid)
-          .filter((g): g is string => g != null),
+        users.map((u) => u.strategyGuid).filter((g): g is string => g != null),
       ),
     ];
     const strategies =
@@ -86,7 +93,9 @@ export class AdminUserService {
         is_admin: u.isAdmin,
         third_auth_type: u.thirdAuthType || '',
         strategy_guid: u.strategyGuid || '',
-        strategy_name: u.strategyGuid ? strategyMap.get(u.strategyGuid) || '' : '',
+        strategy_name: u.strategyGuid
+          ? strategyMap.get(u.strategyGuid) || ''
+          : '',
         avatar: u.avatar || '',
         created_at: u.createdAt,
         updated_at: u.updatedAt,

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -88,7 +88,7 @@ export class User {
    * -1: 未验证邮箱, 0: 禁用, 1: 正常
    */
   @Column({
-    type: 'integer',
+    type: 'int',
     default: UserStatus.ACTIVE,
   })
   status: UserStatus;

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -51,7 +51,6 @@ export class User {
    * 用于登录的唯一标识
    */
   @Column({ unique: true })
-  @Index()
   username: string;
 
   /**
@@ -59,7 +58,6 @@ export class User {
    * 用于邮箱验证和通知
    */
   @Column({ unique: true, nullable: true })
-  @Index()
   email: string;
 
   /**
@@ -135,7 +133,6 @@ export class User {
    * 用于关联OIDC提供商中的用户身份，防止账户接管
    */
   @Column({ unique: true, nullable: true })
-  @Index()
   oidcSubject: string;
 
   @Column({ type: 'varchar', nullable: true })


### PR DESCRIPTION
## Summary

Add MySQL database support to the project, allowing users to switch between SQLite and MySQL via environment variables.

## Changes

- **Add mysql2 driver dependency** for MySQL connection support
- **Create `database.config.ts`** with `ConfigService`-based factory function for dynamic SQLite/MySQL switching
- **Refactor `app.module.ts`** to use `TypeOrmModule.forRootAsync` instead of hardcoded SQLite configuration
- **Add environment variables** for database configuration:
  - `DB_TYPE` - Database type: `sqlite` (default) or `mysql`
  - `DB_HOST` - MySQL host (default: `localhost`)
  - `DB_PORT` - MySQL port (default: `3306`)
  - `DB_USERNAME` - MySQL username (default: `root`)
  - `DB_PASSWORD` - MySQL password
  - `DB_DATABASE` - Database name (default: `rustdesk`)
  - `DB_SYNCHRONIZE` - Auto-sync schema (default: `true`)
  - `DB_LOGGING` - Enable SQL logging (default: `false`)
- **Fix entity column types for MySQL compatibility**:
  - `integer` → `int` (Peer.status, User.status, ActiveConnection.connId)
  - `text` → `varchar(36)` for UUID fields (audit entities, ActiveConnection.deviceUuid)
  - `text` → `varchar(20)` for enum fields (OidcProvider.type, OidcAuthState.providerType, OidcAuthState.status)
- **Update `.env.example`** with MySQL configuration options

## Usage

To use MySQL, set the following environment variables:

```env
DB_TYPE=mysql
DB_HOST=localhost
DB_PORT=3306
DB_USERNAME=root
DB_PASSWORD=your-password
DB_DATABASE=rustdesk
```

Without any `DB_TYPE` setting, the project continues to use SQLite as before.

## Testing

- Build passes (`npm run build`)
- Lint passes (`npm run lint`)