### PR TITLE
fix: align alarm audit query interface with file/connection audit

### DIFF
--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -246,32 +246,39 @@ export class AuditsController {
    *
    * 功能说明：
    * - 支持分页查询
-   * - 支持按设备ID过滤
-   * - 支持按创建时间过滤
+   * - 支持按被控端设备ID过滤（deviceId模糊匹配）
+   * - 支持按时间段过滤（startTime/endTime范围查询）
+   * - 支持按告警类型过滤（type: 0-IP白名单, 1-超30次尝试, 2-1分钟6次尝试, 6-IPv6前缀超限, 7-终端OS登录backoff, 8-终端OS登录并发超限）
    *
    * 安全措施：
    * - 使用AdminGuard进行认证
    * - 只有管理员可以查询审计记录
    *
-   * @param device 设备ID（模糊匹配）
+   * @param deviceId 被控端设备ID（模糊匹配）
+   * @param type 告警类型
+   * @param startTime 开始时间（ISO 8601格式）
+   * @param endTime 结束时间（ISO 8601格式）
    * @param pageSize 每页记录数
    * @param current 当前页码
-   * @param created_at 创建时间（UTC时间字符串）
    * @returns 告警审计列表
    */
   @UseGuards(AdminGuard)
   @Get('alarm')
   async queryAlarmAudits(
-    @Query('device') device?: string,
+    @Query('deviceId') deviceId?: string,
+    @Query('type') type?: number,
+    @Query('startTime') startTime?: string,
+    @Query('endTime') endTime?: string,
     @Query('pageSize') pageSize?: number,
     @Query('current') current?: number,
-    @Query('created_at') created_at?: string,
   ) {
     return await this.auditService.queryAlarmAudits({
-      device,
+      deviceId,
+      type,
+      startTime,
+      endTime,
       pageSize,
       current,
-      created_at,
     });
   }
 

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -424,12 +424,21 @@ export class AuditService {
    * @returns 告警审计列表
    */
   async queryAlarmAudits(filters: {
-    device?: string;
+    deviceId?: string;
+    type?: number;
+    startTime?: string;
+    endTime?: string;
     pageSize?: number;
     current?: number;
-    created_at?: string;
   }) {
-    const { device, pageSize = 10, current = 1, created_at } = filters;
+    const {
+      deviceId,
+      type,
+      startTime,
+      endTime,
+      pageSize = 10,
+      current = 1,
+    } = filters;
     const skip = (current - 1) * pageSize;
 
     const queryBuilder = this.alarmAuditRepository
@@ -445,17 +454,26 @@ export class AuditService {
         'aa.createdAt',
       ]);
 
-    // 按设备ID过滤
-    if (device) {
-      queryBuilder.andWhere('aa.deviceId LIKE :device', {
-        device: `%${device}%`,
+    // 按设备ID过滤（模糊匹配）
+    if (deviceId) {
+      queryBuilder.andWhere('aa.deviceId LIKE :deviceId', {
+        deviceId: `%${deviceId}%`,
       });
     }
 
-    // 按创建时间过滤
-    if (created_at) {
-      const createdAt = new Date(created_at);
-      queryBuilder.andWhere('aa.createdAt >= :createdAt', { createdAt });
+    // 按告警类型过滤
+    if (type !== undefined) {
+      queryBuilder.andWhere('aa.typ = :type', { type });
+    }
+
+    // 按时间段过滤
+    if (startTime) {
+      const start = new Date(startTime);
+      queryBuilder.andWhere('aa.createdAt >= :startTime', { startTime: start });
+    }
+    if (endTime) {
+      const end = new Date(endTime);
+      queryBuilder.andWhere('aa.createdAt <= :endTime', { endTime: end });
     }
 
     queryBuilder.orderBy('aa.createdAt', 'DESC').skip(skip).take(pageSize);

--- a/src/modules/audit/dto/alarm-audit.dto.ts
+++ b/src/modules/audit/dto/alarm-audit.dto.ts
@@ -13,7 +13,7 @@ export class AlarmAuditDto {
 
   @IsInt()
   @Min(0)
-  @Max(6)
+  @Max(8)
   typ: number;
 
   @IsString()

--- a/src/modules/audit/entities/alarm-audit.entity.ts
+++ b/src/modules/audit/entities/alarm-audit.entity.ts
@@ -5,6 +5,18 @@ import {
   CreateDateColumn,
 } from 'typeorm';
 
+/**
+ * 告警类型枚举
+ */
+export enum AlarmType {
+  IP_WHITELIST = 0,
+  EXCEED_THIRTY_ATTEMPTS = 1,
+  SIX_ATTEMPTS_WITHIN_ONE_MINUTE = 2,
+  EXCEED_IPV6_PREFIX_ATTEMPTS = 6,
+  TERMINAL_OS_LOGIN_BACKOFF = 7,
+  TERMINAL_OS_LOGIN_CONCURRENCY = 8,
+}
+
 @Entity('alarm_audits')
 export class AlarmAudit {
   @PrimaryGeneratedColumn()


### PR DESCRIPTION
## Changes

- **Add `AlarmType` enum** with all client-supported types (0, 1, 2, 6, 7, 8)
- **Update `AlarmAuditDto`** typ validation from `@Max(6)` to `@Max(8)` to support new alarm types
- **Rename query param `device` → `deviceId`** for consistency with connection/file audit interfaces
- **Replace `created_at` single-point filter** with `startTime`/`endTime` range filter for consistency
- **Add `type` filter** for querying by alarm type, matching the pattern used by connection and file audit queries

### Alarm Types Reference

| typ | Name | Description |
|-----|------|-------------|
| 0 | IP_WHITELIST | IP not in whitelist |
| 1 | EXCEED_THIRTY_ATTEMPTS | Same IP exceeds 30 failed attempts |
| 2 | SIX_ATTEMPTS_WITHIN_ONE_MINUTE | More than 6 attempts within 1 minute |
| 6 | EXCEED_IPV6_PREFIX_ATTEMPTS | IPv6 prefix attempt limit exceeded |
| 7 | TERMINAL_OS_LOGIN_BACKOFF | Terminal OS login blocked by backoff |
| 8 | TERMINAL_OS_LOGIN_CONCURRENCY | Terminal OS login concurrency limit exceeded |