### PR TITLE
feat: add nexus module for custom client generation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,8 @@ import { LdapModule } from './modules/ldap/ldap.module';
 import { StrategyModule } from './modules/strategy/strategy.module';
 import { Strategy } from './modules/strategy/entities/strategy.entity';
 import { UpdateCheckModule } from './modules/update-check/update-check.module';
+import { NexusModule } from './modules/nexus/nexus.module';
+import { NexusToken } from './modules/nexus/entities/nexus-token.entity';
 
 /**
  * 应用根模块
@@ -98,6 +100,7 @@ import { UpdateCheckModule } from './modules/update-check/update-check.module';
         SystemSetting,
         ActiveConnection,
         Strategy,
+        NexusToken,
       ],
       synchronize: true,
       logging: false,
@@ -116,6 +119,7 @@ import { UpdateCheckModule } from './modules/update-check/update-check.module';
     LdapModule,
     StrategyModule,
     UpdateCheckModule,
+    NexusModule,
   ],
   providers: [
     {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,6 +41,7 @@ import { Strategy } from './modules/strategy/entities/strategy.entity';
 import { UpdateCheckModule } from './modules/update-check/update-check.module';
 import { NexusModule } from './modules/nexus/nexus.module';
 import { NexusToken } from './modules/nexus/entities/nexus-token.entity';
+import { NexusBuild } from './modules/nexus/entities/nexus-build.entity';
 
 /**
  * 应用根模块
@@ -101,6 +102,7 @@ import { NexusToken } from './modules/nexus/entities/nexus-token.entity';
         ActiveConnection,
         Strategy,
         NexusToken,
+        NexusBuild,
       ],
       synchronize: true,
       logging: false,

--- a/src/modules/nexus/dto/nexus-auth.dto.ts
+++ b/src/modules/nexus/dto/nexus-auth.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsOptional } from 'class-validator';
+
+/** 创建 Nexus 登录会话 DTO */
+export class NexusLoginDto {
+  @IsOptional()
+  @IsString()
+  callbackUrl?: string;
+}
+
+/** Nexus 登录会话响应 */
+export interface NexusLoginResponse {
+  login_id: string;
+  auth_url: string;
+  expires_in: number;
+}
+
+/** Nexus 登录状态响应 */
+export interface NexusAuthStatusResponse {
+  state: 'pending' | 'completed' | 'failed';
+  nexus_username?: string;
+  expires_in?: number;
+  error?: string;
+}
+
+/** Nexus 绑定状态响应 */
+export interface NexusBindStatusResponse {
+  bound: boolean;
+  nexus_username?: string;
+  expired?: boolean;
+}

--- a/src/modules/nexus/dto/nexus-auth.dto.ts
+++ b/src/modules/nexus/dto/nexus-auth.dto.ts
@@ -5,6 +5,9 @@ export class NexusLoginDto {
   @IsOptional()
   @IsString()
   callbackUrl?: string;
+
+  @IsString()
+  install_id: string;
 }
 
 /** Nexus 登录会话响应 */

