### PR TITLE
refactor(device): redesign device update API to follow RESTful conventions

### DIFF
--- a/src/common/entities/peer.entity.ts
+++ b/src/common/entities/peer.entity.ts
@@ -60,6 +60,13 @@ export class Peer {
   @Index()
   strategyGuid: string | null;
 
+  /**
+   * 设备备注
+   * 管理员对设备的备注信息
+   */
+  @Column({ type: 'varchar', nullable: true })
+  note: string | null;
+
   @ManyToOne('Strategy', () => Strategy, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'strategyGuid' })
   strategy: any;

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -22,6 +22,7 @@ import {
   UpdateDeviceStatusDto,
   DeviceOperationResult,
 } from './dto/device-status.dto';
+import { UpdateDeviceDto } from './dto/update-device.dto';
 import { DisconnectDto } from './dto/disconnect.dto';
 import { DisconnectStoreService } from '../heartbeat/services/disconnect-store.service';
 import { HeartbeatService } from '../heartbeat/heartbeat.service';
@@ -245,33 +246,24 @@ export class DeviceGroupController {
   }
 
   /**
-   * 禁用设备
-   * 管理员可以禁用设备
+   * 更新设备属性
+   * 管理员可以部分更新设备的用户、设备组、策略和备注
+   * 传字符串值 -> 按名称查找并关联
+   * 传 null -> 清除关联
+   * 不传某字段 -> 不修改该属性
    *
    * @param guid 设备GUID
-   * @returns 禁用结果
+   * @param dto 更新数据
+   * @returns 更新结果
    */
-  @Post('devices/:guid/disable')
+  @Patch('devices/:guid')
   @UseGuards(AdminGuard)
