### PR TITLE
fix: correct is_admin query parameter handling in admin users API

### DIFF
--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -35,7 +35,7 @@ export class AdminUserService {
     }
 
     if (is_admin !== undefined) {
-      queryBuilder.andWhere('user.isAdmin = :isAdmin', { isAdmin: is_admin });
+      queryBuilder.andWhere('user.isAdmin = :isAdmin', { isAdmin: is_admin === 1 });
     }
 
     if (third_auth_type) {

--- a/src/modules/user/dto/admin-user.dto.ts
+++ b/src/modules/user/dto/admin-user.dto.ts
@@ -4,7 +4,7 @@ import {
   Min,
   IsInt,
   IsOptional,
-  IsBoolean,
+  IsIn,
   IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -36,10 +36,11 @@ export class AdminUserQueryDto {
   @IsOptional()
   email?: string;
 
-  @IsBoolean()
+  @IsNumber()
+  @IsIn([0, 1])
   @IsOptional()
-  @Type(() => Boolean)
-  is_admin?: boolean;
+  @Type(() => Number)
+  is_admin?: number;
 
   @IsString()
   @IsOptional()


### PR DESCRIPTION
## Problem

The `is_admin` query parameter on `/api/admin/users` endpoint does not work correctly when set to `false` or `0`. Both `?is_admin=false` and `?is_admin=0` incorrectly return admin users instead of non-admin users.

## Root Cause

The `AdminUserQueryDto` used `@Type(() => Boolean)` for the `is_admin` field. JavaScript's `Boolean()` constructor treats any non-empty string as `true`, including `"false"` and `"0"`:
- `Boolean("false")` → `true`
- `Boolean("0")` → `true`

This means any value passed to `is_admin` was always converted to `true`.

## Fix

- Changed `is_admin` from `boolean` to `number` type (0/1) in `AdminUserQueryDto`
- Used `@IsIn([0, 1])` validation to only accept 0 or 1
- Used `@Type(() => Number)` for proper string-to-number conversion
- In `AdminUserService`, convert `is_admin === 1` to boolean for the database query

## Usage

- `?is_admin=1` → returns admin users only
- `?is_admin=0` → returns non-admin users only
- No `is_admin` param → returns all users