### PR TITLE
fix: make SMTP username and password fields optional

### DIFF
--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -39,10 +39,9 @@ export class EmailService {
         host: config.host,
         port: config.port,
         secure: config.secure,
-        auth: {
-          user: config.user,
-          pass: config.pass,
-        },
+        ...(config.user || config.pass
+          ? { auth: { user: config.user, pass: config.pass } }
+          : {}),
       });
 
       // 渲染模板

--- a/src/modules/settings/dto/smtp-config.dto.ts
+++ b/src/modules/settings/dto/smtp-config.dto.ts
@@ -26,12 +26,12 @@ export class CreateSmtpConfigDto {
   secure?: boolean;
 
   @IsString()
-  @IsNotEmpty()
-  user: string;
+  @IsOptional()
+  user?: string;
 
   @IsString()
-  @IsNotEmpty()
-  pass: string;
+  @IsOptional()
+  pass?: string;
 
   @IsString()
   @IsNotEmpty()
@@ -63,12 +63,10 @@ export class UpdateSmtpConfigDto {
   secure?: boolean;
 
   @IsString()
-  @IsNotEmpty()
   @IsOptional()
   user?: string;
 
   @IsString()
-  @IsNotEmpty()
   @IsOptional()
   pass?: string;
 
@@ -103,12 +101,10 @@ export class TestSmtpConfigDto {
   secure?: boolean;
 
   @IsString()
-  @IsNotEmpty()
   @IsOptional()
   user?: string;
 
   @IsString()
-  @IsNotEmpty()
   @IsOptional()
   pass?: string;
 

--- a/src/modules/settings/services/smtp-settings.service.ts
+++ b/src/modules/settings/services/smtp-settings.service.ts
@@ -42,8 +42,8 @@ export class SmtpSettingsService {
     host: string;
     port: number;
     secure: boolean;
-    user: string;
-    pass: string;
+    user?: string;
+    pass?: string;
     from: string;
     enabled: boolean;
   } | null> {
@@ -57,8 +57,8 @@ export class SmtpSettingsService {
       host: settings.get(this.SMTP_KEYS.HOST) || '',
       port: parseInt(settings.get(this.SMTP_KEYS.PORT) || '587', 10),
       secure: settings.get(this.SMTP_KEYS.SECURE) === 'true',
-      user: settings.get(this.SMTP_KEYS.USER) || '',
-      pass: settings.get(this.SMTP_KEYS.PASS) || '',
+      user: settings.get(this.SMTP_KEYS.USER) || undefined,
+      pass: settings.get(this.SMTP_KEYS.PASS) || undefined,
       from: settings.get(this.SMTP_KEYS.FROM) || '',
       enabled: settings.get(this.SMTP_KEYS.ENABLED) !== 'false',
     };
@@ -72,7 +72,7 @@ export class SmtpSettingsService {
     host: string;
     port: number;
     secure: boolean;
-    user: string;
+    user?: string;
     pass: string;
     from: string;
     enabled: boolean;
@@ -94,7 +94,7 @@ export class SmtpSettingsService {
       host: settings.get(this.SMTP_KEYS.HOST) || '',
       port: parseInt(settings.get(this.SMTP_KEYS.PORT) || '587', 10),
       secure: settings.get(this.SMTP_KEYS.SECURE) === 'true',
-      user: settings.get(this.SMTP_KEYS.USER) || '',
+      user: settings.get(this.SMTP_KEYS.USER) || undefined,
       pass: this.PASS_MASK,
       from: settings.get(this.SMTP_KEYS.FROM) || '',
       enabled: settings.get(this.SMTP_KEYS.ENABLED) !== 'false',
@@ -112,7 +112,7 @@ export class SmtpSettingsService {
     host: string;
     port: number;
     secure: boolean;
-    user: string;
+    user?: string;
     pass: string;
     from: string;
     enabled: boolean;
@@ -170,15 +170,15 @@ export class SmtpSettingsService {
     let host: string;
     let port: number;
     let secure: boolean;
-    let user: string;
-    let pass: string;
+    let user: string | undefined;
+    let pass: string | undefined;
 
     if (dto && dto.host) {
       host = dto.host;
       port = dto.port ?? 587;
       secure = dto.secure ?? false;
-      user = dto.user ?? '';
-      pass = dto.pass ?? '';
+      user = dto.user;
+      pass = dto.pass;
     } else {
       const config = await this.getActiveConfig();
       if (!config) {
@@ -195,7 +195,7 @@ export class SmtpSettingsService {
       host,
       port,
       secure,
-      auth: { user, pass },
+      ...(user || pass ? { auth: { user, pass } } : {}),
     });
 
     try {


### PR DESCRIPTION
## Summary

Makes the SMTP `user` and `pass` configuration fields optional, allowing email servers that don't require authentication to work properly.

## Changes

- **DTO**: Removed `@IsNotEmpty()` validators from `user` and `pass` fields in `CreateSmtpConfigDto`, `UpdateSmtpConfigDto`, and `TestSmtpConfigDto`, making them truly optional
- **EmailService**: Conditionally includes `auth` options in nodemailer transport only when user or pass credentials are provided
- **SmtpSettingsService**: Updated `getActiveConfig()` and `getSmtpConfig()` return types to mark `user`/`pass` as optional; conditionally includes `auth` in test connection transport

Closes #193