### PR TITLE
fix: map os field to standardized platform constants in /ab/peers response

### DIFF
--- a/src/common/utils/platform.util.ts
+++ b/src/common/utils/platform.util.ts
@@ -1,0 +1,48 @@
+/**
+ * Map database os field to standardized platform constant.
+ *
+ * Database `os` field format: `{distribution_id} / {long_os_version}`
+ * Examples:
+ *   - "windows / Windows 10 Pro - 10 (19045)"
+ *   - "linux / Ubuntu 22.04"
+ *   - "macos / macOS 14.0"
+ *   - "android / Android 14"
+ *
+ * The `platform` field in API responses must be one of:
+ *   "Windows" | "Linux" | "Mac OS" | "Android"
+ */
+export function mapOsToPlatform(os: string | null | undefined): string {
+  if (!os) return '';
+
+  // Extract distribution_id (part before " / ")
+  const distributionId = os.includes(' / ')
+    ? os.split(' / ')[0].toLowerCase().trim()
+    : os.toLowerCase().trim();
+
+  if (distributionId.includes('windows') || distributionId === 'win') {
+    return 'Windows';
+  }
+  if (
+    distributionId.includes('mac') ||
+    distributionId.includes('darwin') ||
+    distributionId === 'macos' ||
+    distributionId === 'osx'
+  ) {
+    return 'Mac OS';
+  }
+  if (distributionId.includes('android')) {
+    return 'Android';
+  }
+  if (distributionId.includes('linux')) {
+    return 'Linux';
+  }
+
+  // Fallback: try matching against the full os string
+  const osLower = os.toLowerCase();
+  if (osLower.includes('windows')) return 'Windows';
+  if (osLower.includes('mac') || osLower.includes('darwin')) return 'Mac OS';
+  if (osLower.includes('android')) return 'Android';
+  if (osLower.includes('linux')) return 'Linux';
+
+  return '';
+}

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -9,6 +9,7 @@ import {
   AddressBookPeerTag,
 } from '../entities';
 import { Sysinfo } from '../../../common/entities';
+import { mapOsToPlatform } from '../../../common/utils/platform.util';
 
 @Injectable()
 /**
@@ -106,7 +107,7 @@ export class AddressBookLegacyService {
         hash: p.hash || '',
         username: sysinfo?.username || '',
         hostname: sysinfo?.hostname || '',
-        platform: sysinfo?.os || '',
+        platform: mapOsToPlatform(sysinfo?.os),
         alias: p.alias || '',
         tags: p.tags?.map((t) => t.name) || [],
       };

--- a/src/modules/address-book/services/address-book-peer.service.ts
+++ b/src/modules/address-book/services/address-book-peer.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../entities';
 import { AddPeerDto, UpdatePeerDto, PeersQueryDto, TagMatchMode } from '../dto';
 import { Sysinfo, Peer } from '../../../common/entities';
+import { mapOsToPlatform } from '../../../common/utils/platform.util';
 
 @Injectable()
 /**
@@ -168,7 +169,7 @@ export class AddressBookPeerService {
         password: p.password,
         username: sysinfo?.username || '',
         hostname: sysinfo?.hostname || '',
-        platform: sysinfo?.os || '',
+        platform: mapOsToPlatform(sysinfo?.os),
         alias: p.alias,
         tags: p.tags?.map((t) => t.name) || [],
         note: p.note,


### PR DESCRIPTION
## Summary

Fix the `platform` field in `/ab/peers` and legacy address book API responses to return one of the four standard constants: `Windows`, `Linux`, `Mac OS`, `Android`.

## Problem

The database `os` field stores values in the format `{distribution_id} / {long_os_version}`, for example:
- `windows / Windows 10 Pro - 10 (19045)`
- `windows / Windows Server 2025 Datacenter - 11 (26100)`
- `linux / Ubuntu 22.04`
- `macos / macOS 14.0`
- `android / Android 14`

Previously, the raw `os` string was returned directly as the `platform` field, which does not match the client's expected constant values.

## Solution

Created a `mapOsToPlatform` utility function that:
1. Extracts the `distribution_id` (part before ` / `) from the `os` field
2. Maps it to the correct platform constant:
   - `windows` / `win` → `Windows`
   - `macos` / `darwin` / `osx` → `Mac OS`
   - `android` → `Android`
   - `linux` → `Linux`
3. Falls back to matching the full `os` string if the distribution_id is unrecognized

## Changes

- **New file**: `src/common/utils/platform.util.ts` — `mapOsToPlatform()` utility function
- **Modified**: `src/modules/address-book/services/address-book-peer.service.ts` — use `mapOsToPlatform()` for `platform` field
- **Modified**: `src/modules/address-book/services/address-book-legacy.service.ts` — use `mapOsToPlatform()` for `platform` field

Closes #175