### PR TITLE
fix: store null instead of empty string for user email to avoid unique constraint violation

### DIFF
--- a/src/modules/auth/services/auth-email.service.ts
+++ b/src/modules/auth/services/auth-email.service.ts
@@ -46,6 +46,12 @@ export class AuthEmailService {
    * @throws BadRequestException 当邮件发送失败时抛出
    */
   async initiateEmailVerification(user: User): Promise<LoginResponse> {
+    if (!user.email) {
+      throw new BadRequestException({
+        error: '用户未设置邮箱，无法进行邮箱验证',
+      });
+    }
+
     // 生成6位随机验证码
     const code = Math.random().toString().slice(-6);
 

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -47,7 +47,7 @@ export class AuthTokenService {
     const payload: JwtPayload = {
       sub: user.guid,
       username: user.username,
-      email: user.email,
+      email: user.email ?? undefined,
       isAdmin: user.isAdmin,
       deviceId,
       jti,

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -60,7 +60,7 @@ export class User {
    */
   @Column({ unique: true, nullable: true })
   @Index()
-  email: string;
+  email: string | null;
 
   /**
    * 密码

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -188,7 +188,7 @@ export class UserService {
     const user = new User();
     user.guid = uuidv4();
     user.username = name;
-    user.email = email || '';
+    user.email = email || null;
     user.password = await bcrypt.hash(password, 10);
     user.note = note || '';
     user.status = UserStatus.ACTIVE;
@@ -273,7 +273,7 @@ export class UserService {
           throw new BadRequestException('邮箱已存在');
         }
       }
-      user.email = dto.email;
+      user.email = dto.email || null;
     }
 
     if (dto.note !== undefined) {
@@ -320,7 +320,7 @@ export class UserService {
           throw new BadRequestException('邮箱已存在');
         }
       }
-      user.email = dto.email;
+      user.email = dto.email || null;
     }
 
     if (dto.note !== undefined) {


### PR DESCRIPTION
## Summary

When creating a user without an email, the email field was stored as an empty string (`''`) which violates the UNIQUE constraint on subsequent user creations without email. SQLite treats NULL values as distinct for unique constraints, so storing NULL allows multiple users without email.

## Changes

- Change email default from `''` to `null` in `createUser`, `updateUser`, and `updateCurrentUser`
- Update User entity email type to `string | null`
- Add null check in `initiateEmailVerification` to guard against users without email
- Convert null to undefined for JWT payload email field

Closes #173