### PR TITLE
fix(docker): use login-options endpoint for health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p /data
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3000/api/login', (r) => {process.exit(r.statusCode === 401 ? 0 : 1)})"
+  CMD node -e "require('http').get('http://localhost:3000/api/login-options', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 # Start the application
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary

Fix the Docker health check to use a proper endpoint that returns 200.

## Changes

- Replace `/api/login` (returns 401) with `/api/login-options` (returns 200) in HEALTHCHECK
- Health check now correctly expects HTTP 200 instead of treating 401 as healthy

## Note

The `CMD ["node", "dist/main.js"]` is kept as-is. While it could be simplified to `CMD ["dist/main.js"]` (leveraging `node:22-alpine`'s default ENTRYPOINT `docker-entrypoint.sh`), the explicit form is clearer and is the standard convention for NestJS projects.