-  @HttpCode(HttpStatus.OK)
-  async disableDevice(@Param('guid') guid: string) {
-    await this.deviceGroupService.disableDevice(guid);
-    return { message: '设备已禁用' };
-  }
-
-  /**
-   * 启用设备
-   * 管理员可以启用设备
-   *
-   * @param guid 设备GUID
-   * @returns 启用结果
-   */
-  @Post('devices/:guid/enable')
-  @UseGuards(AdminGuard)
-  @HttpCode(HttpStatus.OK)
-  async enableDevice(@Param('guid') guid: string) {
-    await this.deviceGroupService.enableDevice(guid);
-    return { message: '设备已启用' };
+  async updateDevice(
+    @Param('guid') guid: string,
+    @Body() dto: UpdateDeviceDto,
+  ) {
+    await this.deviceGroupService.updateDevice(guid, dto);
+    return { message: '设备更新成功' };
   }
 
   /**
@@ -309,29 +301,6 @@ export class DeviceGroupController {
   async deleteDevice(@Param('guid') guid: string) {
     await this.deviceGroupService.deleteDevice(guid);
     return { message: '设备已删除' };
-  }
-
-  /**
-   * 分配设备属性
-   * 管理员可以分配设备属性
-   *
-   * @param guid 设备GUID
-   * @param body 分配数据
-   * @returns 分配结果
-   */
-  @Post('devices/:guid/assign')
-  @UseGuards(AdminGuard)
-  @HttpCode(HttpStatus.OK)
-  async assignDevice(
-    @Param('guid') guid: string,
-    @Body()
-    body: {
-      type: string;
-      value: string;
-    },
-  ) {
-    await this.deviceGroupService.assignDevice(guid, body.type, body.value);
-    return { message: '设备属性已分配' };
   }
 
   /**

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -16,6 +16,7 @@ import {
   DeviceOperationResult,
   DeviceOperationFailure,
 } from './dto/device-status.dto';
+import { UpdateDeviceDto } from './dto/update-device.dto';
 
 @Injectable()
 /**
@@ -528,10 +529,16 @@ export class DeviceGroupService {
   }
 
   /**
-   * 禁用设备
+   * 更新设备属性
+   * 支持部分更新设备的用户、设备组、策略和备注
+   * 传字符串值 -> 按名称查找并关联
+   * 传 null -> 清除关联
+   * 不传某字段 -> 不修改该属性
+   *
    * @param guid 设备GUID
+   * @param dto 更新数据
    */
-  async disableDevice(guid: string) {
+  async updateDevice(guid: string, dto: UpdateDeviceDto) {
     const peer = await this.peerRepository.findOne({
       where: { uuid: guid },
     });
@@ -539,28 +546,57 @@ export class DeviceGroupService {
       throw new NotFoundException('设备不存在');
     }
 
-    await this.peerRepository.update(
-      { uuid: guid },
-      { status: PeerStatus.DISABLED },
-    );
-  }
+    const updateData: Partial<Peer> = {};
 
-  /**
-   * 启用设备
-   * @param guid 设备GUID
-   */
-  async enableDevice(guid: string) {
-    const peer = await this.peerRepository.findOne({
-      where: { uuid: guid },
-    });
-    if (!peer) {
-      throw new NotFoundException('设备不存在');
+    if (dto.userName !== undefined) {
+      if (dto.userName === null) {
+        updateData.userGuid = null;
+      } else {
+        const user = await this.userRepository.findOne({
+          where: { username: dto.userName },
+        });
+        if (!user) {
+          throw new NotFoundException('用户不存在');
+        }
+        updateData.userGuid = user.guid;
+      }
     }
 
-    await this.peerRepository.update(
-      { uuid: guid },
-      { status: PeerStatus.ACTIVE },
-    );
+    if (dto.deviceGroupName !== undefined) {
+      if (dto.deviceGroupName === null) {
+        updateData.deviceGroupGuid = null;
+      } else {
+        const deviceGroup = await this.deviceGroupRepository.findOne({
+          where: { name: dto.deviceGroupName },
+        });
+        if (!deviceGroup) {
+          throw new NotFoundException('设备组不存在');
+        }
+        updateData.deviceGroupGuid = deviceGroup.guid;
+      }
+    }
+
+    if (dto.strategyName !== undefined) {
+      if (dto.strategyName === null) {
+        updateData.strategyGuid = null;
+      } else {
+        const strategy = await this.strategyRepository.findOne({
+          where: { name: dto.strategyName },
+        });
+        if (!strategy) {
+          throw new NotFoundException('策略不存在');
+        }
+        updateData.strategyGuid = strategy.guid;
+      }
+    }
+
+    if (dto.note !== undefined) {
+      updateData.note = dto.note;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await this.peerRepository.update({ uuid: guid }, updateData);
+    }
   }
 
   /**
@@ -632,67 +668,5 @@ export class DeviceGroupService {
     }
 
     await this.peerRepository.remove(peer);
-  }
-
-  /**
-   * 分配设备属性
-   * @param guid 设备GUID
-   * @param type 属性类型
-   * @param value 属性值
-   */
-  async assignDevice(guid: string, type: string, value: string) {
-    const peer = await this.peerRepository.findOne({
-      where: { uuid: guid },
-    });
-    if (!peer) {
-      throw new NotFoundException('设备不存在');
-    }
-
-    const updateData: Partial<Peer> = {};
-
-    switch (type) {
-      case 'user_name': {
-        const user = await this.userRepository.findOne({
-          where: { username: value },
-        });
-        if (!user) {
-          throw new NotFoundException('用户不存在');
-        }
-        updateData.userGuid = user.guid;
-        break;
-      }
-      case 'device_group_name': {
-        const deviceGroup = await this.deviceGroupRepository.findOne({
-          where: { name: value },
-        });
-        if (!deviceGroup) {
-          throw new NotFoundException('设备组不存在');
-        }
-        updateData.deviceGroupGuid = deviceGroup.guid;
-        break;
-      }
-      case 'note':
-        // note字段不存在于Peer实体中，暂时忽略
-        break;
-      case 'device_username':
-      case 'device_name':
-      case 'ab':
-      case 'strategy_name': {
-        const strategy = await this.strategyRepository.findOne({
-          where: { name: value },
-        });
-        if (!strategy) {
-          throw new NotFoundException('策略不存在');
-        }
-        updateData.strategyGuid = strategy.guid;
-        break;
-      }
-      default:
-        throw new BadRequestException(`不支持的属性类型: ${type}`);
-    }
-
-    if (Object.keys(updateData).length > 0) {
-      await this.peerRepository.update({ uuid: guid }, updateData);
-    }
   }
 }

--- a/src/modules/device-group/dto/update-device.dto.ts
+++ b/src/modules/device-group/dto/update-device.dto.ts
@@ -1,0 +1,31 @@
+import { IsOptional, IsString, MaxLength, ValidateIf } from 'class-validator';
+
+/**
+ * 更新设备DTO
+ * 用于部分更新设备属性
+ * 传字符串值 -> 按名称查找并关联
+ * 传 null -> 清除关联
+ * 不传某字段 -> 不修改该属性
+ */
+export class UpdateDeviceDto {
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsString()
+  userName?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsString()
+  deviceGroupName?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsString()
+  strategyName?: string | null;
+
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsString()
+  @MaxLength(500)
+  note?: string | null;
+}

--- a/src/modules/user/admin-user.controller.ts
+++ b/src/modules/user/admin-user.controller.ts
@@ -1,9 +1,4 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { AdminUserService } from './admin-user.service';
 import { AdminGuard } from '../../common/guards/admin.guard';
 import { AdminUserQueryDto } from './dto/admin-user.dto';

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -17,7 +17,16 @@ export class AdminUserService {
   async getAdminUsers(
     query: AdminUserQueryDto,
   ): Promise<{ data: any[]; total: number }> {
-    const { current, pageSize, status, name, email, is_admin, third_auth_type, strategy_name } = query;
+    const {
+      current,
+      pageSize,
+      status,
+      name,
+      email,
+      is_admin,
+      third_auth_type,
+      strategy_name,
+    } = query;
     const skip = (current - 1) * pageSize;
 
     const queryBuilder = this.userRepository.createQueryBuilder('user');
@@ -35,7 +44,9 @@ export class AdminUserService {
     }
 
     if (is_admin !== undefined) {
-      queryBuilder.andWhere('user.isAdmin = :isAdmin', { isAdmin: is_admin === 1 });
+      queryBuilder.andWhere('user.isAdmin = :isAdmin', {
+        isAdmin: is_admin === 1,
+      });
     }
 
     if (third_auth_type) {
@@ -63,9 +74,7 @@ export class AdminUserService {
     // Batch load strategy names
     const strategyGuids = [
       ...new Set(
-        users
-          .map((u) => u.strategyGuid)
-          .filter((g): g is string => g != null),
+        users.map((u) => u.strategyGuid).filter((g): g is string => g != null),
       ),
     ];
     const strategies =
@@ -86,7 +95,9 @@ export class AdminUserService {
         is_admin: u.isAdmin,
         third_auth_type: u.thirdAuthType || '',
         strategy_guid: u.strategyGuid || '',
-        strategy_name: u.strategyGuid ? strategyMap.get(u.strategyGuid) || '' : '',
+        strategy_name: u.strategyGuid
+          ? strategyMap.get(u.strategyGuid) || ''
+          : '',
         avatar: u.avatar || '',
         created_at: u.createdAt,
         updated_at: u.updatedAt,


### PR DESCRIPTION
## Summary

Replace non-RESTful device update endpoints with a unified `PATCH devices/:guid` endpoint.

## Changes

### API Changes

| Old Endpoint | New Endpoint | Description |
|---|---|---|
| `POST devices/:guid/assign` | `PATCH devices/:guid` | Update device attributes |
| `POST devices/:guid/disable` | `PATCH devices/:guid` | Now handled via batch status update |
| `POST devices/:guid/enable` | `PATCH devices/:guid` | Now handled via batch status update |
| `DELETE devices/:guid` | `DELETE devices/:guid` | Unchanged |
| `PATCH devices/status` | `PATCH devices/status` | Unchanged (batch operation) |

### New `PATCH devices/:guid` Request Body

```json
{
  "userName": "admin",
  "deviceGroupName": "group1",
  "strategyName": "strategy-a",
  "note": "some note"
}
```

- Pass a string value to associate by name
- Pass `null` to clear the association
- Omit a field to leave it unchanged

### Bug Fixes

- Fixed `device_username`, `device_name`, `ab` types in `assignDevice` incorrectly updating `strategyGuid`
- Fixed `note` type being silently ignored

### Other Changes

- Added `note` field to `Peer` entity
- Added `UpdateDeviceDto` with class-validator validation
- Removed `assignDevice`, `disableDevice`, `enableDevice` methods from service
- Lint auto-formatting for `admin-user.controller.ts` and `admin-user.service.ts`

## Test Plan

- [ ] `PATCH /api/devices/:guid` with `userName` updates `userGuid`
- [ ] `PATCH /api/devices/:guid` with `deviceGroupName` updates `deviceGroupGuid`
- [ ] `PATCH /api/devices/:guid` with `strategyName` updates `strategyGuid`
- [ ] `PATCH /api/devices/:guid` with `note` updates `note`
- [ ] `PATCH /api/devices/:guid` with `null` values clears associations
- [ ] `PATCH /api/devices/:guid` with omitted fields leaves them unchanged
- [ ] `DELETE /api/devices/:guid` still works
- [ ] `PATCH /api/devices/status` still works for batch enable/disable