### PR TITLE
fix: specify varchar type for User.email column

### DIFF
--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -58,7 +58,7 @@ export class User {
    * 邮箱地址
    * 用于邮箱验证和通知
    */
-  @Column({ unique: true, nullable: true })
+  @Column({ type: 'varchar', unique: true, nullable: true })
   @Index()
   email: string | null;
 


### PR DESCRIPTION
## Problem

After merging PR#176, `npm run start` fails with:

```
DataTypeNotSupportedError: Data type "Object" in "User.email" is not supported by "sqlite" database.
```

## Root Cause

The `email` field in `User` entity uses a TypeScript union type `string | null` without an explicit column type:

```typescript
@Column({ unique: true, nullable: true })
email: string | null;
```

TypeORM uses `reflect-metadata` to infer the column type at runtime. Since union types are erased during compilation, it resolves to `Object`, which is not a valid data type for SQLite.

## Fix

Add `type: 'varchar'` to the `@Column` decorator, consistent with other nullable string fields in the same entity (`avatar`, `strategyGuid`):

```typescript
@Column({ type: 'varchar', unique: true, nullable: true })
email: string | null;
```

## Testing

- Verified no other entity fields have the same issue (all other union-typed fields already specify explicit types)