### PR TITLE
fix: LDAP test connection fails when password is masked

### DIFF
--- a/src/modules/ldap/ldap.controller.ts
+++ b/src/modules/ldap/ldap.controller.ts
@@ -64,17 +64,31 @@ export class LdapController {
   @Throttle({ default: { limit: 5, ttl: 60000 } })
   async testLdapConnection(@Body() dto?: TestLdapConfigDto) {
     if (dto && dto.urls && dto.urls.length > 0) {
+      // Get saved config to fall back for fields not provided in DTO (e.g. bindCredentials)
+      const savedConfig = await this.ldapSettingsService.getActiveConfig();
+      const bindCredentials =
+        dto.bindCredentials || savedConfig?.bindCredentials || '';
+
       return this.ldapService.testConnection({
         urls: dto.urls,
-        bindDN: dto.bindDN || '',
-        bindCredentials: dto.bindCredentials || '',
-        searchBase: dto.searchBase || '',
-        searchFilter: dto.searchFilter || '(sAMAccountName={{username}})',
-        searchAttributes: ['dn', 'sAMAccountName', 'mail', 'displayName'],
-        groupSearchBase: '',
-        groupSearchFilter: '',
-        adminGroups: [],
-        tlsOptions: {},
+        bindDN: dto.bindDN || savedConfig?.bindDN || '',
+        bindCredentials,
+        searchBase: dto.searchBase || savedConfig?.searchBase || '',
+        searchFilter:
+          dto.searchFilter ||
+          savedConfig?.searchFilter ||
+          '(sAMAccountName={{username}})',
+        searchAttributes:
+          savedConfig?.searchAttributes || [
+            'dn',
+            'sAMAccountName',
+            'mail',
+            'displayName',
+          ],
+        groupSearchBase: savedConfig?.groupSearchBase || '',
+        groupSearchFilter: savedConfig?.groupSearchFilter || '',
+        adminGroups: savedConfig?.adminGroups || [],
+        tlsOptions: savedConfig?.tlsOptions || {},
         enabled: true,
       });
     }


### PR DESCRIPTION
## Problem

Users reported that the LDAP test connection says "not working" even though LDAP authentication actually works fine. This is because when the settings form loads, the password field shows the masked value `******`. When clicking "Test Connection", the frontend skips sending `bindCredentials` if it's still masked. The backend controller then constructs a new config with an empty password, causing the LDAP bind to always fail.

## Root Cause

In `ldap.controller.ts`, the `testLdapConnection` method constructs a brand new config from the DTO fields only, using `dto.bindCredentials || ''`. Since `bindCredentials` is not sent when masked, it becomes an empty string, and the LDAP bind fails with invalid credentials.

## Fix

The controller now loads the saved config first and uses it as fallback for any fields not provided in the DTO. This ensures:
- `bindCredentials` falls back to the saved password when not provided
- Other fields like `searchBase`, `searchFilter`, `tlsOptions` also fall back to saved values
- New values provided in the DTO still take precedence over saved ones

## Testing

- TypeScript compilation passes with no errors
- The fix preserves the existing behavior when DTO fields are explicitly provided