### PR TITLE
ci(github workflow): add version file config and update package description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           git-user-name: 'DataBK Auto Release'
           git-user-email: 'databk.auto.release@github.com'
           tag-prefix: ''
+          version-file: './package.json,./package-lock.json'
 
       - name: Build and push Docker images
         if: ${{ steps.changelog.outputs.skipped == 'false' }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rustdesk-console",
   "version": "1.5.1",
-  "description": "Remote Desktop Management Console for RustDesk - A comprehensive management platform built with NestJS that provides device management, user authentication, address book management, security auditing, and real-time monitoring capabilities.",
+  "description": "Remote Desktop Management Console for RustDesk - An open-source console designed for self-hosting, as an alternative to RustDesk Server Pro.",
   "author": "databk",
   "private": false,
   "license": "AGPL-3.0",


### PR DESCRIPTION
1. Add `version-file` configuration to the GitHub release workflow, specifying `package.json` and `package-lock.json` as the version files.
2. Update the project description in `package.json` to better align with the positioning of a self-hosted open-source console.