### PR TITLE
docs: add docker-compose.yml and document default admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@ PORT=3000
 JWT_SECRET=your-super-secret-jwt-key-change-in-production
 
 # Default Admin Account (will be created on first run)
-ADMIN_USERNAME=admin
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=admin123
+ADMIN_USERNAME=databk
+ADMIN_EMAIL=databk@github.com
+ADMIN_PASSWORD=databk
 
 # Database Configuration (SQLite by default)
 # For PostgreSQL or MySQL, modify the TypeORM config in app.module.ts

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ docker run -d \
   --name rustdesk-console-web \
   --network rustdesk-net \
   -p 21114:80 \
+  -e BACKEND_URL=http://rustdesk-console:3000 \
   databk/rustdesk-console-web:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ This console serves as the central hub for managing RustDesk clients, handling e
 
 ### Installation
 
-RustDesk Console provides multiple installation methods to suit different deployment needs:
+RustDesk Console provides multiple installation methods to suit different deployment needs.
+
+> **Default Admin Credentials**: username `databk`, password `databk`. Please change the default password before deploying to production!
 
 #### 🔧 Option 1: Build from Source (Recommended for Development)
 
@@ -146,9 +148,7 @@ This project uses a **frontend-backend separated architecture**. The backend (th
 
 **Docker Compose** (recommended):
 
-The project includes a [`docker-compose.yml`](docker-compose.yml) file for easy deployment. Default admin credentials: username `databk`, password `databk`.
-
-> **Important**: Please change the default admin password and `JWT_SECRET` before deploying to production!
+The project includes a [`docker-compose.yml`](docker-compose.yml) file for easy deployment.
 
 ```bash
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -146,33 +146,19 @@ This project uses a **frontend-backend separated architecture**. The backend (th
 
 **Docker Compose** (recommended):
 
-```yaml
-version: '3.8'
-services:
-  rustdesk-console:
-    image: databk/rustdesk-console:latest
-    container_name: rustdesk-console
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - JWT_SECRET=your-super-secret-key
-      - ADMIN_PASSWORD=your-secure-password
+The project includes a [`docker-compose.yml`](docker-compose.yml) file for easy deployment. Default admin credentials: username `databk`, password `databk`.
 
-  rustdesk-console-web:
-    image: databk/rustdesk-console-web:latest
-    container_name: rustdesk-console-web
-    ports:
-      - "21114:80"
-    depends_on:
-      - rustdesk-console
-    restart: unless-stopped
+> **Important**: Please change the default admin password and `JWT_SECRET` before deploying to production!
+
+```bash
+docker compose up -d
 ```
 
 > **Note**: The frontend container connects to the backend via the internal Docker network using the service name `rustdesk-console:3000`. No additional network configuration is needed with the default setup.
 
 **Using GitHub Container Registry (ghcr)**:
 
-If you prefer GHCR images, replace the image lines:
+If you prefer GHCR images, modify the image lines in [`docker-compose.yml`](docker-compose.yml):
 
 ```yaml
     image: ghcr.io/databk/rustdesk-console:latest      # backend
@@ -190,7 +176,6 @@ docker run -d \
   --name rustdesk-console \
   --network rustdesk-net \
   -e JWT_SECRET=your-super-secret-key \
-  -e ADMIN_PASSWORD=your-secure-password \
   databk/rustdesk-console:latest
 
 # Start the frontend
@@ -345,7 +330,7 @@ npm run test:debug     # Run tests in debug mode
 
 ### Production Checklist
 - [ ] Change `JWT_SECRET` to a strong random value (min 32 chars)
-- [ ] Change default admin password in `.env`
+- [ ] Change default admin password (default: `databk`) in `.env`
 - [ ] Configure production SMTP settings via the Settings API
 - [ ] Set `synchronize: false` in TypeORM config and use migrations
 - [ ] Configure CORS origins to your frontend domain only

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  rustdesk-console:
+    image: databk/rustdesk-console:latest
+    container_name: rustdesk-console
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+      - JWT_SECRET=your-super-secret-key
+
+  rustdesk-console-web:
+    image: databk/rustdesk-console-web:latest
+    container_name: rustdesk-console-web
+    ports:
+      - "21114:80"
+    environment:
+      - BACKEND_URL=http://rustdesk-console:3000
+    depends_on:
+      - rustdesk-console
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     container_name: rustdesk-console
     restart: unless-stopped
     environment:
-      - NODE_ENV=production
       - JWT_SECRET=your-super-secret-key
 
   rustdesk-console-web:


### PR DESCRIPTION
## Changes

- Add `docker-compose.yml` file to the repository for independent management of Docker deployment configuration
- Update README to reference the `docker-compose.yml` file instead of embedding the configuration inline
- Document default admin credentials (username: `databk`, password: `databk`)
- Update docker-compose with `BACKEND_URL` environment variable for the frontend container
- Remove `ADMIN_PASSWORD` environment variable from Docker examples (using default credentials)

## Motivation

Having docker-compose.yml as a standalone file makes it easier to manage and update Docker deployment configuration independently, rather than requiring users to copy it from the README.