--- a/src/modules/nexus/dto/nexus-auth.dto.ts
+++ b/src/modules/nexus/dto/nexus-auth.dto.ts
@@ -5,9 +5,6 @@ export class NexusLoginDto {
   @IsOptional()
   @IsString()
   callbackUrl?: string;
-
-  @IsString()
-  install_id: string;
 }
 
 /** Nexus 登录会话响应 */

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -62,6 +62,9 @@ export class NexusGenerateDto {
   @IsIn(['x86_64', 'aarch64', 'x86'])
   arch: string;
 
+  @IsString()
+  install_id: string;
+
   @ValidateNested()
   @Type(() => NexusCustomDto)
   custom: NexusCustomDto;

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -1,15 +1,70 @@
-import { IsString, IsIn } from 'class-validator';
+import {
+  IsString,
+  IsIn,
+  IsOptional,
+  ValidateNested,
+  IsObject,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/** 定制配置对象 */
+export class NexusCustomDto {
+  @IsOptional()
+  @IsString()
+  password?: string;
+
+  @IsOptional()
+  @IsString()
+  salt?: string;
+
+  @IsOptional()
+  @IsIn(['incoming', 'outgoing', 'both'])
+  'conn-type'?: string;
+
+  @IsOptional()
+  @IsIn(['Y', 'N'])
+  'disable-installation'?: string;
+
+  @IsOptional()
+  @IsIn(['Y', 'N'])
+  'disable-settings'?: string;
+
+  @IsOptional()
+  @IsIn(['Y', 'N'])
+  'disable-account'?: string;
+
+  @IsOptional()
+  @IsIn(['Y', 'N'])
+  'disable-ab'?: string;
+
+  @IsOptional()
+  @IsIn(['Y', 'N'])
+  'disable-tcp-listen'?: string;
+
+  @IsOptional()
+  @IsString()
+  'app-name'?: string;
+
+  @IsOptional()
+  @IsObject()
+  'override-settings'?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsObject()
+  'default-settings'?: Record<string, unknown>;
+}
 
 /** 提交构建请求 DTO */
 export class NexusGenerateDto {
-  @IsIn(['windows', 'linux', 'macos'])
+  @IsIn(['windows', 'linux', 'macos', 'android', 'ios', 'web'])
   os: string;
 
   @IsIn(['x64', 'arm64'])
   arch: string;
 
-  @IsString()
-  app_name: string;
+  @ValidateNested()
+  @Type(() => NexusCustomDto)
+  custom: NexusCustomDto;
 }
 
 /** 构建请求响应 */
@@ -23,6 +78,6 @@ export interface NexusGenerateResponse {
 export interface NexusBuildStatusResponse {
   request_id: string;
   status: 'pending' | 'building' | 'completed' | 'failed' | 'cancelled';
-  download_url?: string;
+  files?: string[];
   message?: string;
 }

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -56,10 +56,10 @@ export class NexusCustomDto {
 
 /** 提交构建请求 DTO */
 export class NexusGenerateDto {
-  @IsIn(['windows'])
+  @IsIn(['windows', 'linux', 'macos', 'android', 'ios', 'web'])
   os: string;
 
-  @IsIn(['x86_64', 'aarch64', 'x86'])
+  @IsIn(['x64', 'arm64'])
   arch: string;
 
   @ValidateNested()
@@ -69,14 +69,14 @@ export class NexusGenerateDto {
 
 /** 构建请求响应 */
 export interface NexusGenerateResponse {
-  request_id: string;
+  uuid: string;
   status: string;
   message: string;
 }
 
 /** 构建状态响应 */
 export interface NexusBuildStatusResponse {
-  request_id: string;
+  uuid: string;
   status: 'pending' | 'building' | 'completed' | 'failed' | 'cancelled';
   files?: string[];
   message?: string;

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -62,9 +62,6 @@ export class NexusGenerateDto {
   @IsIn(['x86_64', 'aarch64', 'x86'])
   arch: string;
 
-  @IsString()
-  install_id: string;
-
   @ValidateNested()
   @Type(() => NexusCustomDto)
   custom: NexusCustomDto;

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -1,0 +1,28 @@
+import { IsString, IsIn } from 'class-validator';
+
+/** 提交构建请求 DTO */
+export class NexusGenerateDto {
+  @IsIn(['windows', 'linux', 'macos'])
+  os: string;
+
+  @IsIn(['x64', 'arm64'])
+  arch: string;
+
+  @IsString()
+  app_name: string;
+}
+
+/** 构建请求响应 */
+export interface NexusGenerateResponse {
+  request_id: string;
+  status: string;
+  message: string;
+}
+
+/** 构建状态响应 */
+export interface NexusBuildStatusResponse {
+  request_id: string;
+  status: 'pending' | 'building' | 'completed' | 'failed' | 'cancelled';
+  download_url?: string;
+  message?: string;
+}

--- a/src/modules/nexus/dto/nexus-client.dto.ts
+++ b/src/modules/nexus/dto/nexus-client.dto.ts
@@ -56,10 +56,10 @@ export class NexusCustomDto {
 
 /** 提交构建请求 DTO */
 export class NexusGenerateDto {
-  @IsIn(['windows', 'linux', 'macos', 'android', 'ios', 'web'])
+  @IsIn(['windows'])
   os: string;
 
-  @IsIn(['x64', 'arm64'])
+  @IsIn(['x86_64', 'aarch64', 'x86'])
   arch: string;
 
   @ValidateNested()

--- a/src/modules/nexus/entities/nexus-build.entity.ts
+++ b/src/modules/nexus/entities/nexus-build.entity.ts
@@ -15,10 +15,10 @@ export type BuildStatus = 'pending' | 'building' | 'completed' | 'failed' | 'can
  */
 @Entity('nexus_builds')
 export class NexusBuild {
-  /** Nexus 构建任务 ID */
+  /** Nexus 构建任务 UUID */
   @PrimaryColumn()
   @Index()
-  requestId: string;
+  uuid: string;
 
   /** 关联的本地用户 GUID */
   @Column()

--- a/src/modules/nexus/entities/nexus-build.entity.ts
+++ b/src/modules/nexus/entities/nexus-build.entity.ts
@@ -7,7 +7,12 @@ import {
   Index,
 } from 'typeorm';
 
-export type BuildStatus = 'pending' | 'building' | 'completed' | 'failed' | 'cancelled';
+export type BuildStatus =
+  | 'pending'
+  | 'building'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
 
 /**
  * Nexus 构建记录实体

--- a/src/modules/nexus/entities/nexus-build.entity.ts
+++ b/src/modules/nexus/entities/nexus-build.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export type BuildStatus = 'pending' | 'building' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * Nexus 构建记录实体
+ * 持久化每次客户端定制构建的状态与配置
+ */
+@Entity('nexus_builds')
+export class NexusBuild {
+  /** Nexus 构建任务 ID */
+  @PrimaryColumn()
+  @Index()
+  requestId: string;
+
+  /** 关联的本地用户 GUID */
+  @Column()
+  @Index()
+  userGuid: string;
+
+  /** 操作系统 */
+  @Column()
+  os: string;
+
+  /** 架构 */
+  @Column()
+  arch: string;
+
+  /** 应用名称 */
+  @Column()
+  appName: string;
+
+  /** 定制配置 JSON */
+  @Column({ type: 'text', nullable: true })
+  custom: string;
+
+  /** 构建状态 */
+  @Column({ default: 'pending' })
+  status: BuildStatus;
+
+  /** 构建产物文件列表 JSON */
+  @Column({ type: 'text', nullable: true })
+  files: string;
+
+  /** 状态补充说明 */
+  @Column({ nullable: true })
+  message: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/nexus/entities/nexus-token.entity.ts
+++ b/src/modules/nexus/entities/nexus-token.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Nexus Token 实体
+ * 存储用户与 Nexus 系统的 GitHub OAuth Token 关联
+ */
+@Entity('nexus_tokens')
+export class NexusToken {
+  /** 关联的本地用户 GUID */
+  @PrimaryColumn()
+  @Index()
+  userGuid: string;
+
+  /** Nexus JWT Token */
+  @Column({ type: 'text' })
+  nexusToken: string;
+
+  /** GitHub 用户名 */
+  @Column()
+  nexusUsername: string;
+
+  /** Token 过期时间 */
+  @Column({ type: 'datetime' })
+  expiresAt: Date;
+
+  /** 当前构建任务 ID（如有） */
+  @Column({ nullable: true })
+  currentRequestId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /** 检查 Token 是否已过期 */
+  isExpired(): boolean {
+    return new Date() > this.expiresAt;
+  }
+}

--- a/src/modules/nexus/entities/nexus-token.entity.ts
+++ b/src/modules/nexus/entities/nexus-token.entity.ts
@@ -30,9 +30,9 @@ export class NexusToken {
   @Column({ type: 'datetime' })
   expiresAt: Date;
 
-  /** 当前构建任务 ID（如有） */
+  /** 当前构建任务 UUID（如有） */
   @Column({ nullable: true })
-  currentRequestId: string;
+  currentUuid: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -8,8 +8,11 @@ import {
   Res,
   HttpCode,
   HttpStatus,
+  NotFoundException,
 } from '@nestjs/common';
 import type { Response } from 'express';
+import { createReadStream, existsSync, statSync } from 'fs';
+import { basename } from 'path';
 import { NexusService } from './nexus.service';
 import { NexusLoginDto } from './dto/nexus-auth.dto';
 import { NexusGenerateDto } from './dto/nexus-client.dto';
@@ -21,7 +24,6 @@ export class NexusController {
 
   /**
    * 创建 Nexus 登录会话
-   * 调用 Nexus API 获取 login_id 和 auth_url，前端打开 auth_url 引导用户授权
    */
   @Post('auth/login')
   @HttpCode(HttpStatus.OK)
@@ -34,7 +36,6 @@ export class NexusController {
 
   /**
    * 轮询 Nexus 登录状态
-   * 前端每 2-3 秒轮询此接口，登录成功后后端自动存储 Nexus Token
    */
   @Get('auth/status')
   async pollLoginStatus(@Query('login_id') loginId: string) {
@@ -76,6 +77,7 @@ export class NexusController {
 
   /**
    * 查询构建状态
+   * 构建完成后后端自动下载产物到本地
    */
   @Get('client/status')
   async getBuildStatus(@CurrentUser('id') userGuid: string) {
@@ -83,27 +85,22 @@ export class NexusController {
   }
 
   /**
-   * 列出构建产物的文件列表
-   * 构建完成后，前端先调用此接口获取可下载的文件名列表
+   * 列出构建产物的文件列表（从本地存储读取）
    */
   @Get('client/files')
-  async listBuildFiles(
-    @CurrentUser('id') userGuid: string,
-    @Query('request_id') requestId: string,
-  ) {
+  async listBuildFiles(@Query('request_id') requestId: string) {
     if (!requestId) {
       return [];
     }
-    return this.nexusService.listBuildFiles(userGuid, requestId);
+    return this.nexusService.listBuildFiles(requestId);
   }
 
   /**
    * 下载构建产物
-   * 流式转发指定文件
+   * 直接从本地存储返回文件流
    */
   @Get('client/download')
   async downloadBuildFile(
-    @CurrentUser('id') userGuid: string,
     @Query('request_id') requestId: string,
     @Query('filename') filename: string,
     @Res() res: Response,
@@ -113,33 +110,21 @@ export class NexusController {
       return;
     }
 
-    const result = await this.nexusService.downloadBuildFile(
-      userGuid,
-      requestId,
-      filename,
-    );
+    const filePath = this.nexusService.getLocalFilePath(requestId, filename);
 
-    res.setHeader('Content-Type', result.contentType);
+    if (!existsSync(filePath)) {
+      throw new NotFoundException('文件不存在');
+    }
+
+    const stat = statSync(filePath);
+    res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader(
       'Content-Disposition',
-      `attachment; filename="${result.filename}"`,
+      `attachment; filename="${basename(filePath)}"`,
     );
+    res.setHeader('Content-Length', stat.size);
 
-    if (!result.stream) {
-      res.status(500).send('下载失败');
-      return;
-    }
-
-    const reader = result.stream.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        res.write(value);
-      }
-      res.end();
-    } catch {
-      res.end();
-    }
+    const stream = createReadStream(filePath);
+    stream.pipe(res);
   }
 }

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -1,0 +1,124 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Query,
+  Res,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import type { Response } from 'express';
+import { NexusService } from './nexus.service';
+import { NexusLoginDto } from './dto/nexus-auth.dto';
+import { NexusGenerateDto } from './dto/nexus-client.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@Controller('nexus')
+export class NexusController {
+  constructor(private readonly nexusService: NexusService) {}
+
+  /**
+   * 创建 Nexus 登录会话
+   * 调用 Nexus API 获取 login_id 和 auth_url，前端打开 auth_url 引导用户授权
+   */
+  @Post('auth/login')
+  @HttpCode(HttpStatus.OK)
+  async createLoginSession(
+    @CurrentUser('id') userGuid: string,
+    @Body() _dto: NexusLoginDto,
+  ) {
+    return this.nexusService.createLoginSession(userGuid);
+  }
+
+  /**
+   * 轮询 Nexus 登录状态
+   * 前端每 2-3 秒轮询此接口，登录成功后后端自动存储 Nexus Token
+   */
+  @Get('auth/status')
+  async pollLoginStatus(@Query('login_id') loginId: string) {
+    if (!loginId) {
+      return { state: 'failed', error: '缺少 login_id 参数' };
+    }
+    return this.nexusService.pollLoginStatus(loginId);
+  }
+
+  /**
+   * 查询 Nexus 绑定状态
+   */
+  @Get('auth/bind-status')
+  async getBindStatus(@CurrentUser('id') userGuid: string) {
+    return this.nexusService.getBindStatus(userGuid);
+  }
+
+  /**
+   * 解绑 Nexus 账号
+   */
+  @Delete('auth/bind')
+  @HttpCode(HttpStatus.OK)
+  async unbind(@CurrentUser('id') userGuid: string) {
+    await this.nexusService.unbind(userGuid);
+    return { message: '已解绑 Nexus 账号' };
+  }
+
+  /**
+   * 提交客户端构建请求
+   */
+  @Post('client/generate')
+  @HttpCode(HttpStatus.OK)
+  async submitBuild(
+    @CurrentUser('id') userGuid: string,
+    @Body() dto: NexusGenerateDto,
+  ) {
+    return this.nexusService.submitBuild(userGuid, dto);
+  }
+
+  /**
+   * 查询构建状态
+   */
+  @Get('client/status')
+  async getBuildStatus(@CurrentUser('id') userGuid: string) {
+    return this.nexusService.getBuildStatus(userGuid);
+  }
+
+  /**
+   * 下载构建产物
+   * 流式转发 ZIP 文件
+   */
+  @Get('client/download')
+  async downloadBuild(
+    @CurrentUser('id') userGuid: string,
+    @Query('request_id') requestId: string,
+    @Res() res: Response,
+  ) {
+    const { stream, filename } = await this.nexusService.downloadBuild(
+      userGuid,
+      requestId,
+    );
+
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${filename}"`,
+    );
+
+    if (!stream) {
+      res.status(500).send('下载失败');
+      return;
+    }
+
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(value);
+      }
+      res.end();
+    } catch {
+      res.end();
+    }
+  }
+}

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -86,13 +86,13 @@ export class NexusController {
 
   /** 列出构建产物的文件列表 */
   @Get('builds/:uuid/files')
-  async listBuildFiles(@Param('uuid') uuid: string) {
+  listBuildFiles(@Param('uuid') uuid: string) {
     return this.nexusService.listBuildFiles(uuid);
   }
 
   /** 下载构建产物 */
   @Get('builds/:uuid/files/:filename')
-  async downloadBuildFile(
+  downloadBuildFile(
     @Param('uuid') uuid: string,
     @Param('filename') filename: string,
     @Res() res: Response,

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -29,9 +29,9 @@ export class NexusController {
   @HttpCode(HttpStatus.OK)
   async createLoginSession(
     @CurrentUser('id') userGuid: string,
-    @Body() dto: NexusLoginDto,
+    @Body() _dto: NexusLoginDto,
   ) {
-    return this.nexusService.createLoginSession(userGuid, dto.install_id);
+    return this.nexusService.createLoginSession(userGuid);
   }
 
   @Get('auth/status')

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -66,28 +66,10 @@ export class NexusController {
     return this.nexusService.submitBuild(userGuid, dto);
   }
 
-  /** 获取当前用户的所有构建记录 */
+  /** 获取当前用户的所有构建记录（含实时状态） */
   @Get('builds')
   async listBuilds(@CurrentUser('id') userGuid: string) {
     return this.nexusService.listBuilds(userGuid);
-  }
-
-  /** 获取单个构建记录 */
-  @Get('builds/:requestId')
-  async getBuild(
-    @CurrentUser('id') userGuid: string,
-    @Param('requestId') requestId: string,
-  ) {
-    return this.nexusService.getBuild(userGuid, requestId);
-  }
-
-  /** 查询当前构建状态（轮询用，自动下载产物到本地） */
-  @Get('builds/:requestId/status')
-  async getBuildStatus(
-    @CurrentUser('id') userGuid: string,
-    @Param('requestId') requestId: string,
-  ) {
-    return this.nexusService.getBuildStatusByRequestId(userGuid, requestId);
   }
 
   /** 删除构建记录 */

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -29,9 +29,9 @@ export class NexusController {
   @HttpCode(HttpStatus.OK)
   async createLoginSession(
     @CurrentUser('id') userGuid: string,
-    @Body() _dto: NexusLoginDto,
+    @Body() dto: NexusLoginDto,
   ) {
-    return this.nexusService.createLoginSession(userGuid);
+    return this.nexusService.createLoginSession(userGuid, dto.install_id);
   }
 
   @Get('auth/status')

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -73,31 +73,31 @@ export class NexusController {
   }
 
   /** 删除构建记录 */
-  @Delete('builds/:requestId')
+  @Delete('builds/:uuid')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteBuild(
     @CurrentUser('id') userGuid: string,
-    @Param('requestId') requestId: string,
+    @Param('uuid') uuid: string,
   ) {
-    await this.nexusService.deleteBuild(userGuid, requestId);
+    await this.nexusService.deleteBuild(userGuid, uuid);
   }
 
   // ── Files & Download ──────────────────────────────────
 
   /** 列出构建产物的文件列表 */
-  @Get('builds/:requestId/files')
-  async listBuildFiles(@Param('requestId') requestId: string) {
-    return this.nexusService.listBuildFiles(requestId);
+  @Get('builds/:uuid/files')
+  async listBuildFiles(@Param('uuid') uuid: string) {
+    return this.nexusService.listBuildFiles(uuid);
   }
 
   /** 下载构建产物 */
-  @Get('builds/:requestId/files/:filename')
+  @Get('builds/:uuid/files/:filename')
   async downloadBuildFile(
-    @Param('requestId') requestId: string,
+    @Param('uuid') uuid: string,
     @Param('filename') filename: string,
     @Res() res: Response,
   ) {
-    const filePath = this.nexusService.getLocalFilePath(requestId, filename);
+    const filePath = this.nexusService.getLocalFilePath(uuid, filename);
 
     if (!existsSync(filePath)) {
       throw new NotFoundException('文件不存在');

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -4,6 +4,7 @@ import {
   Post,
   Delete,
   Body,
+  Param,
   Query,
   Res,
   HttpCode,
@@ -22,9 +23,8 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 export class NexusController {
   constructor(private readonly nexusService: NexusService) {}
 
-  /**
-   * 创建 Nexus 登录会话
-   */
+  // ── Auth ──────────────────────────────────────────────
+
   @Post('auth/login')
   @HttpCode(HttpStatus.OK)
   async createLoginSession(
@@ -34,9 +34,6 @@ export class NexusController {
     return this.nexusService.createLoginSession(userGuid);
   }
 
-  /**
-   * 轮询 Nexus 登录状态
-   */
   @Get('auth/status')
   async pollLoginStatus(@Query('login_id') loginId: string) {
     if (!loginId) {
@@ -45,17 +42,11 @@ export class NexusController {
     return this.nexusService.pollLoginStatus(loginId);
   }
 
-  /**
-   * 查询 Nexus 绑定状态
-   */
   @Get('auth/bind-status')
   async getBindStatus(@CurrentUser('id') userGuid: string) {
     return this.nexusService.getBindStatus(userGuid);
   }
 
-  /**
-   * 解绑 Nexus 账号
-   */
   @Delete('auth/bind')
   @HttpCode(HttpStatus.OK)
   async unbind(@CurrentUser('id') userGuid: string) {
@@ -63,53 +54,67 @@ export class NexusController {
     return { message: '已解绑 Nexus 账号' };
   }
 
-  /**
-   * 提交客户端构建请求
-   */
-  @Post('client/generate')
-  @HttpCode(HttpStatus.OK)
-  async submitBuild(
+  // ── Builds (RESTful) ──────────────────────────────────
+
+  /** 提交客户端构建请求 */
+  @Post('builds')
+  @HttpCode(HttpStatus.CREATED)
+  async createBuild(
     @CurrentUser('id') userGuid: string,
     @Body() dto: NexusGenerateDto,
   ) {
     return this.nexusService.submitBuild(userGuid, dto);
   }
 
-  /**
-   * 查询构建状态
-   * 构建完成后后端自动下载产物到本地
-   */
-  @Get('client/status')
-  async getBuildStatus(@CurrentUser('id') userGuid: string) {
-    return this.nexusService.getBuildStatus(userGuid);
+  /** 获取当前用户的所有构建记录 */
+  @Get('builds')
+  async listBuilds(@CurrentUser('id') userGuid: string) {
+    return this.nexusService.listBuilds(userGuid);
   }
 
-  /**
-   * 列出构建产物的文件列表（从本地存储读取）
-   */
-  @Get('client/files')
-  async listBuildFiles(@Query('request_id') requestId: string) {
-    if (!requestId) {
-      return [];
-    }
+  /** 获取单个构建记录 */
+  @Get('builds/:requestId')
+  async getBuild(
+    @CurrentUser('id') userGuid: string,
+    @Param('requestId') requestId: string,
+  ) {
+    return this.nexusService.getBuild(userGuid, requestId);
+  }
+
+  /** 查询当前构建状态（轮询用，自动下载产物到本地） */
+  @Get('builds/:requestId/status')
+  async getBuildStatus(
+    @CurrentUser('id') userGuid: string,
+    @Param('requestId') requestId: string,
+  ) {
+    return this.nexusService.getBuildStatusByRequestId(userGuid, requestId);
+  }
+
+  /** 删除构建记录 */
+  @Delete('builds/:requestId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteBuild(
+    @CurrentUser('id') userGuid: string,
+    @Param('requestId') requestId: string,
+  ) {
+    await this.nexusService.deleteBuild(userGuid, requestId);
+  }
+
+  // ── Files & Download ──────────────────────────────────
+
+  /** 列出构建产物的文件列表 */
+  @Get('builds/:requestId/files')
+  async listBuildFiles(@Param('requestId') requestId: string) {
     return this.nexusService.listBuildFiles(requestId);
   }
 
-  /**
-   * 下载构建产物
-   * 直接从本地存储返回文件流
-   */
-  @Get('client/download')
+  /** 下载构建产物 */
+  @Get('builds/:requestId/files/:filename')
   async downloadBuildFile(
-    @Query('request_id') requestId: string,
-    @Query('filename') filename: string,
+    @Param('requestId') requestId: string,
+    @Param('filename') filename: string,
     @Res() res: Response,
   ) {
-    if (!requestId || !filename) {
-      res.status(400).json({ message: 'request_id 和 filename 为必填参数' });
-      return;
-    }
-
     const filePath = this.nexusService.getLocalFilePath(requestId, filename);
 
     if (!existsSync(filePath)) {

--- a/src/modules/nexus/nexus.controller.ts
+++ b/src/modules/nexus/nexus.controller.ts
@@ -9,7 +9,6 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import type { Response } from 'express';
 import { NexusService } from './nexus.service';
 import { NexusLoginDto } from './dto/nexus-auth.dto';
@@ -84,32 +83,54 @@ export class NexusController {
   }
 
   /**
-   * 下载构建产物
-   * 流式转发 ZIP 文件
+   * 列出构建产物的文件列表
+   * 构建完成后，前端先调用此接口获取可下载的文件名列表
    */
-  @Get('client/download')
-  async downloadBuild(
+  @Get('client/files')
+  async listBuildFiles(
     @CurrentUser('id') userGuid: string,
     @Query('request_id') requestId: string,
+  ) {
+    if (!requestId) {
+      return [];
+    }
+    return this.nexusService.listBuildFiles(userGuid, requestId);
+  }
+
+  /**
+   * 下载构建产物
+   * 流式转发指定文件
+   */
+  @Get('client/download')
+  async downloadBuildFile(
+    @CurrentUser('id') userGuid: string,
+    @Query('request_id') requestId: string,
+    @Query('filename') filename: string,
     @Res() res: Response,
   ) {
-    const { stream, filename } = await this.nexusService.downloadBuild(
+    if (!requestId || !filename) {
+      res.status(400).json({ message: 'request_id 和 filename 为必填参数' });
+      return;
+    }
+
+    const result = await this.nexusService.downloadBuildFile(
       userGuid,
       requestId,
+      filename,
     );
 
-    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Type', result.contentType);
     res.setHeader(
       'Content-Disposition',
-      `attachment; filename="${filename}"`,
+      `attachment; filename="${result.filename}"`,
     );
 
-    if (!stream) {
+    if (!result.stream) {
       res.status(500).send('下载失败');
       return;
     }
 
-    const reader = stream.getReader();
+    const reader = result.stream.getReader();
     try {
       while (true) {
         const { done, value } = await reader.read();

--- a/src/modules/nexus/nexus.module.ts
+++ b/src/modules/nexus/nexus.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NexusController } from './nexus.controller';
+import { NexusService } from './nexus.service';
+import { NexusToken } from './entities/nexus-token.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([NexusToken])],
+  controllers: [NexusController],
+  providers: [NexusService],
+  exports: [NexusService],
+})
+export class NexusModule {}

--- a/src/modules/nexus/nexus.module.ts
+++ b/src/modules/nexus/nexus.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { NexusController } from './nexus.controller';
 import { NexusService } from './nexus.service';
 import { NexusToken } from './entities/nexus-token.entity';
+import { NexusBuild } from './entities/nexus-build.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([NexusToken])],
+  imports: [TypeOrmModule.forFeature([NexusToken, NexusBuild])],
   controllers: [NexusController],
   providers: [NexusService],
   exports: [NexusService],

--- a/src/modules/nexus/nexus.module.ts
+++ b/src/modules/nexus/nexus.module.ts
@@ -4,9 +4,13 @@ import { NexusController } from './nexus.controller';
 import { NexusService } from './nexus.service';
 import { NexusToken } from './entities/nexus-token.entity';
 import { NexusBuild } from './entities/nexus-build.entity';
+import { UpdateCheckModule } from '../update-check/update-check.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([NexusToken, NexusBuild])],
+  imports: [
+    TypeOrmModule.forFeature([NexusToken, NexusBuild]),
+    UpdateCheckModule,
+  ],
   controllers: [NexusController],
   providers: [NexusService],
   exports: [NexusService],

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -11,7 +11,13 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync } from 'fs';
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  readdirSync,
+  mkdirSync,
+} from 'fs';
 import { join } from 'path';
 import { NexusToken } from './entities/nexus-token.entity';
 import { NexusBuild } from './entities/nexus-build.entity';
@@ -59,7 +65,10 @@ export class NexusService implements OnModuleInit {
 
   async onModuleInit() {
     // 启动定时轮询
-    this.pollTimer = setInterval(() => this.pollActiveBuilds(), POLL_INTERVAL_MS);
+    this.pollTimer = setInterval(
+      () => this.pollActiveBuilds(),
+      POLL_INTERVAL_MS,
+    );
     // 首次立即执行一次
     await this.pollActiveBuilds();
   }
@@ -71,10 +80,7 @@ export class NexusService implements OnModuleInit {
   private async pollActiveBuilds() {
     try {
       const activeBuilds = await this.nexusBuildRepository.find({
-        where: [
-          { status: 'pending' as NexusBuild['status'] },
-          { status: 'building' as NexusBuild['status'] },
-        ],
+        where: [{ status: 'pending' }, { status: 'building' }],
       });
 
       if (activeBuilds.length === 0) return;
@@ -83,7 +89,9 @@ export class NexusService implements OnModuleInit {
         await this.syncBuildStatus(build);
       }
     } catch (err) {
-      this.logger.error(`Error polling active builds: ${err instanceof Error ? err.message : err}`);
+      this.logger.error(
+        `Error polling active builds: ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
 
@@ -113,9 +121,7 @@ export class NexusService implements OnModuleInit {
     );
 
     if (!response.ok) {
-      this.logger.warn(
-        `Poll build ${build.uuid} failed: ${response.status}`,
-      );
+      this.logger.warn(`Poll build ${build.uuid} failed: ${response.status}`);
       return;
     }
 
@@ -125,7 +131,7 @@ export class NexusService implements OnModuleInit {
     await this.nexusBuildRepository.update(
       { uuid: build.uuid },
       {
-        status: data.status as NexusBuild['status'],
+        status: data.status,
         files: data.files ? JSON.stringify(data.files) : undefined,
         message: data.message ?? undefined,
       },
@@ -188,9 +194,7 @@ export class NexusService implements OnModuleInit {
   /**
    * 轮询 Nexus 登录状态
    */
-  async pollLoginStatus(
-    loginId: string,
-  ): Promise<NexusAuthStatusResponse> {
+  async pollLoginStatus(loginId: string): Promise<NexusAuthStatusResponse> {
     const response = await this.fetchNexus(
       `/v1/auth/github/status?login_id=${encodeURIComponent(loginId)}`,
       { method: 'GET' },
@@ -201,9 +205,7 @@ export class NexusService implements OnModuleInit {
     }
 
     if (!response.ok) {
-      this.logger.error(
-        `Nexus login status poll failed: ${response.status}`,
-      );
+      this.logger.error(`Nexus login status poll failed: ${response.status}`);
       return { state: 'failed', error: '查询登录状态失败' };
     }
 
@@ -258,7 +260,11 @@ export class NexusService implements OnModuleInit {
     }
 
     if (nexusToken.isExpired()) {
-      return { bound: false, expired: true, nexus_username: nexusToken.nexusUsername };
+      return {
+        bound: false,
+        expired: true,
+        nexus_username: nexusToken.nexusUsername,
+      };
     }
 
     return { bound: true, nexus_username: nexusToken.nexusUsername };
@@ -419,14 +425,14 @@ export class NexusService implements OnModuleInit {
           this.logger.error(
             `Failed to download ${file}: ${response.status} ${await response.text()}`,
           );
-          throw new InternalServerErrorException(
-            `下载构建产物 ${file} 失败`,
-          );
+          throw new InternalServerErrorException(`下载构建产物 ${file} 失败`);
         }
 
         const writeStream = createWriteStream(filePath);
         if (!response.body) {
-          throw new InternalServerErrorException(`下载构建产物 ${file} 失败：响应体为空`);
+          throw new InternalServerErrorException(
+            `下载构建产物 ${file} 失败：响应体为空`,
+          );
         }
         const reader = response.body.getReader();
 

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   Logger,
+  OnModuleInit,
   BadRequestException,
   UnauthorizedException,
   ForbiddenException,
@@ -9,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { NexusToken } from './entities/nexus-token.entity';
@@ -27,11 +28,13 @@ import {
 
 const NEXUS_BASE_URL = 'https://api.databk.top';
 const DEFAULT_STORAGE_PATH = './data/nexus-builds';
+const POLL_INTERVAL_MS = 10_000;
 
 @Injectable()
-export class NexusService {
+export class NexusService implements OnModuleInit {
   private readonly logger = new Logger(NexusService.name);
   private readonly storagePath: string;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
 
   /** 内存中暂存 login_id 与 userGuid 的映射，用于轮询成功后关联用户 */
   private loginSessionMap = new Map<string, string>();
@@ -50,6 +53,98 @@ export class NexusService {
       'NEXUS_STORAGE_PATH',
       DEFAULT_STORAGE_PATH,
     );
+  }
+
+  async onModuleInit() {
+    // 启动定时轮询
+    this.pollTimer = setInterval(() => this.pollActiveBuilds(), POLL_INTERVAL_MS);
+    // 首次立即执行一次
+    await this.pollActiveBuilds();
+  }
+
+  /**
+   * 定时轮询所有进行中的构建任务
+   * 每隔 10 秒查询一次 Nexus，更新状态并下载产物
+   */
+  private async pollActiveBuilds() {
+    try {
+      const activeBuilds = await this.nexusBuildRepository.find({
+        where: [
+          { status: 'pending' as NexusBuild['status'] },
+          { status: 'building' as NexusBuild['status'] },
+        ],
+      });
+
+      if (activeBuilds.length === 0) return;
+
+      for (const build of activeBuilds) {
+        await this.syncBuildStatus(build);
+      }
+    } catch (err) {
+      this.logger.error(`Error polling active builds: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /**
+   * 同步单个构建任务的状态
+   */
+  private async syncBuildStatus(build: NexusBuild) {
+    const nexusToken = await this.nexusTokenRepository.findOne({
+      where: { userGuid: build.userGuid },
+    });
+
+    if (!nexusToken || nexusToken.isExpired()) {
+      // Nexus Token 不可用，标记任务失败
+      await this.nexusBuildRepository.update(
+        { requestId: build.requestId },
+        { status: 'failed', message: 'Nexus Token 已过期' },
+      );
+      return;
+    }
+
+    const response = await this.fetchNexus(
+      `/v1/client/generate/${encodeURIComponent(build.requestId)}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${nexusToken.nexusToken}` },
+      },
+    );
+
+    if (!response.ok) {
+      this.logger.warn(
+        `Poll build ${build.requestId} failed: ${response.status}`,
+      );
+      return;
+    }
+
+    const data = (await response.json()) as NexusBuildStatusResponse;
+
+    // 更新构建记录
+    await this.nexusBuildRepository.update(
+      { requestId: build.requestId },
+      {
+        status: data.status as NexusBuild['status'],
+        files: data.files ? JSON.stringify(data.files) : undefined,
+        message: data.message ?? undefined,
+      },
+    );
+
+    // 构建完成后下载产物
+    if (data.status === 'completed' && data.files?.length) {
+      await this.downloadBuildFilesToLocal(
+        nexusToken.nexusToken,
+        build.requestId,
+        data.files,
+      );
+    }
+
+    // 终态时清除 currentRequestId
+    if (['completed', 'failed', 'cancelled'].includes(data.status)) {
+      if (nexusToken.currentRequestId === build.requestId) {
+        nexusToken.currentRequestId = null as unknown as string;
+        await this.nexusTokenRepository.save(nexusToken);
+      }
+    }
   }
 
   /**
@@ -241,100 +336,6 @@ export class NexusService {
   }
 
   /**
-   * 查询构建状态
-   * 构建完成后自动将产物下载到本地，并更新构建记录
-   */
-  async getBuildStatusByRequestId(
-    userGuid: string,
-    requestId: string,
-  ): Promise<NexusBuildStatusResponse> {
-    const nexusToken = await this.getValidNexusToken(userGuid);
-
-    // 校验构建记录属于当前用户
-    const build = await this.nexusBuildRepository.findOne({
-      where: { requestId, userGuid },
-    });
-    if (!build) {
-      throw new BadRequestException('构建记录不存在');
-    }
-
-    // 如果已是终态且文件已下载到本地，直接返回
-    if (build.status === 'completed') {
-      const localFiles = this.getLocalFiles(requestId);
-      if (localFiles.length > 0) {
-        return {
-          request_id: requestId,
-          status: 'completed',
-          files: localFiles,
-        };
-      }
-    }
-
-    // 终态不再查询 Nexus
-    if (['failed', 'cancelled'].includes(build.status)) {
-      return {
-        request_id: requestId,
-        status: build.status,
-        message: build.message ?? undefined,
-      };
-    }
-
-    const response = await this.fetchNexus(
-      `/v1/client/generate/${encodeURIComponent(requestId)}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${nexusToken.nexusToken}`,
-        },
-      },
-    );
-
-    if (response.status === 401) {
-      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
-    }
-
-    if (!response.ok) {
-      this.logger.error(
-        `Nexus build status query failed: ${response.status}`,
-      );
-      throw new InternalServerErrorException('查询构建状态失败');
-    }
-
-    const data = (await response.json()) as NexusBuildStatusResponse;
-
-    // 更新构建记录状态
-    await this.nexusBuildRepository.update(
-      { requestId },
-      {
-        status: data.status as NexusBuild['status'],
-        files: data.files ? JSON.stringify(data.files) : undefined,
-        message: data.message ?? undefined,
-      },
-    );
-
-    // 构建完成后，将产物下载到本地
-    if (data.status === 'completed' && data.files?.length) {
-      await this.downloadBuildFilesToLocal(
-        nexusToken.nexusToken,
-        requestId,
-        data.files,
-      );
-      // 清除 currentRequestId（如仍指向此任务）
-      if (nexusToken.currentRequestId === requestId) {
-        nexusToken.currentRequestId = null as unknown as string;
-        await this.nexusTokenRepository.save(nexusToken);
-      }
-    } else if (['failed', 'cancelled'].includes(data.status)) {
-      if (nexusToken.currentRequestId === requestId) {
-        nexusToken.currentRequestId = null as unknown as string;
-        await this.nexusTokenRepository.save(nexusToken);
-      }
-    }
-
-    return data;
-  }
-
-  /**
    * 获取当前用户的所有构建记录
    */
   async listBuilds(userGuid: string): Promise<NexusBuild[]> {
@@ -345,20 +346,7 @@ export class NexusService {
   }
 
   /**
-   * 获取单个构建记录
-   */
-  async getBuild(userGuid: string, requestId: string): Promise<NexusBuild> {
-    const build = await this.nexusBuildRepository.findOne({
-      where: { requestId, userGuid },
-    });
-    if (!build) {
-      throw new BadRequestException('构建记录不存在');
-    }
-    return build;
-  }
-
-  /**
-   * 删除构建记录及本地文件
+   * 删除构建记录
    */
   async deleteBuild(userGuid: string, requestId: string): Promise<void> {
     const build = await this.nexusBuildRepository.findOne({

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -18,7 +18,7 @@ import {
   readdirSync,
   mkdirSync,
 } from 'fs';
-import { join } from 'path';
+import { resolve, relative } from 'path';
 import { NexusToken } from './entities/nexus-token.entity';
 import { NexusBuild } from './entities/nexus-build.entity';
 import { UpdateCheckService } from '../update-check/update-check.service';
@@ -160,6 +160,19 @@ export class NexusService implements OnModuleInit {
    */
   getStoragePath(): string {
     return this.storagePath;
+  }
+
+  /**
+   * Safely join storage path with user-provided segments.
+   * Throws BadRequestException if the resolved path escapes storagePath.
+   */
+  private safeJoin(...segments: string[]): string {
+    const target = resolve(this.storagePath, ...segments);
+    const rel = relative(this.storagePath, target);
+    if (rel.startsWith('..') || resolve(this.storagePath) === target) {
+      throw new BadRequestException('Invalid path');
+    }
+    return target;
   }
 
   /**
@@ -383,7 +396,7 @@ export class NexusService implements OnModuleInit {
    * 获取本地文件路径，用于下载
    */
   getLocalFilePath(uuid: string, filename: string): string {
-    return join(this.storagePath, uuid, filename);
+    return this.safeJoin(uuid, filename);
   }
 
   /**
@@ -399,12 +412,12 @@ export class NexusService implements OnModuleInit {
     }
     this.downloadingSet.add(uuid);
 
-    const dir = join(this.storagePath, uuid);
+    const dir = this.safeJoin(uuid);
     mkdirSync(dir, { recursive: true });
 
     try {
       for (const file of files) {
-        const filePath = join(dir, file);
+        const filePath = this.safeJoin(uuid, file);
         if (existsSync(filePath)) {
           continue;
         }
@@ -463,13 +476,13 @@ export class NexusService implements OnModuleInit {
    * 从本地目录读取文件列表
    */
   private getLocalFiles(uuid: string): string[] {
-    const dir = join(this.storagePath, uuid);
+    const dir = this.safeJoin(uuid);
     if (!existsSync(dir)) {
       return [];
     }
     return readdirSync(dir).filter((f) => {
       try {
-        return !createReadStream(join(dir, f)).destroyed;
+        return !createReadStream(this.safeJoin(uuid, f)).destroyed;
       } catch {
         return false;
       }

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -12,8 +12,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { pipeline } from 'stream/promises';
 import { NexusToken } from './entities/nexus-token.entity';
+import { NexusBuild } from './entities/nexus-build.entity';
 import {
   NexusLoginResponse,
   NexusAuthStatusResponse,
@@ -42,6 +42,8 @@ export class NexusService {
   constructor(
     @InjectRepository(NexusToken)
     private nexusTokenRepository: Repository<NexusToken>,
+    @InjectRepository(NexusBuild)
+    private nexusBuildRepository: Repository<NexusBuild>,
     private configService: ConfigService,
   ) {
     this.storagePath = this.configService.get<string>(
@@ -223,32 +225,62 @@ export class NexusService {
     nexusToken.currentRequestId = data.request_id;
     await this.nexusTokenRepository.save(nexusToken);
 
+    // 持久化构建记录
+    const build = this.nexusBuildRepository.create({
+      requestId: data.request_id,
+      userGuid,
+      os: dto.os,
+      arch: dto.arch,
+      appName: dto.custom?.['app-name'] ?? '',
+      custom: JSON.stringify(dto.custom),
+      status: 'pending',
+    });
+    await this.nexusBuildRepository.save(build);
+
     return data;
   }
 
   /**
    * 查询构建状态
-   * 构建完成后自动将产物下载到本地
+   * 构建完成后自动将产物下载到本地，并更新构建记录
    */
-  async getBuildStatus(userGuid: string): Promise<NexusBuildStatusResponse> {
+  async getBuildStatusByRequestId(
+    userGuid: string,
+    requestId: string,
+  ): Promise<NexusBuildStatusResponse> {
     const nexusToken = await this.getValidNexusToken(userGuid);
 
-    if (!nexusToken.currentRequestId) {
-      throw new BadRequestException('当前没有构建任务');
+    // 校验构建记录属于当前用户
+    const build = await this.nexusBuildRepository.findOne({
+      where: { requestId, userGuid },
+    });
+    if (!build) {
+      throw new BadRequestException('构建记录不存在');
     }
 
-    // 如果文件已下载到本地，直接从本地返回终态
-    const localFiles = this.getLocalFiles(nexusToken.currentRequestId);
-    if (localFiles.length > 0) {
+    // 如果已是终态且文件已下载到本地，直接返回
+    if (build.status === 'completed') {
+      const localFiles = this.getLocalFiles(requestId);
+      if (localFiles.length > 0) {
+        return {
+          request_id: requestId,
+          status: 'completed',
+          files: localFiles,
+        };
+      }
+    }
+
+    // 终态不再查询 Nexus
+    if (['failed', 'cancelled'].includes(build.status)) {
       return {
-        request_id: nexusToken.currentRequestId,
-        status: 'completed',
-        files: localFiles,
+        request_id: requestId,
+        status: build.status,
+        message: build.message ?? undefined,
       };
     }
 
     const response = await this.fetchNexus(
-      `/v1/client/generate/${encodeURIComponent(nexusToken.currentRequestId)}`,
+      `/v1/client/generate/${encodeURIComponent(requestId)}`,
       {
         method: 'GET',
         headers: {
@@ -270,22 +302,75 @@ export class NexusService {
 
     const data = (await response.json()) as NexusBuildStatusResponse;
 
+    // 更新构建记录状态
+    await this.nexusBuildRepository.update(
+      { requestId },
+      {
+        status: data.status as NexusBuild['status'],
+        files: data.files ? JSON.stringify(data.files) : undefined,
+        message: data.message ?? undefined,
+      },
+    );
+
     // 构建完成后，将产物下载到本地
     if (data.status === 'completed' && data.files?.length) {
       await this.downloadBuildFilesToLocal(
         nexusToken.nexusToken,
-        nexusToken.currentRequestId,
+        requestId,
         data.files,
       );
-      // 下载完成后清除 currentRequestId
-      nexusToken.currentRequestId = null as unknown as string;
-      await this.nexusTokenRepository.save(nexusToken);
+      // 清除 currentRequestId（如仍指向此任务）
+      if (nexusToken.currentRequestId === requestId) {
+        nexusToken.currentRequestId = null as unknown as string;
+        await this.nexusTokenRepository.save(nexusToken);
+      }
     } else if (['failed', 'cancelled'].includes(data.status)) {
-      nexusToken.currentRequestId = null as unknown as string;
-      await this.nexusTokenRepository.save(nexusToken);
+      if (nexusToken.currentRequestId === requestId) {
+        nexusToken.currentRequestId = null as unknown as string;
+        await this.nexusTokenRepository.save(nexusToken);
+      }
     }
 
     return data;
+  }
+
+  /**
+   * 获取当前用户的所有构建记录
+   */
+  async listBuilds(userGuid: string): Promise<NexusBuild[]> {
+    return this.nexusBuildRepository.find({
+      where: { userGuid },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * 获取单个构建记录
+   */
+  async getBuild(userGuid: string, requestId: string): Promise<NexusBuild> {
+    const build = await this.nexusBuildRepository.findOne({
+      where: { requestId, userGuid },
+    });
+    if (!build) {
+      throw new BadRequestException('构建记录不存在');
+    }
+    return build;
+  }
+
+  /**
+   * 删除构建记录及本地文件
+   */
+  async deleteBuild(userGuid: string, requestId: string): Promise<void> {
+    const build = await this.nexusBuildRepository.findOne({
+      where: { requestId, userGuid },
+    });
+    if (!build) {
+      throw new BadRequestException('构建记录不存在');
+    }
+    if (build.status === 'pending' || build.status === 'building') {
+      throw new BadRequestException('进行中的构建任务不能删除');
+    }
+    await this.nexusBuildRepository.delete({ requestId });
   }
 
   /**

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -1,0 +1,362 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  UnauthorizedException,
+  ForbiddenException,
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NexusToken } from './entities/nexus-token.entity';
+import {
+  NexusLoginResponse,
+  NexusAuthStatusResponse,
+  NexusBindStatusResponse,
+} from './dto/nexus-auth.dto';
+import {
+  NexusGenerateDto,
+  NexusGenerateResponse,
+  NexusBuildStatusResponse,
+} from './dto/nexus-client.dto';
+
+const NEXUS_BASE_URL = 'https://api.databk.top';
+
+@Injectable()
+export class NexusService {
+  private readonly logger = new Logger(NexusService.name);
+
+  /** 内存中暂存 login_id 与 userGuid 的映射，用于轮询成功后关联用户 */
+  private loginSessionMap = new Map<string, string>();
+
+  constructor(
+    @InjectRepository(NexusToken)
+    private nexusTokenRepository: Repository<NexusToken>,
+    private configService: ConfigService,
+  ) {}
+
+  /**
+   * 创建 Nexus 登录会话
+   * 调用 Nexus API 获取 login_id 和 auth_url
+   */
+  async createLoginSession(userGuid: string): Promise<NexusLoginResponse> {
+    const response = await this.fetchNexus('/v1/auth/github/login', {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      this.logger.error(
+        `Failed to create Nexus login session: ${response.status} ${await response.text()}`,
+      );
+      throw new InternalServerErrorException('创建 Nexus 登录会话失败');
+    }
+
+    const data = (await response.json()) as NexusLoginResponse;
+
+    // 记录 login_id 与 userGuid 的关联
+    this.loginSessionMap.set(data.login_id, userGuid);
+
+    // 设置自动清理（按 expires_in）
+    setTimeout(
+      () => this.loginSessionMap.delete(data.login_id),
+      data.expires_in * 1000,
+    );
+
+    return data;
+  }
+
+  /**
+   * 轮询 Nexus 登录状态
+   * 登录成功后将 Nexus Token 存储到数据库
+   */
+  async pollLoginStatus(
+    loginId: string,
+  ): Promise<NexusAuthStatusResponse> {
+    const response = await this.fetchNexus(
+      `/v1/auth/github/status?login_id=${encodeURIComponent(loginId)}`,
+      { method: 'GET' },
+    );
+
+    if (response.status === 404) {
+      return { state: 'failed', error: '登录会话已过期' };
+    }
+
+    if (!response.ok) {
+      this.logger.error(
+        `Nexus login status poll failed: ${response.status}`,
+      );
+      return { state: 'failed', error: '查询登录状态失败' };
+    }
+
+    const data = (await response.json()) as {
+      state: string;
+      token?: string;
+      username?: string;
+      expires_in?: number;
+      error?: string;
+    };
+
+    if (data.state === 'completed' && data.token && data.username) {
+      const userGuid = this.loginSessionMap.get(loginId);
+      if (userGuid) {
+        await this.saveNexusToken(
+          userGuid,
+          data.token,
+          data.username,
+          data.expires_in ?? 2592000,
+        );
+        this.loginSessionMap.delete(loginId);
+      }
+
+      return {
+        state: 'completed',
+        nexus_username: data.username,
+        expires_in: data.expires_in,
+      };
+    }
+
+    if (data.state === 'failed') {
+      this.loginSessionMap.delete(loginId);
+      return {
+        state: 'failed',
+        error: data.error ?? '登录失败',
+      };
+    }
+
+    return { state: 'pending' };
+  }
+
+  /**
+   * 查询当前用户的 Nexus 绑定状态
+   */
+  async getBindStatus(userGuid: string): Promise<NexusBindStatusResponse> {
+    const nexusToken = await this.nexusTokenRepository.findOne({
+      where: { userGuid },
+    });
+
+    if (!nexusToken) {
+      return { bound: false };
+    }
+
+    if (nexusToken.isExpired()) {
+      return { bound: false, expired: true, nexus_username: nexusToken.nexusUsername };
+    }
+
+    return { bound: true, nexus_username: nexusToken.nexusUsername };
+  }
+
+  /**
+   * 解绑 Nexus（删除 Token）
+   */
+  async unbind(userGuid: string): Promise<void> {
+    await this.nexusTokenRepository.delete({ userGuid });
+  }
+
+  /**
+   * 提交构建请求
+   */
+  async submitBuild(
+    userGuid: string,
+    dto: NexusGenerateDto,
+  ): Promise<NexusGenerateResponse> {
+    const nexusToken = await this.getValidNexusToken(userGuid);
+
+    const response = await this.fetchNexus('/v1/client/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${nexusToken.nexusToken}`,
+      },
+      body: JSON.stringify(dto),
+    });
+
+    if (response.status === 401) {
+      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    }
+
+    if (response.status === 403) {
+      throw new ForbiddenException(
+        '请先对 databk/rustdesk-console 仓库进行 Star、Fork 或 Watch 操作',
+      );
+    }
+
+    if (response.status === 409) {
+      throw new ConflictException('已有一个正在进行的构建任务');
+    }
+
+    if (response.status === 429) {
+      throw new ConflictException('本月生成次数已达上限（15 次/月）');
+    }
+
+    if (response.status === 400) {
+      const msg = await response.text();
+      throw new BadRequestException(msg || '请求参数无效');
+    }
+
+    if (!response.ok) {
+      this.logger.error(
+        `Nexus build submit failed: ${response.status} ${await response.text()}`,
+      );
+      throw new InternalServerErrorException('提交构建请求失败');
+    }
+
+    const data = (await response.json()) as NexusGenerateResponse;
+
+    // 记录当前构建任务 ID
+    nexusToken.currentRequestId = data.request_id;
+    await this.nexusTokenRepository.save(nexusToken);
+
+    return data;
+  }
+
+  /**
+   * 查询构建状态
+   */
+  async getBuildStatus(userGuid: string): Promise<NexusBuildStatusResponse> {
+    const nexusToken = await this.getValidNexusToken(userGuid);
+
+    if (!nexusToken.currentRequestId) {
+      throw new BadRequestException('当前没有构建任务');
+    }
+
+    const response = await this.fetchNexus(
+      `/v1/client/generate/${encodeURIComponent(nexusToken.currentRequestId)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${nexusToken.nexusToken}`,
+        },
+      },
+    );
+
+    if (response.status === 401) {
+      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    }
+
+    if (!response.ok) {
+      this.logger.error(
+        `Nexus build status query failed: ${response.status}`,
+      );
+      throw new InternalServerErrorException('查询构建状态失败');
+    }
+
+    const data = (await response.json()) as NexusBuildStatusResponse;
+
+    // 构建终态时清除 currentRequestId
+    if (['completed', 'failed', 'cancelled'].includes(data.status)) {
+      nexusToken.currentRequestId = null as unknown as string;
+      await this.nexusTokenRepository.save(nexusToken);
+    }
+
+    return data;
+  }
+
+  /**
+   * 下载构建产物
+   * 返回 Nexus 的下载流供 Controller 转发
+   */
+  async downloadBuild(
+    userGuid: string,
+    requestId: string,
+  ): Promise<{ stream: ReadableStream | null; filename: string }> {
+    const nexusToken = await this.getValidNexusToken(userGuid);
+
+    const targetRequestId = requestId || nexusToken.currentRequestId;
+    if (!targetRequestId) {
+      throw new BadRequestException('未指定构建任务 ID');
+    }
+
+    const response = await this.fetchNexus(
+      `/v1/client/download/${encodeURIComponent(targetRequestId)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${nexusToken.nexusToken}`,
+        },
+      },
+    );
+
+    if (response.status === 404) {
+      throw new BadRequestException('构建任务不存在或构建未完成');
+    }
+
+    if (!response.ok) {
+      throw new InternalServerErrorException('下载构建产物失败');
+    }
+
+    const disposition = response.headers.get('content-disposition');
+    let filename = `custom-client-${targetRequestId}.zip`;
+    if (disposition) {
+      const match = disposition.match(/filename=([^;]+)/);
+      if (match) {
+        filename = match[1].replace(/"/g, '');
+      }
+    }
+
+    return { stream: response.body, filename };
+  }
+
+  /**
+   * 获取用户有效的 Nexus Token，过期则抛出异常
+   */
+  private async getValidNexusToken(userGuid: string): Promise<NexusToken> {
+    const nexusToken = await this.nexusTokenRepository.findOne({
+      where: { userGuid },
+    });
+
+    if (!nexusToken) {
+      throw new UnauthorizedException('请先绑定 Nexus 账号');
+    }
+
+    if (nexusToken.isExpired()) {
+      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    }
+
+    return nexusToken;
+  }
+
+  /**
+   * 保存或更新 Nexus Token
+   */
+  private async saveNexusToken(
+    userGuid: string,
+    token: string,
+    username: string,
+    expiresIn: number,
+  ): Promise<void> {
+    let nexusToken = await this.nexusTokenRepository.findOne({
+      where: { userGuid },
+    });
+
+    const expiresAt = new Date();
+    expiresAt.setSeconds(expiresAt.getSeconds() + expiresIn);
+
+    if (nexusToken) {
+      nexusToken.nexusToken = token;
+      nexusToken.nexusUsername = username;
+      nexusToken.expiresAt = expiresAt;
+    } else {
+      nexusToken = this.nexusTokenRepository.create({
+        userGuid,
+        nexusToken: token,
+        nexusUsername: username,
+        expiresAt,
+      });
+    }
+
+    await this.nexusTokenRepository.save(nexusToken);
+  }
+
+  /**
+   * 封装 Nexus API 请求
+   */
+  private async fetchNexus(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<Response> {
+    const url = `${this.configService.get<string>('NEXUS_BASE_URL', NEXUS_BASE_URL)}${path}`;
+    return fetch(url, options);
+  }
+}

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -10,6 +10,9 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { pipeline } from 'stream/promises';
 import { NexusToken } from './entities/nexus-token.entity';
 import {
   NexusLoginResponse,
@@ -23,23 +26,39 @@ import {
 } from './dto/nexus-client.dto';
 
 const NEXUS_BASE_URL = 'https://api.databk.top';
+const DEFAULT_STORAGE_PATH = './data/nexus-builds';
 
 @Injectable()
 export class NexusService {
   private readonly logger = new Logger(NexusService.name);
+  private readonly storagePath: string;
 
   /** 内存中暂存 login_id 与 userGuid 的映射，用于轮询成功后关联用户 */
   private loginSessionMap = new Map<string, string>();
+
+  /** 正在下载的 request_id 集合，防止并发重复下载 */
+  private downloadingSet = new Set<string>();
 
   constructor(
     @InjectRepository(NexusToken)
     private nexusTokenRepository: Repository<NexusToken>,
     private configService: ConfigService,
-  ) {}
+  ) {
+    this.storagePath = this.configService.get<string>(
+      'NEXUS_STORAGE_PATH',
+      DEFAULT_STORAGE_PATH,
+    );
+  }
+
+  /**
+   * 获取本地存储路径
+   */
+  getStoragePath(): string {
+    return this.storagePath;
+  }
 
   /**
    * 创建 Nexus 登录会话
-   * 调用 Nexus API 获取 login_id 和 auth_url
    */
   async createLoginSession(userGuid: string): Promise<NexusLoginResponse> {
     const response = await this.fetchNexus('/v1/auth/github/login', {
@@ -55,10 +74,8 @@ export class NexusService {
 
     const data = (await response.json()) as NexusLoginResponse;
 
-    // 记录 login_id 与 userGuid 的关联
     this.loginSessionMap.set(data.login_id, userGuid);
 
-    // 设置自动清理（按 expires_in）
     setTimeout(
       () => this.loginSessionMap.delete(data.login_id),
       data.expires_in * 1000,
@@ -69,7 +86,6 @@ export class NexusService {
 
   /**
    * 轮询 Nexus 登录状态
-   * 登录成功后将 Nexus Token 存储到数据库
    */
   async pollLoginStatus(
     loginId: string,
@@ -204,7 +220,6 @@ export class NexusService {
 
     const data = (await response.json()) as NexusGenerateResponse;
 
-    // 记录当前构建任务 ID
     nexusToken.currentRequestId = data.request_id;
     await this.nexusTokenRepository.save(nexusToken);
 
@@ -213,12 +228,23 @@ export class NexusService {
 
   /**
    * 查询构建状态
+   * 构建完成后自动将产物下载到本地
    */
   async getBuildStatus(userGuid: string): Promise<NexusBuildStatusResponse> {
     const nexusToken = await this.getValidNexusToken(userGuid);
 
     if (!nexusToken.currentRequestId) {
       throw new BadRequestException('当前没有构建任务');
+    }
+
+    // 如果文件已下载到本地，直接从本地返回终态
+    const localFiles = this.getLocalFiles(nexusToken.currentRequestId);
+    if (localFiles.length > 0) {
+      return {
+        request_id: nexusToken.currentRequestId,
+        status: 'completed',
+        files: localFiles,
+      };
     }
 
     const response = await this.fetchNexus(
@@ -244,8 +270,17 @@ export class NexusService {
 
     const data = (await response.json()) as NexusBuildStatusResponse;
 
-    // 构建终态时清除 currentRequestId
-    if (['completed', 'failed', 'cancelled'].includes(data.status)) {
+    // 构建完成后，将产物下载到本地
+    if (data.status === 'completed' && data.files?.length) {
+      await this.downloadBuildFilesToLocal(
+        nexusToken.nexusToken,
+        nexusToken.currentRequestId,
+        data.files,
+      );
+      // 下载完成后清除 currentRequestId
+      nexusToken.currentRequestId = null as unknown as string;
+      await this.nexusTokenRepository.save(nexusToken);
+    } else if (['failed', 'cancelled'].includes(data.status)) {
       nexusToken.currentRequestId = null as unknown as string;
       await this.nexusTokenRepository.save(nexusToken);
     }
@@ -254,89 +289,107 @@ export class NexusService {
   }
 
   /**
-   * 列出构建产物的文件列表
+   * 列出构建产物的文件列表（从本地目录读取）
    */
-  async listBuildFiles(
-    userGuid: string,
-    requestId: string,
-  ): Promise<string[]> {
-    const nexusToken = await this.getValidNexusToken(userGuid);
-
-    const response = await this.fetchNexus(
-      `/v1/client/download/${encodeURIComponent(requestId)}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${nexusToken.nexusToken}`,
-        },
-      },
-    );
-
-    if (response.status === 401) {
-      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
-    }
-
-    if (response.status === 404) {
-      throw new BadRequestException('构建任务不存在或构建未完成');
-    }
-
-    if (!response.ok) {
-      throw new InternalServerErrorException('查询构建产物列表失败');
-    }
-
-    return (await response.json()) as string[];
+  async listBuildFiles(requestId: string): Promise<string[]> {
+    return this.getLocalFiles(requestId);
   }
 
   /**
-   * 下载构建产物
-   * 返回 Nexus 的下载流供 Controller 转发
+   * 获取本地文件路径，用于下载
    */
-  async downloadBuildFile(
-    userGuid: string,
+  getLocalFilePath(requestId: string, filename: string): string {
+    return join(this.storagePath, requestId, filename);
+  }
+
+  /**
+   * 将构建产物从 Nexus 下载到本地存储
+   */
+  private async downloadBuildFilesToLocal(
+    nexusToken: string,
     requestId: string,
-    filename: string,
-  ): Promise<{ stream: ReadableStream | null; filename: string; contentType: string }> {
-    const nexusToken = await this.getValidNexusToken(userGuid);
-
-    const response = await this.fetchNexus(
-      `/v1/client/download/${encodeURIComponent(requestId)}/${encodeURIComponent(filename)}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${nexusToken.nexusToken}`,
-        },
-      },
-    );
-
-    if (response.status === 401) {
-      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    files: string[],
+  ): Promise<void> {
+    if (this.downloadingSet.has(requestId)) {
+      return;
     }
+    this.downloadingSet.add(requestId);
 
-    if (response.status === 404) {
-      throw new BadRequestException('构建任务不存在或文件不存在');
-    }
+    const dir = join(this.storagePath, requestId);
+    mkdirSync(dir, { recursive: true });
 
-    if (!response.ok) {
-      throw new InternalServerErrorException('下载构建产物失败');
-    }
+    try {
+      for (const file of files) {
+        const filePath = join(dir, file);
+        if (existsSync(filePath)) {
+          continue;
+        }
 
-    const disposition = response.headers.get('content-disposition');
-    let resolvedFilename = filename;
-    if (disposition) {
-      const match = disposition.match(/filename=([^;]+)/);
-      if (match) {
-        resolvedFilename = match[1].replace(/"/g, '');
+        this.logger.log(`Downloading build artifact: ${requestId}/${file}`);
+
+        const response = await this.fetchNexus(
+          `/v1/client/download/${encodeURIComponent(requestId)}/${encodeURIComponent(file)}`,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${nexusToken}`,
+            },
+          },
+        );
+
+        if (!response.ok) {
+          this.logger.error(
+            `Failed to download ${file}: ${response.status} ${await response.text()}`,
+          );
+          throw new InternalServerErrorException(
+            `下载构建产物 ${file} 失败`,
+          );
+        }
+
+        const writeStream = createWriteStream(filePath);
+        if (!response.body) {
+          throw new InternalServerErrorException(`下载构建产物 ${file} 失败：响应体为空`);
+        }
+        const reader = response.body.getReader();
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            writeStream.write(value);
+          }
+          writeStream.end();
+          await new Promise<void>((resolve, reject) => {
+            writeStream.on('finish', resolve);
+            writeStream.on('error', reject);
+          });
+        } catch (err) {
+          writeStream.destroy();
+          throw err;
+        }
       }
+
+      this.logger.log(`All build artifacts downloaded: ${requestId}`);
+    } finally {
+      this.downloadingSet.delete(requestId);
     }
+  }
 
-    const contentType =
-      response.headers.get('content-type') || 'application/octet-stream';
-
-    return {
-      stream: response.body,
-      filename: resolvedFilename,
-      contentType,
-    };
+  /**
+   * 从本地目录读取文件列表
+   */
+  private getLocalFiles(requestId: string): string[] {
+    const dir = join(this.storagePath, requestId);
+    if (!existsSync(dir)) {
+      return [];
+    }
+    return readdirSync(dir).filter((f) => {
+      try {
+        return !createReadStream(join(dir, f)).destroyed;
+      } catch {
+        return false;
+      }
+    });
   }
 
   /**

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -277,7 +277,7 @@ export class NexusService implements OnModuleInit {
   async submitBuild(
     userGuid: string,
     dto: NexusGenerateDto,
-  ): Promise<NexusGenerateResponse> {
+  ): Promise<{ request_id: string; status: string; message: string }> {
     const nexusToken = await this.getValidNexusToken(userGuid);
     const installId = await this.updateCheckService.getInstallId();
 
@@ -322,12 +322,12 @@ export class NexusService implements OnModuleInit {
 
     const data = (await response.json()) as NexusGenerateResponse;
 
-    nexusToken.currentRequestId = data.request_id;
+    nexusToken.currentRequestId = data.uuid;
     await this.nexusTokenRepository.save(nexusToken);
 
     // 持久化构建记录
     const build = this.nexusBuildRepository.create({
-      requestId: data.request_id,
+      requestId: data.uuid,
       userGuid,
       os: dto.os,
       arch: dto.arch,
@@ -337,7 +337,11 @@ export class NexusService implements OnModuleInit {
     });
     await this.nexusBuildRepository.save(build);
 
-    return data;
+    return {
+      request_id: data.uuid,
+      status: data.status,
+      message: data.message,
+    };
   }
 
   /**

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -254,22 +254,16 @@ export class NexusService {
   }
 
   /**
-   * 下载构建产物
-   * 返回 Nexus 的下载流供 Controller 转发
+   * 列出构建产物的文件列表
    */
-  async downloadBuild(
+  async listBuildFiles(
     userGuid: string,
     requestId: string,
-  ): Promise<{ stream: ReadableStream | null; filename: string }> {
+  ): Promise<string[]> {
     const nexusToken = await this.getValidNexusToken(userGuid);
 
-    const targetRequestId = requestId || nexusToken.currentRequestId;
-    if (!targetRequestId) {
-      throw new BadRequestException('未指定构建任务 ID');
-    }
-
     const response = await this.fetchNexus(
-      `/v1/client/download/${encodeURIComponent(targetRequestId)}`,
+      `/v1/client/download/${encodeURIComponent(requestId)}`,
       {
         method: 'GET',
         headers: {
@@ -278,8 +272,48 @@ export class NexusService {
       },
     );
 
+    if (response.status === 401) {
+      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    }
+
     if (response.status === 404) {
       throw new BadRequestException('构建任务不存在或构建未完成');
+    }
+
+    if (!response.ok) {
+      throw new InternalServerErrorException('查询构建产物列表失败');
+    }
+
+    return (await response.json()) as string[];
+  }
+
+  /**
+   * 下载构建产物
+   * 返回 Nexus 的下载流供 Controller 转发
+   */
+  async downloadBuildFile(
+    userGuid: string,
+    requestId: string,
+    filename: string,
+  ): Promise<{ stream: ReadableStream | null; filename: string; contentType: string }> {
+    const nexusToken = await this.getValidNexusToken(userGuid);
+
+    const response = await this.fetchNexus(
+      `/v1/client/download/${encodeURIComponent(requestId)}/${encodeURIComponent(filename)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${nexusToken.nexusToken}`,
+        },
+      },
+    );
+
+    if (response.status === 401) {
+      throw new UnauthorizedException('Nexus Token 已过期，请重新绑定');
+    }
+
+    if (response.status === 404) {
+      throw new BadRequestException('构建任务不存在或文件不存在');
     }
 
     if (!response.ok) {
@@ -287,15 +321,22 @@ export class NexusService {
     }
 
     const disposition = response.headers.get('content-disposition');
-    let filename = `custom-client-${targetRequestId}.zip`;
+    let resolvedFilename = filename;
     if (disposition) {
       const match = disposition.match(/filename=([^;]+)/);
       if (match) {
-        filename = match[1].replace(/"/g, '');
+        resolvedFilename = match[1].replace(/"/g, '');
       }
     }
 
-    return { stream: response.body, filename };
+    const contentType =
+      response.headers.get('content-type') || 'application/octet-stream';
+
+    return {
+      stream: response.body,
+      filename: resolvedFilename,
+      contentType,
+    };
   }
 
   /**

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -277,7 +277,7 @@ export class NexusService implements OnModuleInit {
   async submitBuild(
     userGuid: string,
     dto: NexusGenerateDto,
-  ): Promise<{ uuid: string; status: string; message: string }> {
+  ): Promise<NexusGenerateResponse> {
     const nexusToken = await this.getValidNexusToken(userGuid);
     const installId = await this.updateCheckService.getInstallId();
 
@@ -337,11 +337,7 @@ export class NexusService implements OnModuleInit {
     });
     await this.nexusBuildRepository.save(build);
 
-    return {
-      uuid: data.uuid,
-      status: data.status,
-      message: data.message,
-    };
+    return data;
   }
 
   /**

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -66,7 +66,7 @@ export class NexusService implements OnModuleInit {
   async onModuleInit() {
     // 启动定时轮询
     this.pollTimer = setInterval(
-      () => this.pollActiveBuilds(),
+      () => void this.pollActiveBuilds(),
       POLL_INTERVAL_MS,
     );
     // 首次立即执行一次
@@ -375,7 +375,7 @@ export class NexusService implements OnModuleInit {
   /**
    * 列出构建产物的文件列表（从本地目录读取）
    */
-  async listBuildFiles(uuid: string): Promise<string[]> {
+  listBuildFiles(uuid: string): string[] {
     return this.getLocalFiles(uuid);
   }
 

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository } from 'typeorm';
 import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { NexusToken } from './entities/nexus-token.entity';
@@ -40,7 +40,7 @@ export class NexusService implements OnModuleInit {
   /** 内存中暂存 login_id 与 userGuid 的映射，用于轮询成功后关联用户 */
   private loginSessionMap = new Map<string, string>();
 
-  /** 正在下载的 request_id 集合，防止并发重复下载 */
+  /** 正在下载的 uuid 集合，防止并发重复下载 */
   private downloadingSet = new Set<string>();
 
   constructor(
@@ -98,14 +98,14 @@ export class NexusService implements OnModuleInit {
     if (!nexusToken || nexusToken.isExpired()) {
       // Nexus Token 不可用，标记任务失败
       await this.nexusBuildRepository.update(
-        { requestId: build.requestId },
+        { uuid: build.uuid },
         { status: 'failed', message: 'Nexus Token 已过期' },
       );
       return;
     }
 
     const response = await this.fetchNexus(
-      `/v1/client/generate/${encodeURIComponent(build.requestId)}`,
+      `/v1/client/generate/${encodeURIComponent(build.uuid)}`,
       {
         method: 'GET',
         headers: { Authorization: `Bearer ${nexusToken.nexusToken}` },
@@ -114,7 +114,7 @@ export class NexusService implements OnModuleInit {
 
     if (!response.ok) {
       this.logger.warn(
-        `Poll build ${build.requestId} failed: ${response.status}`,
+        `Poll build ${build.uuid} failed: ${response.status}`,
       );
       return;
     }
@@ -123,7 +123,7 @@ export class NexusService implements OnModuleInit {
 
     // 更新构建记录
     await this.nexusBuildRepository.update(
-      { requestId: build.requestId },
+      { uuid: build.uuid },
       {
         status: data.status as NexusBuild['status'],
         files: data.files ? JSON.stringify(data.files) : undefined,
@@ -135,15 +135,15 @@ export class NexusService implements OnModuleInit {
     if (data.status === 'completed' && data.files?.length) {
       await this.downloadBuildFilesToLocal(
         nexusToken.nexusToken,
-        build.requestId,
+        build.uuid,
         data.files,
       );
     }
 
-    // 终态时清除 currentRequestId
+    // 终态时清除 currentUuid
     if (['completed', 'failed', 'cancelled'].includes(data.status)) {
-      if (nexusToken.currentRequestId === build.requestId) {
-        nexusToken.currentRequestId = null as unknown as string;
+      if (nexusToken.currentUuid === build.uuid) {
+        nexusToken.currentUuid = null as unknown as string;
         await this.nexusTokenRepository.save(nexusToken);
       }
     }
@@ -277,7 +277,7 @@ export class NexusService implements OnModuleInit {
   async submitBuild(
     userGuid: string,
     dto: NexusGenerateDto,
-  ): Promise<{ request_id: string; status: string; message: string }> {
+  ): Promise<{ uuid: string; status: string; message: string }> {
     const nexusToken = await this.getValidNexusToken(userGuid);
     const installId = await this.updateCheckService.getInstallId();
 
@@ -322,12 +322,12 @@ export class NexusService implements OnModuleInit {
 
     const data = (await response.json()) as NexusGenerateResponse;
 
-    nexusToken.currentRequestId = data.uuid;
+    nexusToken.currentUuid = data.uuid;
     await this.nexusTokenRepository.save(nexusToken);
 
     // 持久化构建记录
     const build = this.nexusBuildRepository.create({
-      requestId: data.uuid,
+      uuid: data.uuid,
       userGuid,
       os: dto.os,
       arch: dto.arch,
@@ -338,7 +338,7 @@ export class NexusService implements OnModuleInit {
     await this.nexusBuildRepository.save(build);
 
     return {
-      request_id: data.uuid,
+      uuid: data.uuid,
       status: data.status,
       message: data.message,
     };
@@ -357,9 +357,9 @@ export class NexusService implements OnModuleInit {
   /**
    * 删除构建记录
    */
-  async deleteBuild(userGuid: string, requestId: string): Promise<void> {
+  async deleteBuild(userGuid: string, uuid: string): Promise<void> {
     const build = await this.nexusBuildRepository.findOne({
-      where: { requestId, userGuid },
+      where: { uuid, userGuid },
     });
     if (!build) {
       throw new BadRequestException('构建记录不存在');
@@ -367,21 +367,21 @@ export class NexusService implements OnModuleInit {
     if (build.status === 'pending' || build.status === 'building') {
       throw new BadRequestException('进行中的构建任务不能删除');
     }
-    await this.nexusBuildRepository.delete({ requestId });
+    await this.nexusBuildRepository.delete({ uuid });
   }
 
   /**
    * 列出构建产物的文件列表（从本地目录读取）
    */
-  async listBuildFiles(requestId: string): Promise<string[]> {
-    return this.getLocalFiles(requestId);
+  async listBuildFiles(uuid: string): Promise<string[]> {
+    return this.getLocalFiles(uuid);
   }
 
   /**
    * 获取本地文件路径，用于下载
    */
-  getLocalFilePath(requestId: string, filename: string): string {
-    return join(this.storagePath, requestId, filename);
+  getLocalFilePath(uuid: string, filename: string): string {
+    return join(this.storagePath, uuid, filename);
   }
 
   /**
@@ -389,15 +389,15 @@ export class NexusService implements OnModuleInit {
    */
   private async downloadBuildFilesToLocal(
     nexusToken: string,
-    requestId: string,
+    uuid: string,
     files: string[],
   ): Promise<void> {
-    if (this.downloadingSet.has(requestId)) {
+    if (this.downloadingSet.has(uuid)) {
       return;
     }
-    this.downloadingSet.add(requestId);
+    this.downloadingSet.add(uuid);
 
-    const dir = join(this.storagePath, requestId);
+    const dir = join(this.storagePath, uuid);
     mkdirSync(dir, { recursive: true });
 
     try {
@@ -407,10 +407,10 @@ export class NexusService implements OnModuleInit {
           continue;
         }
 
-        this.logger.log(`Downloading build artifact: ${requestId}/${file}`);
+        this.logger.log(`Downloading build artifact: ${uuid}/${file}`);
 
         const response = await this.fetchNexus(
-          `/v1/client/download/${encodeURIComponent(requestId)}/${encodeURIComponent(file)}`,
+          `/v1/client/download/${encodeURIComponent(uuid)}/${encodeURIComponent(file)}`,
           {
             method: 'GET',
             headers: {
@@ -451,17 +451,17 @@ export class NexusService implements OnModuleInit {
         }
       }
 
-      this.logger.log(`All build artifacts downloaded: ${requestId}`);
+      this.logger.log(`All build artifacts downloaded: ${uuid}`);
     } finally {
-      this.downloadingSet.delete(requestId);
+      this.downloadingSet.delete(uuid);
     }
   }
 
   /**
    * 从本地目录读取文件列表
    */
-  private getLocalFiles(requestId: string): string[] {
-    const dir = join(this.storagePath, requestId);
+  private getLocalFiles(uuid: string): string[] {
+    const dir = join(this.storagePath, uuid);
     if (!existsSync(dir)) {
       return [];
     }

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -157,10 +157,11 @@ export class NexusService implements OnModuleInit {
   /**
    * 创建 Nexus 登录会话
    */
-  async createLoginSession(userGuid: string): Promise<NexusLoginResponse> {
-    const response = await this.fetchNexus('/v1/auth/github/login', {
-      method: 'GET',
-    });
+  async createLoginSession(userGuid: string, installId: string): Promise<NexusLoginResponse> {
+    const response = await this.fetchNexus(
+      `/v1/auth/github/login?install_id=${encodeURIComponent(installId)}`,
+      { method: 'GET' },
+    );
 
     if (!response.ok) {
       this.logger.error(

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -15,6 +15,7 @@ import { createReadStream, createWriteStream, existsSync, readdirSync, mkdirSync
 import { join } from 'path';
 import { NexusToken } from './entities/nexus-token.entity';
 import { NexusBuild } from './entities/nexus-build.entity';
+import { UpdateCheckService } from '../update-check/update-check.service';
 import {
   NexusLoginResponse,
   NexusAuthStatusResponse,
@@ -47,6 +48,7 @@ export class NexusService implements OnModuleInit {
     private nexusTokenRepository: Repository<NexusToken>,
     @InjectRepository(NexusBuild)
     private nexusBuildRepository: Repository<NexusBuild>,
+    private updateCheckService: UpdateCheckService,
     private configService: ConfigService,
   ) {
     this.storagePath = this.configService.get<string>(
@@ -157,7 +159,8 @@ export class NexusService implements OnModuleInit {
   /**
    * 创建 Nexus 登录会话
    */
-  async createLoginSession(userGuid: string, installId: string): Promise<NexusLoginResponse> {
+  async createLoginSession(userGuid: string): Promise<NexusLoginResponse> {
+    const installId = await this.updateCheckService.getInstallId();
     const response = await this.fetchNexus(
       `/v1/auth/github/login?install_id=${encodeURIComponent(installId)}`,
       { method: 'GET' },
@@ -276,6 +279,7 @@ export class NexusService implements OnModuleInit {
     dto: NexusGenerateDto,
   ): Promise<NexusGenerateResponse> {
     const nexusToken = await this.getValidNexusToken(userGuid);
+    const installId = await this.updateCheckService.getInstallId();
 
     const response = await this.fetchNexus('/v1/client/generate', {
       method: 'POST',
@@ -283,7 +287,7 @@ export class NexusService implements OnModuleInit {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${nexusToken.nexusToken}`,
       },
-      body: JSON.stringify(dto),
+      body: JSON.stringify({ ...dto, install_id: installId }),
     });
 
     if (response.status === 401) {


### PR DESCRIPTION
## Summary

Add `NexusModule` that integrates with the Nexus API to provide custom RustDesk client generation capabilities. The backend acts as a proxy between the frontend and Nexus, handling GitHub OAuth login flow, build request submission, status polling, and build artifact download.

## Changes

- **NexusModule**: New module under `src/modules/nexus/`
- **NexusToken entity**: Stores per-user Nexus JWT token in SQLite
- **NexusService**: Proxies all Nexus API calls (OAuth login, build, download)
- **NexusController**: Exposes frontend-facing REST endpoints

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/nexus/auth/login` | Create Nexus login session, returns `auth_url` for browser redirect |
| GET | `/api/nexus/auth/status?login_id=xxx` | Poll Nexus login status |
| GET | `/api/nexus/auth/bind-status` | Check if current user has bound Nexus |
| DELETE | `/api/nexus/auth/bind` | Unbind Nexus account |
| POST | `/api/nexus/client/generate` | Submit build request (os, arch, app_name) |
| GET | `/api/nexus/client/status` | Query current build status |
| GET | `/api/nexus/client/download?request_id=xxx` | Download build artifact (ZIP stream) |

## Integration Flow

1. Frontend calls `POST /api/nexus/auth/login` → gets `auth_url`
2. Opens `auth_url` in browser → user authorizes via GitHub
3. Frontend polls `GET /api/nexus/auth/status` → on success, backend stores Nexus Token
4. Frontend calls `POST /api/nexus/client/generate` with os/arch/app_name
5. Frontend polls `GET /api/nexus/client/status` until completed
6. Frontend downloads via `GET /api/nexus/client/download`

## Environment Variable

- `NEXUS_BASE_URL` (optional, defaults to `https://api.databk.top`)