### PR TITLE
feat: implement user groups and group-based address-book access

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ File transfer auditing with detailed logs showing direction, file size, timestam
 
 ### User Management
 - Complete CRUD operations for user accounts (RESTful conventions)
+- User-group CRUD, single-group membership, bulk member moves, and protected default-group assignment
 - User invitation via email
 - Enable/disable user accounts with batch operations
 - Force logout capabilities (single and batch)
@@ -75,7 +76,7 @@ File transfer auditing with detailed logs showing direction, file size, timestam
 - Personal and shared address books
 - Device peer management (add, update, delete)
 - Tag-based organization with custom colors
-- Access rules and permission levels
+- Direct-user, user-group, and everyone access rules with strongest-permission resolution
 - Legacy API compatibility support
 - Pagination and search functionality
 
@@ -136,7 +137,7 @@ backend and frontend may not yet be feature-complete for the items below.
 | Area | Current Status | Notes |
 |------|----------------|-------|
 | **Role management / RBAC** | Frontend scaffold only | The frontend exposes `/roles` and calls `/api/roles` and `/api/permissions`, but the backend does not currently include role or permission modules/controllers. Access control is currently based on `isAdmin` plus device/user/group permission mappings rather than a complete role-permission system. |
-| **User groups** | Frontend scaffold only | The frontend includes a user-group management page and `/api/user-groups` service calls. Backend support for user groups is not implemented yet. |
+| **User groups** | Backend implemented, frontend partial | `/api/user-groups` supports CRUD, membership, default assignment, and address-book group grants. The current frontend supports group CRUD; member and grant-management UI remains follow-up work. |
 | **Generic system settings** | Partially implemented | The backend currently implements SMTP settings under `/api/settings/smtp`. Generic settings endpoints such as `/api/settings`, `/api/settings/:key`, and `/api/settings/batch` are not implemented yet. |
 | **Dashboard online-user and alarm counters** | Partially implemented | Some dashboard metrics are placeholders: online users, active connections, unread alarms, and critical alarms currently require additional session/alarm-state tracking fields. |
 | **SMS-code login** | Placeholder | The login flow recognizes `sms_code`, but SMS verification is not implemented and currently returns a "feature under development" error. |
@@ -274,6 +275,7 @@ src/
 ├── modules/
 │   ├── auth/                  # Authentication & authorization (JWT, TFA, OIDC, email)
 │   ├── user/                  # User management (CRUD, avatar, password, admin queries)
+│   ├── user-group/            # User-group CRUD, membership, and default assignment
 │   ├── address-book/          # Address book & device peer management
 │   ├── device-group/          # Device grouping & permissions
 │   ├── strategy/              # Strategy configuration & assignment
@@ -303,6 +305,7 @@ The application uses **SQLite** as the default database engine (file: `rustdesk-
 - User accounts, tokens & avatars
 - Address books, peers, tags & access rules
 - Device groups & permissions
+- User groups & membership assignments
 - Strategies & assignments
 - Audit logs (connections, file transfers, alarms, console)
 - Active connections
@@ -427,6 +430,7 @@ This project is licensed under the **GNU Affero General Public License v3.0** (A
 
 - [Discord Community](https://discord.gg/vrQSJfqpwD) - Join our community for discussions and support
 - [Frontend Project](https://github.com/databk/rustdesk-console-web) - Web UI for RustDesk Console
+- [User Group API Contract](docs/user-groups-api.md) - Backend endpoints, compatibility, and frontend follow-up fields
 - [NestJS Documentation](https://docs.nestjs.com/) - Framework documentation
 - [TypeORM Documentation](https://typeorm.io/) - ORM documentation
 - [RustDesk Official Site](https://rustdesk.com/) - Main product information

--- a/docs/user-groups-api.md
+++ b/docs/user-groups-api.md
@@ -1,0 +1,179 @@
+# User Group API Contract
+
+User groups are distinct from device groups. Each user belongs to exactly one
+user group, and a protected default group is used whenever an administrator or
+identity provider does not select a group.
+
+All `/api/user-groups` routes require an authenticated administrator. The
+application-wide `/api` prefix is omitted from route declarations in the NestJS
+controllers but included below.
+
+## Group CRUD
+
+```text
+GET    /api/user-groups?current=1&pageSize=20&search=term
+POST   /api/user-groups
+PUT    /api/user-groups/:guid
+DELETE /api/user-groups/:guid
+```
+
+Create body:
+
+```json
+{ "name": "Operations", "note": "Primary operators" }
+```
+
+Update body fields are optional:
+
+```json
+{ "name": "Operations", "note": "Updated note" }
+```
+
+List response:
+
+```json
+{
+  "data": [
+    {
+      "guid": "f2d89530-94d8-4ca9-9122-62c136d9a384",
+      "name": "Operations",
+      "note": "Primary operators",
+      "user_count": 12,
+      "is_default": false,
+      "created_at": "2026-07-15T12:00:00.000Z",
+      "updated_at": "2026-07-15T12:00:00.000Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+Names are trimmed and unique case-insensitively. The display casing is
+preserved. The default group can be renamed or annotated but cannot be deleted.
+
+Deleting another group moves its members to the default group and removes its
+address-book grants in one transaction:
+
+```json
+{
+  "message": "用户组删除成功",
+  "moved_user_count": 4,
+  "deleted_rule_count": 2
+}
+```
+
+## Membership
+
+```text
+GET  /api/user-groups/:guid/users?current=1&pageSize=20&search=term
+POST /api/user-groups/:guid/users
+```
+
+Bulk move body:
+
+```json
+{
+  "user_guids": [
+    "9c89174d-bc33-4139-b3c8-7c20ca26bebe",
+    "f5d3e63a-d4e6-4c56-936f-a34ba7002c05"
+  ]
+}
+```
+
+The operation validates every user before writing and is atomic. Posting users
+to the default group is the canonical removal operation; users are never left
+without a group.
+
+## User Assignment
+
+Administrator-controlled create and invite requests accept:
+
+```json
+{ "user_group_guid": "f2d89530-94d8-4ca9-9122-62c136d9a384" }
+```
+
+The field is optional and falls back to the default group. User list/detail
+responses expose both:
+
+```json
+{
+  "user_group_guid": "f2d89530-94d8-4ca9-9122-62c136d9a384",
+  "user_group_name": "Operations"
+}
+```
+
+Legacy `group_name` input remains accepted by create/invite DTOs but is a
+deprecated no-op. It is not translated into a user group because the existing
+API also uses `group_name` for device-group-derived filters. Public
+registration, default-admin seeding, LDAP JIT, and OIDC JIT always resolve the
+default group internally.
+
+## Address-Book Grants
+
+The existing address-book rule endpoint accepts a user-group GUID:
+
+```text
+POST /api/ab/rule
+```
+
+```json
+{
+  "guid": "address-book-guid",
+  "group": "f2d89530-94d8-4ca9-9122-62c136d9a384",
+  "rule": 2
+}
+```
+
+`rule` is `1` (read), `2` (read/write), or `3` (full control). The caller must
+already have full control of the address book. A group target must exist, and
+`user` and `group` cannot be supplied together.
+
+Rule management uses the existing paginated endpoints:
+
+```text
+GET    /api/ab/rules?ab=<address-book-guid>&current=1&pageSize=100
+PATCH  /api/ab/rule
+DELETE /api/ab/rules
+```
+
+The list response is `{ "data": [...], "total": number }`; clients that
+manage every rule must continue requesting pages until `total` rows have been
+read. `PATCH` accepts `{ "guid": "rule-guid", "rule": 1|2|3 }`. `DELETE`
+accepts the rule GUID array as its raw JSON body, for example
+`["rule-guid"]`, not a wrapper such as `{ "ids": [...] }`.
+
+Owners always have full control. Other users receive the strongest applicable
+direct-user, current-user-group, or everyone rule. Membership is evaluated at
+read time, so moving a user changes access immediately without copying grants
+onto the user.
+
+The shared-address-book list endpoints apply the same aggregation:
+
+```text
+GET  /api/ab/shared/profiles
+POST /api/ab/shared/profiles
+```
+
+## Upgrade Behavior
+
+Startup creates one default group and backfills users with missing or invalid
+assignments. Legacy empty-string address-book targets are normalized to SQL
+`NULL`. Rules that reference unknown user groups are removed because they never
+granted effective access in earlier releases and must not become everyone
+rules accidentally.
+
+The schema remains managed by TypeORM `synchronize: true`. Back up the SQLite
+database before every application upgrade.
+
+## Frontend Integration
+
+The companion `rustdesk-console-web` implementation extends the existing user
+group, user, and shared-address-book pages. It provides member listing and
+bulk moves, validated `user_group_guid` selectors for create/invite, assigned
+group display, and group-grant list/add/update/delete controls. The default
+group is labeled and cannot be deleted in the UI.
+
+The group-grant surface filters to rules with a group target and leaves
+direct-user and everyone rules untouched. It is shown only to administrators
+with full control of the address book. The frontend does not relabel or
+reinterpret the legacy `group_name` field.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@nestjs/testing": "^11.0.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^5.0.0",
+        "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^24.0.0",
         "@types/nodemailer": "^8.0.0",
@@ -4222,6 +4223,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/express": "^5.0.0",
+    "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^24.0.0",
     "@types/nodemailer": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,6 +42,8 @@ import { UpdateCheckModule } from './modules/update-check/update-check.module';
 import { NexusModule } from './modules/nexus/nexus.module';
 import { NexusToken } from './modules/nexus/entities/nexus-token.entity';
 import { NexusBuild } from './modules/nexus/entities/nexus-build.entity';
+import { UserGroupModule } from './modules/user-group/user-group.module';
+import { UserGroup } from './modules/user-group/entities/user-group.entity';
 
 /**
  * 应用根模块
@@ -103,6 +105,7 @@ import { NexusBuild } from './modules/nexus/entities/nexus-build.entity';
         Strategy,
         NexusToken,
         NexusBuild,
+        UserGroup,
       ],
       synchronize: true,
       logging: false,
@@ -122,6 +125,7 @@ import { NexusBuild } from './modules/nexus/entities/nexus-build.entity';
     StrategyModule,
     UpdateCheckModule,
     NexusModule,
+    UserGroupModule,
   ],
   providers: [
     {

--- a/src/database/database-init.service.ts
+++ b/src/database/database-init.service.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../modules/user/entities/user.entity';
 import { OidcProvider } from '../modules/oidc/entities/oidc-provider.entity';
 import { OidcAuthState } from '../modules/oidc/entities/oidc-auth-state.entity';
+import { UserGroupService } from '../modules/user-group/user-group.service';
 
 @Injectable()
 /**
@@ -25,10 +26,12 @@ export class DatabaseInitService implements OnModuleInit {
     private oidcProviderRepository: Repository<OidcProvider>,
     @InjectRepository(OidcAuthState)
     private oidcAuthStateRepository: Repository<OidcAuthState>,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   async onModuleInit() {
-    await this.createDefaultAdmin();
+    const defaultGroup = await this.userGroupService.initializeStorage();
+    await this.createDefaultAdmin(defaultGroup.guid);
     await this.createDefaultOidcProviders();
     await this.cleanupExpiredAuthStates();
   }
@@ -36,7 +39,7 @@ export class DatabaseInitService implements OnModuleInit {
   /**
    * 创建默认管理员账户
    */
-  private async createDefaultAdmin() {
+  private async createDefaultAdmin(defaultGroupGuid: string) {
     // 检查数据库中是否已存在管理员用户
     const existingAdmin = await this.userRepository.findOne({
       where: { isAdmin: true },
@@ -66,6 +69,7 @@ export class DatabaseInitService implements OnModuleInit {
       status: UserStatus.ACTIVE,
       isAdmin: true,
       note: 'Default administrator account',
+      userGroupGuid: defaultGroupGuid,
     });
 
     await this.userRepository.save(admin);

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -6,6 +6,7 @@ import { OidcProvider } from '../modules/oidc/entities/oidc-provider.entity';
 import { OidcAuthState } from '../modules/oidc/entities/oidc-auth-state.entity';
 import { SystemSetting } from '../modules/settings/entities/system-setting.entity';
 import { DatabaseInitService } from './database-init.service';
+import { UserGroupModule } from '../modules/user-group/user-group.module';
 
 @Global()
 /**
@@ -24,6 +25,7 @@ import { DatabaseInitService } from './database-init.service';
       OidcAuthState,
       SystemSetting,
     ]),
+    UserGroupModule,
   ],
   providers: [DatabaseInitService],
   exports: [DatabaseInitService],

--- a/src/modules/address-book/address-book.controller.ts
+++ b/src/modules/address-book/address-book.controller.ts
@@ -526,11 +526,7 @@ export class AddressBookController {
   @Post('rule')
   @HttpCode(HttpStatus.OK)
   async addRule(@Body() dto: CreateRuleDto, @CurrentUser('id') userId: number) {
-    try {
-      return await this.ruleService.createRule(dto, String(userId));
-    } catch (e: unknown) {
-      return { error: e instanceof Error ? e.message : String(e) };
-    }
+    return this.ruleService.createRule(dto, String(userId));
   }
 
   /**
@@ -547,11 +543,7 @@ export class AddressBookController {
     @Body() dto: UpdateRuleDto,
     @CurrentUser('id') userId: number,
   ) {
-    try {
-      return await this.ruleService.updateRule(dto, String(userId));
-    } catch (e: unknown) {
-      return { error: e instanceof Error ? e.message : String(e) };
-    }
+    return this.ruleService.updateRule(dto, String(userId));
   }
 
   /**
@@ -568,10 +560,6 @@ export class AddressBookController {
     @Body() ruleGuids: string[],
     @CurrentUser('id') userId: number,
   ) {
-    try {
-      return await this.ruleService.deleteRules(ruleGuids, String(userId));
-    } catch (e: unknown) {
-      return { error: e instanceof Error ? e.message : String(e) };
-    }
+    return this.ruleService.deleteRules(ruleGuids, String(userId));
   }
 }

--- a/src/modules/address-book/address-book.module.ts
+++ b/src/modules/address-book/address-book.module.ts
@@ -18,6 +18,7 @@ import {
 } from './entities';
 import { Sysinfo, Peer } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
+import { UserGroupModule } from '../user-group/user-group.module';
 
 /**
  * 地址簿模块
@@ -49,6 +50,7 @@ import { User } from '../user/entities/user.entity';
       Peer,
       User,
     ]),
+    UserGroupModule,
   ],
   controllers: [AddressBookController],
   providers: [

--- a/src/modules/address-book/dto/rule.dto.ts
+++ b/src/modules/address-book/dto/rule.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   Min,
   Max,
+  IsUUID,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { PaginationDto } from './query.dto';
@@ -52,8 +53,7 @@ export class CreateRuleDto {
    * 与 user 互斥
    */
   @IsOptional()
-  @IsString()
-  @IsNotEmpty()
+  @IsUUID('4')
   group?: string;
 
   /**

--- a/src/modules/address-book/entities/address-book-rule.entity.ts
+++ b/src/modules/address-book/entities/address-book-rule.entity.ts
@@ -5,8 +5,11 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
+  JoinColumn,
+  Index,
 } from 'typeorm';
 import { AddressBook } from './address-book.entity';
+import { UserGroup } from '../../user-group/entities/user-group.entity';
 
 /**
  * 共享权限规则枚举
@@ -57,7 +60,8 @@ export class AddressBookRule {
    * 当规则类型为 'group' 或 'everyone' 时，此字段为空
    */
   @Column({ type: 'varchar', nullable: true })
-  targetUserId: string;
+  @Index()
+  targetUserId: string | null;
 
   /**
    * 目标组 GUID
@@ -65,7 +69,15 @@ export class AddressBookRule {
    * 当规则类型为 'user' 或 'everyone' 时，此字段为空
    */
   @Column({ type: 'varchar', nullable: true })
-  targetGroupId: string;
+  @Index()
+  targetGroupId: string | null;
+
+  @ManyToOne(() => UserGroup, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'targetGroupId' })
+  targetGroup: UserGroup | null;
 
   /**
    * 规则权限级别

--- a/src/modules/address-book/services/address-book-permission.service.ts
+++ b/src/modules/address-book/services/address-book-permission.service.ts
@@ -4,8 +4,9 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, IsNull } from 'typeorm';
+import { FindOptionsWhere, IsNull, Repository } from 'typeorm';
 import { AddressBook, AddressBookRule, ShareRule } from '../entities';
+import { User } from '../../user/entities/user.entity';
 
 /**
  * 地址簿权限检查服务
@@ -24,6 +25,9 @@ export class AddressBookPermissionService {
 
     @InjectRepository(AddressBookRule)
     private ruleRepository: Repository<AddressBookRule>,
+
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
   ) {}
 
   /**
@@ -55,21 +59,47 @@ export class AddressBookPermissionService {
       return addressBook;
     }
 
-    // 检查规则权限（用户规则）
-    const rule = await this.ruleRepository.findOne({
-      where: {
+    const user = await this.userRepository.findOne({
+      where: { guid: userId },
+      select: ['guid', 'userGroupGuid'],
+    });
+    if (!user) {
+      throw new ForbiddenException('无权访问此地址簿');
+    }
+
+    const applicableTargets: FindOptionsWhere<AddressBookRule>[] = [
+      {
         addressBookGuid,
         targetUserId: userId,
-        targetGroupId: IsNull(), // 确保是用户规则
+        targetGroupId: IsNull(),
       },
-    });
+      {
+        addressBookGuid,
+        targetUserId: IsNull(),
+        targetGroupId: IsNull(),
+      },
+    ];
 
-    if (!rule) {
+    if (user.userGroupGuid) {
+      applicableTargets.push({
+        addressBookGuid,
+        targetUserId: IsNull(),
+        targetGroupId: user.userGroupGuid,
+      });
+    }
+
+    const rules = await this.ruleRepository.find({ where: applicableTargets });
+    const effectiveRule = rules.reduce(
+      (strongest, rule) => Math.max(strongest, rule.rule),
+      0,
+    );
+
+    if (effectiveRule === 0) {
       throw new ForbiddenException('无权访问此地址簿');
     }
 
     // 检查权限级别
-    if (rule.rule < Number(requiredRule)) {
+    if (effectiveRule < Number(requiredRule)) {
       const requiredPermission =
         requiredRule === ShareRule.READ_WRITE ? '读写' : '完全控制';
       throw new ForbiddenException(`需要${requiredPermission}权限`);

--- a/src/modules/address-book/services/address-book-rule.service.ts
+++ b/src/modules/address-book/services/address-book-rule.service.ts
@@ -6,8 +6,9 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, IsNull } from 'typeorm';
+import { FindOptionsWhere, In, IsNull, Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
+import { isUUID } from 'class-validator';
 import { AddressBookRule, AddressBook, ShareRule } from '../entities';
 import { User } from '../../user/entities/user.entity';
 import {
@@ -17,6 +18,16 @@ import {
   PaginationDto,
 } from '../dto';
 import { AddressBookPermissionService } from './address-book-permission.service';
+import { UserGroupService } from '../../user-group/user-group.service';
+
+interface SharedAddressBookRow {
+  guid: string;
+  name: string | null;
+  owner: string;
+  note: string | null;
+  info: string | null;
+  rule: string | number;
+}
 
 /**
  * 地址簿规则服务
@@ -47,6 +58,7 @@ export class AddressBookRuleService {
     private userRepository: Repository<User>,
 
     private readonly permissionService: AddressBookPermissionService,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   /**
@@ -112,13 +124,13 @@ export class AddressBookRuleService {
     }
 
     // 如果没有指定用户或组，默认为 everyone
-    let finalTargetUserId = user || '';
-    const finalTargetGroupId = group || '';
+    let finalTargetUserId: string | null = null;
+    let finalTargetGroupId: string | null = null;
 
     // 如果提供了用户名而不是用户GUID，尝试查找用户
-    if (finalTargetUserId && !finalTargetUserId.includes('-')) {
+    if (user) {
       const userEntity = await this.userRepository.findOne({
-        where: { username: finalTargetUserId },
+        where: isUUID(user, '4') ? { guid: user } : { username: user },
       });
       if (userEntity) {
         finalTargetUserId = userEntity.guid;
@@ -127,18 +139,17 @@ export class AddressBookRuleService {
       }
     }
 
-    // 检查是否已存在相同规则
-    const whereClause: Record<string, unknown> = {
-      addressBookGuid: dto.guid,
-    };
+    if (group) {
+      finalTargetGroupId = (await this.userGroupService.requireGroup(group))
+        .guid;
+    }
 
-    // 只添加非空值到 where 子句
-    if (finalTargetUserId) {
-      whereClause.targetUserId = finalTargetUserId;
-    }
-    if (finalTargetGroupId) {
-      whereClause.targetGroupId = finalTargetGroupId;
-    }
+    // 检查是否已存在相同规则
+    const whereClause: FindOptionsWhere<AddressBookRule> = {
+      addressBookGuid: dto.guid,
+      targetUserId: finalTargetUserId || IsNull(),
+      targetGroupId: finalTargetGroupId || IsNull(),
+    };
 
     const existingRule = await this.ruleRepository.findOne({
       where: whereClause,
@@ -149,13 +160,13 @@ export class AddressBookRuleService {
     }
 
     // 创建新规则
-    const newRule: Partial<AddressBookRule> = {
+    const newRule = this.ruleRepository.create({
       guid: uuidv4(),
       addressBookGuid: dto.guid,
       targetUserId: finalTargetUserId,
       targetGroupId: finalTargetGroupId,
       rule,
-    };
+    });
 
     await this.ruleRepository.save(newRule);
 
@@ -256,25 +267,68 @@ export class AddressBookRuleService {
     const { current = 1, pageSize = 100, name } = query;
     const skip = (current - 1) * pageSize;
 
-    const whereCondition: Record<string, unknown> = {
-      targetUserId: userId,
-      targetGroupId: IsNull(), // 只查询用户规则
-    };
-
-    const [rules, total] = await this.ruleRepository.findAndCount({
-      where: whereCondition as Partial<AddressBookRule>,
-      relations: ['addressBook'],
-      skip,
-      take: pageSize,
+    const user = await this.userRepository.findOne({
+      where: { guid: userId },
+      select: ['guid', 'userGroupGuid'],
     });
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    const subjectConditions = [
+      '(rule.targetUserId = :userId AND rule.targetGroupId IS NULL)',
+      '(rule.targetUserId IS NULL AND rule.targetGroupId IS NULL)',
+    ];
+    const parameters: Record<string, string> = { userId };
+    if (user.userGroupGuid) {
+      subjectConditions.push(
+        '(rule.targetUserId IS NULL AND rule.targetGroupId = :userGroupGuid)',
+      );
+      parameters.userGroupGuid = user.userGroupGuid;
+    }
+
+    const queryBuilder = this.addressBookRepository
+      .createQueryBuilder('addressBook')
+      .innerJoin(
+        AddressBookRule,
+        'rule',
+        'rule.addressBookGuid = addressBook.guid',
+      )
+      .where(`(${subjectConditions.join(' OR ')})`, parameters);
+
+    const trimmedName = name?.trim();
+    if (trimmedName) {
+      queryBuilder.andWhere('addressBook.name LIKE :name', {
+        name: `%${trimmedName}%`,
+      });
+    }
+
+    const totalRow = await queryBuilder
+      .clone()
+      .select('COUNT(DISTINCT addressBook.guid)', 'total')
+      .getRawOne<{ total: string | number }>();
+
+    const rows = await queryBuilder
+      .select('addressBook.guid', 'guid')
+      .addSelect('addressBook.name', 'name')
+      .addSelect('addressBook.owner', 'owner')
+      .addSelect('addressBook.note', 'note')
+      .addSelect('addressBook.info', 'info')
+      .addSelect('MAX(rule.rule)', 'rule')
+      .groupBy('addressBook.guid')
+      .addGroupBy('addressBook.name')
+      .addGroupBy('addressBook.owner')
+      .addGroupBy('addressBook.note')
+      .addGroupBy('addressBook.info')
+      .orderBy('addressBook.name', 'ASC')
+      .addOrderBy('addressBook.guid', 'ASC')
+      .offset(skip)
+      .limit(pageSize)
+      .getRawMany<SharedAddressBookRow>();
 
     // 收集所有 owner (用户 GUID)
     const ownerGuids = [
-      ...new Set(
-        rules
-          .map((r) => r.addressBook?.owner)
-          .filter((guid): guid is string => !!guid),
-      ),
+      ...new Set(rows.map((row) => row.owner).filter((guid) => !!guid)),
     ];
 
     // 批量查询用户信息
@@ -288,24 +342,16 @@ export class AddressBookRuleService {
     const userMap = new Map(users.map((u) => [u.guid, u.username]));
 
     // 组装返回数据
-    let data = rules.map((r) => ({
-      guid: r.addressBookGuid,
-      name: r.addressBook?.name || '',
-      owner:
-        userMap.get(r.addressBook?.owner || '') || r.addressBook?.owner || '',
-      note: r.addressBook?.note || '',
-      rule: r.rule,
-      info: r.addressBook?.info
-        ? (JSON.parse(r.addressBook.info) as Record<string, unknown>)
-        : {},
+    const data = rows.map((row) => ({
+      guid: row.guid,
+      name: row.name || '',
+      owner: userMap.get(row.owner) || row.owner,
+      note: row.note || '',
+      rule: Number(row.rule),
+      info: row.info ? (JSON.parse(row.info) as Record<string, unknown>) : {},
     }));
 
-    // 如果提供了name参数，进行过滤
-    if (name) {
-      data = data.filter((item) => item.name.includes(name));
-    }
-
-    return { total, data };
+    return { total: Number(totalRow?.total || 0), data };
   }
 
   /**

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -18,6 +18,7 @@ import { Peer } from '../../common/entities';
 import { EmailVerificationSession } from './entities/email-verification-session.entity';
 import { EmailModule } from '../email/email.module';
 import { LdapModule } from '../ldap/ldap.module';
+import { UserGroupModule } from '../user-group/user-group.module';
 
 /**
  * 认证模块
@@ -43,6 +44,7 @@ import { LdapModule } from '../ldap/ldap.module';
     TypeOrmModule.forFeature([User, UserToken, Peer, EmailVerificationSession]),
     EmailModule,
     LdapModule,
+    UserGroupModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       secret:

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -27,6 +27,7 @@ import { AuthTfaService } from './auth-tfa.service';
 import { AuthEmailService } from './auth-email.service';
 import { AuthDeviceService } from './auth-device.service';
 import { LdapService } from '../../ldap/ldap.service';
+import { UserGroupService } from '../../user-group/user-group.service';
 
 /**
  * 认证服务
@@ -56,6 +57,7 @@ export class AuthService {
     private readonly emailAuthService: AuthEmailService,
     private readonly deviceService: AuthDeviceService,
     private readonly ldapService: LdapService,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   /**
@@ -83,6 +85,7 @@ export class AuthService {
 
     // 使用bcrypt加密密码，强度为10
     const hashedPassword = await bcrypt.hash(password, 10);
+    const userGroupGuid = await this.userGroupService.resolveUserGroupGuid();
 
     // 创建新用户
     const user = this.userRepository.create({
@@ -93,6 +96,7 @@ export class AuthService {
       note: note || '',
       status: UserStatus.ACTIVE,
       isAdmin: false,
+      userGroupGuid,
     });
 
     await this.userRepository.save(user);

--- a/src/modules/ldap/ldap.module.ts
+++ b/src/modules/ldap/ldap.module.ts
@@ -5,6 +5,7 @@ import { User } from '../user/entities/user.entity';
 import { LdapController } from './ldap.controller';
 import { LdapService } from './ldap.service';
 import { LdapSettingsService } from './ldap-settings.service';
+import { UserGroupModule } from '../user-group/user-group.module';
 
 /**
  * LDAP 认证模块
@@ -18,7 +19,7 @@ import { LdapSettingsService } from './ldap-settings.service';
  * - LdapSettingsService（供其他模块读取 LDAP 配置）
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([SystemSetting, User])],
+  imports: [TypeOrmModule.forFeature([SystemSetting, User]), UserGroupModule],
   controllers: [LdapController],
   providers: [LdapService, LdapSettingsService],
   exports: [LdapService, LdapSettingsService],

--- a/src/modules/ldap/ldap.service.ts
+++ b/src/modules/ldap/ldap.service.ts
@@ -11,6 +11,7 @@ import { Client, SearchOptions } from 'ldapts';
 import { User, UserStatus } from '../user/entities/user.entity';
 import { LdapSettingsService, LdapConfig } from './ldap-settings.service';
 import { TlsOptionsDto } from './dto/ldap-config.dto';
+import { UserGroupService } from '../user-group/user-group.service';
 
 /**
  * LDAP 用户信息接口
@@ -49,6 +50,7 @@ export class LdapService {
     @InjectRepository(User)
     private userRepository: Repository<User>,
     private readonly ldapSettingsService: LdapSettingsService,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   /**
@@ -373,6 +375,7 @@ export class LdapService {
     let finalUsername = username;
     let suffix = 1;
     const maxRetries = 3;
+    const userGroupGuid = await this.userGroupService.resolveUserGroupGuid();
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       while (
@@ -401,6 +404,7 @@ export class LdapService {
           : 'LDAP用户';
         user.thirdAuthType = 'ldap';
         user.oidcSubject = ldapSubject;
+        user.userGroupGuid = userGroupGuid;
 
         await this.userRepository.save(user);
         this.logger.log(`LDAP 用户已创建: ${finalUsername}`);

--- a/src/modules/oidc/oidc.module.ts
+++ b/src/modules/oidc/oidc.module.ts
@@ -9,11 +9,13 @@ import { OidcProvider } from './entities/oidc-provider.entity';
 import { OidcAuthState } from './entities/oidc-auth-state.entity';
 import { User } from '../user/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
+import { UserGroupModule } from '../user-group/user-group.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([OidcProvider, OidcAuthState, User]),
     AuthModule,
+    UserGroupModule,
   ],
   controllers: [OidcController, OidcAdminController],
   providers: [OidcService, OidcAdminService, OidcAuthStateCleanupService],

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -22,6 +22,7 @@ import { OidcAuthRequestDto } from '../dto/oidc.dto';
 import { LoginResponse } from '../../../common/interfaces';
 import { AuthTokenService } from '../../auth/services/auth-token.service';
 import { AuthDeviceService } from '../../auth/services/auth-device.service';
+import { UserGroupService } from '../../user-group/user-group.service';
 
 /**
  * OIDC配置接口
@@ -121,6 +122,7 @@ export class OidcService {
     private authTokenService: AuthTokenService,
     private deviceService: AuthDeviceService,
     private configService: ConfigService,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   /**
@@ -790,6 +792,7 @@ export class OidcService {
     let finalUsername = username;
     let suffix = 1;
     const maxRetries = 3;
+    const userGroupGuid = await this.userGroupService.resolveUserGroupGuid();
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       // 检查用户名是否已存在
@@ -818,6 +821,7 @@ export class OidcService {
         user.note = `OIDC用户 (${providerName})`;
         user.thirdAuthType = 'oidc';
         user.oidcSubject = oidcSubject;
+        user.userGroupGuid = userGroupGuid;
 
         await this.userRepository.save(user);
         this.logger.log(

--- a/src/modules/user-group/dto/user-group.dto.ts
+++ b/src/modules/user-group/dto/user-group.dto.ts
@@ -1,0 +1,64 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class UserGroupQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  current?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number = 20;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  search?: string;
+}
+
+export class CreateUserGroupDto {
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+}
+
+export class UpdateUserGroupDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+}
+
+export class UserGroupMembersDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(200)
+  @IsUUID('4', { each: true })
+  user_guids: string[];
+}

--- a/src/modules/user-group/entities/user-group.entity.ts
+++ b/src/modules/user-group/entities/user-group.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('user_groups')
+@Index('UQ_user_groups_single_default', ['isDefault'], {
+  unique: true,
+  where: '"isDefault" = 1',
+})
+export class UserGroup {
+  @PrimaryColumn()
+  guid: string;
+
+  @Column()
+  name: string;
+
+  @Column({ unique: true })
+  @Index()
+  normalizedName: string;
+
+  @Column({ type: 'text', nullable: true })
+  note: string | null;
+
+  @Column({ default: false })
+  isDefault: boolean;
+
+  @OneToMany(() => User, (user) => user.userGroup)
+  users: User[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/user-group/user-group.controller.ts
+++ b/src/modules/user-group/user-group.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminGuard } from '../../common/guards/admin.guard';
+import {
+  CreateUserGroupDto,
+  UpdateUserGroupDto,
+  UserGroupMembersDto,
+  UserGroupQueryDto,
+} from './dto/user-group.dto';
+import { UserGroupService } from './user-group.service';
+
+@Controller('user-groups')
+@UseGuards(AdminGuard)
+export class UserGroupController {
+  constructor(private readonly userGroupService: UserGroupService) {}
+
+  @Get()
+  getGroups(@Query() query: UserGroupQueryDto) {
+    return this.userGroupService.getGroups(query);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  createGroup(@Body() dto: CreateUserGroupDto) {
+    return this.userGroupService.createGroup(dto);
+  }
+
+  @Put(':guid')
+  @HttpCode(HttpStatus.OK)
+  updateGroup(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @Body() dto: UpdateUserGroupDto,
+  ) {
+    return this.userGroupService.updateGroup(guid, dto);
+  }
+
+  @Delete(':guid')
+  @HttpCode(HttpStatus.OK)
+  deleteGroup(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+  ) {
+    return this.userGroupService.deleteGroup(guid);
+  }
+
+  @Get(':guid/users')
+  getGroupUsers(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @Query() query: UserGroupQueryDto,
+  ) {
+    return this.userGroupService.getGroupUsers(guid, query);
+  }
+
+  @Post(':guid/users')
+  @HttpCode(HttpStatus.OK)
+  moveUsers(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @Body() dto: UserGroupMembersDto,
+  ) {
+    return this.userGroupService.moveUsers(guid, dto.user_guids);
+  }
+}

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -1,0 +1,785 @@
+import 'reflect-metadata';
+import { randomUUID } from 'node:crypto';
+import { Server } from 'node:http';
+import {
+  ConflictException,
+  ForbiddenException,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { Test } from '@nestjs/testing';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { DataSource, Repository } from 'typeorm';
+import request from 'supertest';
+import { AdminGuard } from '../../common/guards/admin.guard';
+import { DatabaseInitService } from '../../database/database-init.service';
+import { AddressBookPeerTag } from '../address-book/entities/address-book-peer-tag.entity';
+import { AddressBookPeer } from '../address-book/entities/address-book-peer.entity';
+import {
+  AddressBookRule,
+  ShareRule,
+} from '../address-book/entities/address-book-rule.entity';
+import { AddressBookTag } from '../address-book/entities/address-book-tag.entity';
+import { AddressBook } from '../address-book/entities/address-book.entity';
+import { CreateRuleDto } from '../address-book/dto/rule.dto';
+import { AddressBookPermissionService } from '../address-book/services/address-book-permission.service';
+import { AddressBookRuleService } from '../address-book/services/address-book-rule.service';
+import { DeviceGroupUserPermission } from '../device-group/entities/device-group-user-permission.entity';
+import { UserUserPermission } from '../device-group/entities/user-user-permission.entity';
+import { AuthService } from '../auth/services/auth.service';
+import { LdapService } from '../ldap/ldap.service';
+import { OidcService } from '../oidc/services/oidc.service';
+import { Strategy } from '../strategy/entities/strategy.entity';
+import { CreateUserDto, UserQueryDto } from '../user/dto/user.dto';
+import { UserToken } from '../user/entities/user-token.entity';
+import { User, UserStatus } from '../user/entities/user.entity';
+import { UserService } from '../user/user.service';
+import { UserGroupMembersDto, UserGroupQueryDto } from './dto/user-group.dto';
+import { UserGroup } from './entities/user-group.entity';
+import { UserGroupController } from './user-group.controller';
+import { UserGroupService } from './user-group.service';
+
+interface UserGroupHttpBody {
+  guid: string;
+  name: string;
+  note: string;
+  user_count: number;
+}
+
+interface UserGroupListHttpBody {
+  data: UserGroupHttpBody[];
+  total: number;
+}
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+jest.mock('openid-client', () => ({}));
+
+describe('User group integration', () => {
+  let dataSource: DataSource;
+  let groupRepository: Repository<UserGroup>;
+  let userRepository: Repository<User>;
+  let ruleRepository: Repository<AddressBookRule>;
+  let addressBookRepository: Repository<AddressBook>;
+  let userGroupService: UserGroupService;
+  let permissionService: AddressBookPermissionService;
+  let ruleService: AddressBookRuleService;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      dropSchema: true,
+      synchronize: true,
+      logging: false,
+      entities: [
+        UserGroup,
+        User,
+        UserToken,
+        Strategy,
+        AddressBook,
+        AddressBookPeer,
+        AddressBookTag,
+        AddressBookPeerTag,
+        AddressBookRule,
+      ],
+    });
+    await dataSource.initialize();
+
+    groupRepository = dataSource.getRepository(UserGroup);
+    userRepository = dataSource.getRepository(User);
+    ruleRepository = dataSource.getRepository(AddressBookRule);
+    addressBookRepository = dataSource.getRepository(AddressBook);
+
+    userGroupService = new UserGroupService(
+      groupRepository,
+      userRepository,
+      ruleRepository,
+      dataSource,
+    );
+    permissionService = new AddressBookPermissionService(
+      addressBookRepository,
+      ruleRepository,
+      userRepository,
+    );
+    ruleService = new AddressBookRuleService(
+      ruleRepository,
+      addressBookRepository,
+      userRepository,
+      permissionService,
+      userGroupService,
+    );
+    userService = new UserService(
+      userRepository,
+      dataSource.getRepository(UserToken),
+      {} as Repository<DeviceGroupUserPermission>,
+      {} as Repository<UserUserPermission>,
+      userGroupService,
+    );
+  });
+
+  afterEach(async () => {
+    if (dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  async function createUser(
+    username: string,
+    userGroupGuid: string | null,
+  ): Promise<User> {
+    return userRepository.save(
+      userRepository.create({
+        guid: randomUUID(),
+        username,
+        email: null,
+        password: 'hashed-password',
+        note: '',
+        status: UserStatus.ACTIVE,
+        isAdmin: false,
+        userGroupGuid,
+      }),
+    );
+  }
+
+  async function createAddressBook(
+    owner: string,
+    name = 'Shared book',
+  ): Promise<AddressBook> {
+    return addressBookRepository.save(
+      addressBookRepository.create({
+        guid: randomUUID(),
+        owner,
+        name,
+        isPersonal: false,
+      }),
+    );
+  }
+
+  async function createRule(
+    addressBookGuid: string,
+    targetUserId: string | null,
+    targetGroupId: string | null,
+    rule: ShareRule,
+  ): Promise<AddressBookRule> {
+    return ruleRepository.save(
+      ruleRepository.create({
+        guid: randomUUID(),
+        addressBookGuid,
+        targetUserId,
+        targetGroupId,
+        rule,
+      }),
+    );
+  }
+
+  it('initializes a single default group, backfills users, and cleans legacy rule targets', async () => {
+    const legacyUser = await createUser('legacy-user', null);
+    const addressBook = await createAddressBook(legacyUser.guid);
+    const everyoneRuleGuid = randomUUID();
+    const invalidGroupRuleGuid = randomUUID();
+
+    await dataSource.query('PRAGMA foreign_keys = OFF');
+    await dataSource.query(
+      `INSERT INTO address_book_rules
+       (guid, addressBookGuid, targetUserId, targetGroupId, rule, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [everyoneRuleGuid, addressBook.guid, '', '', ShareRule.READ],
+    );
+    await dataSource.query(
+      `INSERT INTO address_book_rules
+       (guid, addressBookGuid, targetUserId, targetGroupId, rule, createdAt, updatedAt)
+       VALUES (?, ?, NULL, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [invalidGroupRuleGuid, addressBook.guid, randomUUID(), ShareRule.READ],
+    );
+    await dataSource.query('PRAGMA foreign_keys = ON');
+
+    const firstDefault = await userGroupService.initializeStorage();
+    const secondDefault = await userGroupService.initializeStorage();
+
+    expect(secondDefault.guid).toBe(firstDefault.guid);
+    expect(await groupRepository.count({ where: { isDefault: true } })).toBe(1);
+    expect(
+      (await userRepository.findOneByOrFail({ guid: legacyUser.guid }))
+        .userGroupGuid,
+    ).toBe(firstDefault.guid);
+
+    const everyoneRule = await ruleRepository.findOneByOrFail({
+      guid: everyoneRuleGuid,
+    });
+    expect(everyoneRule.targetUserId).toBeNull();
+    expect(everyoneRule.targetGroupId).toBeNull();
+    expect(
+      await ruleRepository.findOneBy({ guid: invalidGroupRuleGuid }),
+    ).toBeNull();
+    expect(await dataSource.query('PRAGMA foreign_key_check')).toEqual([]);
+  });
+
+  it('enforces normalized names and moves members atomically', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const operations = await userGroupService.createGroup({
+      name: '  Operations  ',
+      note: '  Primary operators  ',
+    });
+
+    expect(operations.name).toBe('Operations');
+    expect(operations.note).toBe('Primary operators');
+    await expect(userGroupService.createGroup({ name: '   ' })).rejects.toThrow(
+      '用户组名称不能为空',
+    );
+    await expect(
+      userGroupService.createGroup({ name: 'operations' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      userGroupService.updateGroup(operations.guid, {
+        name: 'Operations Team',
+      }),
+    ).resolves.toMatchObject({ name: 'Operations Team' });
+
+    const alice = await createUser('alice', defaultGroup.guid);
+    const bob = await createUser('bob', defaultGroup.guid);
+    await expect(
+      userGroupService.moveUsers(operations.guid, [alice.guid, randomUUID()]),
+    ).rejects.toThrow('一个或多个用户不存在');
+    expect(
+      (await userRepository.findOneByOrFail({ guid: alice.guid }))
+        .userGroupGuid,
+    ).toBe(defaultGroup.guid);
+
+    await expect(
+      userGroupService.moveUsers(operations.guid, [alice.guid, bob.guid]),
+    ).resolves.toMatchObject({ moved_user_count: 2 });
+
+    const groups = await userGroupService.getGroups({
+      current: 1,
+      pageSize: 20,
+      search: 'OPER',
+    });
+    expect(groups.total).toBe(1);
+    expect(groups.data[0]).toMatchObject({
+      guid: operations.guid,
+      user_count: 2,
+    });
+
+    const members = await userGroupService.getGroupUsers(operations.guid, {
+      current: 1,
+      pageSize: 20,
+    });
+    expect(members.total).toBe(2);
+    expect(members.data.map((user) => user.name)).toEqual(['alice', 'bob']);
+    await expect(
+      userGroupService.getGroupUsers(randomUUID(), {
+        current: 1,
+        pageSize: 20,
+      }),
+    ).rejects.toThrow('用户组不存在');
+  });
+
+  it('uses user_group_guid while keeping legacy group_name as a no-op', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const selectedGroup = await userGroupService.createGroup({
+      name: 'Selected',
+    });
+
+    await userService.createUser({
+      name: 'legacy-field-user',
+      password: 'test-password',
+      group_name: 'Selected',
+    });
+    await userService.createUser({
+      name: 'canonical-field-user',
+      password: 'test-password',
+      user_group_guid: selectedGroup.guid,
+    });
+    await userService.inviteUser({
+      name: 'invited-user',
+      email: 'invited@example.com',
+      user_group_guid: selectedGroup.guid,
+    });
+
+    expect(
+      (
+        await userRepository.findOneByOrFail({
+          username: 'legacy-field-user',
+        })
+      ).userGroupGuid,
+    ).toBe(defaultGroup.guid);
+    expect(
+      (
+        await userRepository.findOneByOrFail({
+          username: 'canonical-field-user',
+        })
+      ).userGroupGuid,
+    ).toBe(selectedGroup.guid);
+    expect(
+      (await userRepository.findOneByOrFail({ username: 'invited-user' }))
+        .userGroupGuid,
+    ).toBe(selectedGroup.guid);
+  });
+
+  it('assigns the default group in admin seed, registration, LDAP JIT, and OIDC JIT paths', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const authService = new AuthService(
+      userRepository,
+      dataSource.getRepository(UserToken),
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      userGroupService,
+    );
+    const databaseInitService = new DatabaseInitService(
+      userRepository,
+      undefined as never,
+      undefined as never,
+      userGroupService,
+    );
+    const ldapService = new LdapService(
+      userRepository,
+      undefined as never,
+      userGroupService,
+    );
+    const oidcService = new OidcService(
+      undefined as never,
+      undefined as never,
+      userRepository,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      userGroupService,
+    );
+
+    const previousAdminUsername = process.env.ADMIN_USERNAME;
+    const previousAdminEmail = process.env.ADMIN_EMAIL;
+    const previousAdminPassword = process.env.ADMIN_PASSWORD;
+    process.env.ADMIN_USERNAME = 'seed-admin';
+    process.env.ADMIN_EMAIL = 'seed-admin@example.com';
+    process.env.ADMIN_PASSWORD = 'seed-password';
+
+    try {
+      await (
+        databaseInitService as unknown as {
+          createDefaultAdmin(groupGuid: string): Promise<void>;
+        }
+      ).createDefaultAdmin(defaultGroup.guid);
+    } finally {
+      if (previousAdminUsername === undefined) {
+        delete process.env.ADMIN_USERNAME;
+      } else {
+        process.env.ADMIN_USERNAME = previousAdminUsername;
+      }
+      if (previousAdminEmail === undefined) {
+        delete process.env.ADMIN_EMAIL;
+      } else {
+        process.env.ADMIN_EMAIL = previousAdminEmail;
+      }
+      if (previousAdminPassword === undefined) {
+        delete process.env.ADMIN_PASSWORD;
+      } else {
+        process.env.ADMIN_PASSWORD = previousAdminPassword;
+      }
+    }
+
+    await authService.register({
+      username: 'registered-user',
+      email: 'registered@example.com',
+      password: 'registered-password',
+    });
+    await (
+      ldapService as unknown as {
+        findOrCreateUser(
+          userInfo: {
+            dn: string;
+            username: string;
+            email: string;
+            displayName: string;
+            groups: string[];
+          },
+          config: { adminGroups: string[] },
+        ): Promise<User>;
+      }
+    ).findOrCreateUser(
+      {
+        dn: 'cn=ldap-user,dc=example,dc=com',
+        username: 'ldap-user',
+        email: 'ldap@example.com',
+        displayName: 'LDAP User',
+        groups: [],
+      },
+      { adminGroups: [] },
+    );
+    await (
+      oidcService as unknown as {
+        findOrCreateUser(
+          userInfo: {
+            sub: string;
+            preferred_username: string;
+            email: string;
+            email_verified: boolean;
+          },
+          providerName: string,
+        ): Promise<User>;
+      }
+    ).findOrCreateUser(
+      {
+        sub: 'oidc-subject',
+        preferred_username: 'oidc-user',
+        email: 'oidc@example.com',
+        email_verified: true,
+      },
+      'test-provider',
+    );
+
+    const createdUsers = await userRepository.find({
+      where: [
+        { username: 'seed-admin' },
+        { username: 'registered-user' },
+        { username: 'ldap-user' },
+        { username: 'oidc-user' },
+      ],
+    });
+    expect(createdUsers).toHaveLength(4);
+    expect(
+      createdUsers.every((user) => user.userGroupGuid === defaultGroup.guid),
+    ).toBe(true);
+  });
+
+  it('deletes group grants and moves members in one transaction', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const temporaryGroup = await userGroupService.createGroup({
+      name: 'Temporary',
+    });
+    const owner = await createUser('owner', defaultGroup.guid);
+    const member = await createUser('member', temporaryGroup.guid);
+    const addressBook = await createAddressBook(owner.guid);
+    await createRule(
+      addressBook.guid,
+      null,
+      temporaryGroup.guid,
+      ShareRule.READ_WRITE,
+    );
+
+    await expect(
+      userGroupService.deleteGroup(temporaryGroup.guid),
+    ).resolves.toEqual({
+      message: '用户组删除成功',
+      moved_user_count: 1,
+      deleted_rule_count: 1,
+    });
+    expect(
+      (await userRepository.findOneByOrFail({ guid: member.guid }))
+        .userGroupGuid,
+    ).toBe(defaultGroup.guid);
+    expect(
+      await groupRepository.findOneBy({ guid: temporaryGroup.guid }),
+    ).toBeNull();
+    expect(
+      await ruleRepository.count({
+        where: { targetGroupId: temporaryGroup.guid },
+      }),
+    ).toBe(0);
+    await expect(
+      userGroupService.deleteGroup(defaultGroup.guid),
+    ).rejects.toThrow('默认用户组不能删除');
+  });
+
+  it('rolls back member and rule changes when group deletion fails', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const protectedGroup = await userGroupService.createGroup({
+      name: 'Rollback target',
+    });
+    const owner = await createUser('rollback-owner', defaultGroup.guid);
+    const member = await createUser('rollback-member', protectedGroup.guid);
+    const addressBook = await createAddressBook(owner.guid);
+    const rule = await createRule(
+      addressBook.guid,
+      null,
+      protectedGroup.guid,
+      ShareRule.READ,
+    );
+    await dataSource.query(
+      `CREATE TRIGGER fail_user_group_delete
+       BEFORE DELETE ON user_groups
+       WHEN OLD.isDefault = 0
+       BEGIN
+         SELECT RAISE(ABORT, 'forced delete failure');
+       END`,
+    );
+
+    await expect(
+      userGroupService.deleteGroup(protectedGroup.guid),
+    ).rejects.toThrow('forced delete failure');
+    expect(
+      (await userRepository.findOneByOrFail({ guid: member.guid }))
+        .userGroupGuid,
+    ).toBe(protectedGroup.guid);
+    expect(await ruleRepository.findOneBy({ guid: rule.guid })).not.toBeNull();
+    expect(
+      await groupRepository.findOneBy({ guid: protectedGroup.guid }),
+    ).not.toBeNull();
+  });
+
+  it('resolves owner, direct, group, and everyone rules by strongest permission', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const operators = await userGroupService.createGroup({ name: 'Operators' });
+    const guests = await userGroupService.createGroup({ name: 'Guests' });
+    const owner = await createUser('book-owner', defaultGroup.guid);
+    const member = await createUser('operator', operators.guid);
+    const outsider = await createUser('guest', guests.guid);
+    const addressBook = await createAddressBook(owner.guid, 'Operations book');
+
+    await createRule(addressBook.guid, member.guid, null, ShareRule.READ);
+    await createRule(
+      addressBook.guid,
+      null,
+      operators.guid,
+      ShareRule.FULL_CONTROL,
+    );
+    await createRule(addressBook.guid, null, null, ShareRule.READ_WRITE);
+
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        owner.guid,
+        ShareRule.FULL_CONTROL,
+      ),
+    ).resolves.toMatchObject({ guid: addressBook.guid });
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        member.guid,
+        ShareRule.FULL_CONTROL,
+      ),
+    ).resolves.toMatchObject({ guid: addressBook.guid });
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        outsider.guid,
+        ShareRule.READ_WRITE,
+      ),
+    ).resolves.toMatchObject({ guid: addressBook.guid });
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        outsider.guid,
+        ShareRule.FULL_CONTROL,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    await userGroupService.moveUsers(guests.guid, [member.guid]);
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        member.guid,
+        ShareRule.FULL_CONTROL,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(
+      permissionService.checkAddressBookAccess(
+        addressBook.guid,
+        member.guid,
+        ShareRule.READ_WRITE,
+      ),
+    ).resolves.toMatchObject({ guid: addressBook.guid });
+  });
+
+  it('validates group rules and aggregates shared address books without duplicates', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const operators = await userGroupService.createGroup({
+      name: 'Rule operators',
+    });
+    const guests = await userGroupService.createGroup({ name: 'Rule guests' });
+    const owner = await createUser('rule-owner', defaultGroup.guid);
+    const member = await createUser('rule-member', operators.guid);
+    const outsider = await createUser('rule-outsider', guests.guid);
+    const addressBook = await createAddressBook(owner.guid, 'Rule book');
+
+    await ruleService.createRule(
+      {
+        guid: addressBook.guid,
+        group: operators.guid,
+        rule: ShareRule.FULL_CONTROL,
+      },
+      owner.guid,
+    );
+    await ruleService.createRule(
+      { guid: addressBook.guid, rule: ShareRule.READ },
+      owner.guid,
+    );
+
+    await expect(
+      ruleService.createRule(
+        {
+          guid: addressBook.guid,
+          group: operators.guid,
+          rule: ShareRule.READ,
+        },
+        owner.guid,
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+    await expect(
+      ruleService.createRule(
+        {
+          guid: addressBook.guid,
+          group: randomUUID(),
+          rule: ShareRule.READ,
+        },
+        owner.guid,
+      ),
+    ).rejects.toThrow('用户组不存在');
+
+    const memberBooks = await ruleService.getSharedAddressBooks(member.guid, {
+      current: 1,
+      pageSize: 20,
+    });
+    expect(memberBooks).toMatchObject({
+      total: 1,
+      data: [{ guid: addressBook.guid, rule: ShareRule.FULL_CONTROL }],
+    });
+
+    const outsiderBooks = await ruleService.getSharedAddressBooks(
+      outsider.guid,
+      { current: 1, pageSize: 20, name: 'Rule' },
+    );
+    expect(outsiderBooks).toMatchObject({
+      total: 1,
+      data: [{ guid: addressBook.guid, rule: ShareRule.READ }],
+    });
+
+    await userGroupService.moveUsers(guests.guid, [member.guid]);
+    const movedMemberBooks = await ruleService.getSharedAddressBooks(
+      member.guid,
+      { current: 1, pageSize: 20 },
+    );
+    expect(movedMemberBooks.data[0].rule).toBe(ShareRule.READ);
+  });
+
+  it('publishes validated DTOs and protects every user-group route with AdminGuard', async () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      UserGroupController,
+    ) as unknown[];
+    expect(guards).toContain(AdminGuard);
+
+    const validLegacyCreate = plainToInstance(CreateUserDto, {
+      name: 'new-user',
+      password: 'test-password',
+      group_name: 'legacy-value',
+      user_group_guid: randomUUID(),
+    });
+    expect(await validate(validLegacyCreate)).toHaveLength(0);
+
+    const rustDeskGroupQuery = plainToInstance(UserQueryDto, {
+      current: 1,
+      pageSize: 100,
+      accessible: '',
+      status: '1',
+    });
+    expect(
+      await validate(rustDeskGroupQuery, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    ).toHaveLength(0);
+
+    const invalidMembers = plainToInstance(UserGroupMembersDto, {
+      user_guids: ['not-a-uuid'],
+    });
+    expect(await validate(invalidMembers)).not.toHaveLength(0);
+
+    const oversizedPage = plainToInstance(UserGroupQueryDto, {
+      current: 1,
+      pageSize: 101,
+    });
+    expect(await validate(oversizedPage)).not.toHaveLength(0);
+
+    const invalidGroupRule = plainToInstance(CreateRuleDto, {
+      guid: randomUUID(),
+      group: 'not-a-uuid',
+      rule: ShareRule.READ,
+    });
+    expect(await validate(invalidGroupRule)).not.toHaveLength(0);
+  });
+
+  it('serves the existing frontend CRUD contract under /api/user-groups', async () => {
+    await userGroupService.initializeStorage();
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UserGroupController],
+      providers: [
+        { provide: UserGroupService, useValue: userGroupService },
+        AdminGuard,
+      ],
+    })
+      .overrideGuard(AdminGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+    const app: INestApplication = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    const httpServer = app.getHttpServer() as unknown as Server;
+
+    try {
+      const created = await request(httpServer)
+        .post('/api/user-groups')
+        .send({ name: 'Frontend group', note: 'Created through HTTP' })
+        .expect(200);
+      const createdBody = created.body as unknown as UserGroupHttpBody;
+
+      expect(createdBody).toMatchObject({
+        name: 'Frontend group',
+        note: 'Created through HTTP',
+        user_count: 0,
+      });
+
+      const listed = await request(httpServer)
+        .get('/api/user-groups')
+        .query({ current: 1, pageSize: 20, search: 'frontend' })
+        .expect(200);
+      const listedBody = listed.body as unknown as UserGroupListHttpBody;
+      expect(listedBody).toMatchObject({
+        total: 1,
+        data: [{ guid: createdBody.guid, name: 'Frontend group' }],
+      });
+
+      await request(httpServer)
+        .put(`/api/user-groups/${createdBody.guid}`)
+        .send({ note: 'Updated through HTTP' })
+        .expect(200)
+        .expect((response) => {
+          const responseBody = response.body as unknown as UserGroupHttpBody;
+          expect(responseBody.note).toBe('Updated through HTTP');
+        });
+
+      await request(httpServer)
+        .get('/api/user-groups')
+        .query({ current: 0, pageSize: 20 })
+        .expect(400);
+      await request(httpServer)
+        .post('/api/user-groups')
+        .send({ name: 'Rejected', unknown: true })
+        .expect(400);
+      await request(httpServer)
+        .delete(`/api/user-groups/${createdBody.guid}`)
+        .expect(200);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/modules/user-group/user-group.module.ts
+++ b/src/modules/user-group/user-group.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AddressBookRule } from '../address-book/entities/address-book-rule.entity';
+import { User } from '../user/entities/user.entity';
+import { UserGroup } from './entities/user-group.entity';
+import { UserGroupController } from './user-group.controller';
+import { UserGroupService } from './user-group.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserGroup, User, AddressBookRule])],
+  controllers: [UserGroupController],
+  providers: [UserGroupService],
+  exports: [UserGroupService],
+})
+export class UserGroupModule {}

--- a/src/modules/user-group/user-group.service.ts
+++ b/src/modules/user-group/user-group.service.ts
@@ -1,0 +1,392 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, QueryFailedError, Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { AddressBookRule } from '../address-book/entities/address-book-rule.entity';
+import { User } from '../user/entities/user.entity';
+import {
+  CreateUserGroupDto,
+  UpdateUserGroupDto,
+  UserGroupQueryDto,
+} from './dto/user-group.dto';
+import { UserGroup } from './entities/user-group.entity';
+
+const DEFAULT_USER_GROUP_NAME = 'Default';
+
+type UserGroupWithCount = UserGroup & { userCount?: number };
+
+@Injectable()
+export class UserGroupService {
+  private readonly logger = new Logger(UserGroupService.name);
+
+  constructor(
+    @InjectRepository(UserGroup)
+    private readonly userGroupRepository: Repository<UserGroup>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(AddressBookRule)
+    private readonly ruleRepository: Repository<AddressBookRule>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async initializeStorage(): Promise<UserGroup> {
+    const defaultGroup = await this.ensureDefaultGroup();
+
+    const backfillResult = await this.userRepository
+      .createQueryBuilder()
+      .update(User)
+      .set({ userGroupGuid: defaultGroup.guid })
+      .where('"userGroupGuid" IS NULL')
+      .orWhere('"userGroupGuid" NOT IN (SELECT "guid" FROM "user_groups")')
+      .execute();
+
+    const emptyUserTargets = await this.ruleRepository
+      .createQueryBuilder()
+      .update(AddressBookRule)
+      .set({ targetUserId: null })
+      .where('"targetUserId" = :empty', { empty: '' })
+      .execute();
+
+    const emptyGroupTargets = await this.ruleRepository
+      .createQueryBuilder()
+      .update(AddressBookRule)
+      .set({ targetGroupId: null })
+      .where('"targetGroupId" = :empty', { empty: '' })
+      .execute();
+
+    const invalidGroupTargets = await this.ruleRepository
+      .createQueryBuilder()
+      .delete()
+      .from(AddressBookRule)
+      .where('"targetGroupId" IS NOT NULL')
+      .andWhere('"targetGroupId" NOT IN (SELECT "guid" FROM "user_groups")')
+      .execute();
+
+    if (backfillResult.affected) {
+      this.logger.log(
+        `Assigned ${backfillResult.affected} existing users to the default group`,
+      );
+    }
+
+    const normalizedTargetCount =
+      (emptyUserTargets.affected || 0) + (emptyGroupTargets.affected || 0);
+    if (normalizedTargetCount > 0) {
+      this.logger.log(
+        `Normalized ${normalizedTargetCount} legacy address-book rule targets`,
+      );
+    }
+    if (invalidGroupTargets.affected) {
+      this.logger.warn(
+        `Removed ${invalidGroupTargets.affected} address-book rules with unknown user groups`,
+      );
+    }
+
+    return defaultGroup;
+  }
+
+  async ensureDefaultGroup(): Promise<UserGroup> {
+    const existingDefault = await this.userGroupRepository.findOne({
+      where: { isDefault: true },
+    });
+    if (existingDefault) {
+      return existingDefault;
+    }
+
+    const { name, normalizedName } = this.normalizeName(
+      DEFAULT_USER_GROUP_NAME,
+    );
+    const existingNamedGroup = await this.userGroupRepository.findOne({
+      where: { normalizedName },
+    });
+
+    if (existingNamedGroup) {
+      existingNamedGroup.isDefault = true;
+      return this.userGroupRepository.save(existingNamedGroup);
+    }
+
+    const defaultGroup = this.userGroupRepository.create({
+      guid: uuidv4(),
+      name,
+      normalizedName,
+      note: null,
+      isDefault: true,
+    });
+
+    try {
+      const saved = await this.userGroupRepository.save(defaultGroup);
+      this.logger.log(`Default user group created: ${saved.guid}`);
+      return saved;
+    } catch (error: unknown) {
+      if (this.isUniqueConstraintError(error)) {
+        const concurrentDefault = await this.userGroupRepository.findOne({
+          where: { isDefault: true },
+        });
+        if (concurrentDefault) {
+          return concurrentDefault;
+        }
+      }
+      throw error;
+    }
+  }
+
+  async resolveUserGroupGuid(userGroupGuid?: string): Promise<string> {
+    if (!userGroupGuid) {
+      return (await this.ensureDefaultGroup()).guid;
+    }
+    return (await this.requireGroup(userGroupGuid)).guid;
+  }
+
+  async requireGroup(guid: string): Promise<UserGroup> {
+    const group = await this.userGroupRepository.findOne({ where: { guid } });
+    if (!group) {
+      throw new NotFoundException('用户组不存在');
+    }
+    return group;
+  }
+
+  async getGroups(query: UserGroupQueryDto) {
+    const { current = 1, pageSize = 20, search } = query;
+    const queryBuilder = this.userGroupRepository
+      .createQueryBuilder('userGroup')
+      .loadRelationCountAndMap('userGroup.userCount', 'userGroup.users');
+
+    const normalizedSearch = search?.trim().toLowerCase();
+    if (normalizedSearch) {
+      queryBuilder.andWhere('userGroup.normalizedName LIKE :search', {
+        search: `%${normalizedSearch}%`,
+      });
+    }
+
+    const [groups, total] = await queryBuilder
+      .orderBy('userGroup.normalizedName', 'ASC')
+      .addOrderBy('userGroup.guid', 'ASC')
+      .skip((current - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      data: (groups as UserGroupWithCount[]).map((group) =>
+        this.toGroupResponse(group, group.userCount || 0),
+      ),
+      total,
+    };
+  }
+
+  async createGroup(dto: CreateUserGroupDto) {
+    const { name, normalizedName } = this.normalizeName(dto.name);
+    await this.assertNameAvailable(normalizedName);
+
+    const group = this.userGroupRepository.create({
+      guid: uuidv4(),
+      name,
+      normalizedName,
+      note: this.normalizeNote(dto.note),
+      isDefault: false,
+    });
+
+    try {
+      const saved = await this.userGroupRepository.save(group);
+      return this.toGroupResponse(saved, 0);
+    } catch (error: unknown) {
+      this.rethrowUniqueName(error);
+    }
+  }
+
+  async updateGroup(guid: string, dto: UpdateUserGroupDto) {
+    const group = await this.requireGroup(guid);
+
+    if (dto.name !== undefined) {
+      const { name, normalizedName } = this.normalizeName(dto.name);
+      await this.assertNameAvailable(normalizedName, guid);
+      group.name = name;
+      group.normalizedName = normalizedName;
+    }
+
+    if (dto.note !== undefined) {
+      group.note = this.normalizeNote(dto.note);
+    }
+
+    try {
+      const saved = await this.userGroupRepository.save(group);
+      const userCount = await this.userRepository.count({
+        where: { userGroupGuid: guid },
+      });
+      return this.toGroupResponse(saved, userCount);
+    } catch (error: unknown) {
+      this.rethrowUniqueName(error);
+    }
+  }
+
+  async deleteGroup(guid: string) {
+    return this.dataSource.transaction(async (manager) => {
+      const groupRepository = manager.getRepository(UserGroup);
+      const userRepository = manager.getRepository(User);
+      const ruleRepository = manager.getRepository(AddressBookRule);
+
+      const group = await groupRepository.findOne({ where: { guid } });
+      if (!group) {
+        throw new NotFoundException('用户组不存在');
+      }
+      if (group.isDefault) {
+        throw new BadRequestException('默认用户组不能删除');
+      }
+
+      const defaultGroup = await groupRepository.findOne({
+        where: { isDefault: true },
+      });
+      if (!defaultGroup) {
+        throw new BadRequestException('默认用户组不存在');
+      }
+
+      const movedUsers = await userRepository.update(
+        { userGroupGuid: guid },
+        { userGroupGuid: defaultGroup.guid },
+      );
+      const deletedRules = await ruleRepository.delete({
+        targetGroupId: guid,
+      });
+      await groupRepository.delete({ guid });
+
+      return {
+        message: '用户组删除成功',
+        moved_user_count: movedUsers.affected || 0,
+        deleted_rule_count: deletedRules.affected || 0,
+      };
+    });
+  }
+
+  async getGroupUsers(guid: string, query: UserGroupQueryDto) {
+    const group = await this.requireGroup(guid);
+    const { current = 1, pageSize = 20, search } = query;
+    const queryBuilder = this.userRepository
+      .createQueryBuilder('user')
+      .where('user.userGroupGuid = :guid', { guid });
+
+    const trimmedSearch = search?.trim();
+    if (trimmedSearch) {
+      queryBuilder.andWhere(
+        '(user.username LIKE :search OR user.email LIKE :search)',
+        { search: `%${trimmedSearch}%` },
+      );
+    }
+
+    const [users, total] = await queryBuilder
+      .orderBy('user.username', 'ASC')
+      .addOrderBy('user.guid', 'ASC')
+      .skip((current - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      data: users.map((user) => ({
+        guid: user.guid,
+        name: user.username,
+        email: user.email || '',
+        note: user.note || '',
+        status: user.status,
+        is_admin: user.isAdmin,
+        user_group_guid: group.guid,
+        user_group_name: group.name,
+      })),
+      total,
+    };
+  }
+
+  async moveUsers(guid: string, userGuids: string[]) {
+    const uniqueGuids = [...new Set(userGuids)];
+
+    return this.dataSource.transaction(async (manager) => {
+      const groupRepository = manager.getRepository(UserGroup);
+      const userRepository = manager.getRepository(User);
+
+      const group = await groupRepository.findOne({ where: { guid } });
+      if (!group) {
+        throw new NotFoundException('用户组不存在');
+      }
+
+      const users = await userRepository.find({
+        where: { guid: In(uniqueGuids) },
+        select: ['guid', 'userGroupGuid'],
+      });
+      if (users.length !== uniqueGuids.length) {
+        throw new NotFoundException('一个或多个用户不存在');
+      }
+
+      const guidsToMove = users
+        .filter((user) => user.userGroupGuid !== guid)
+        .map((user) => user.guid);
+
+      if (guidsToMove.length > 0) {
+        await userRepository.update(
+          { guid: In(guidsToMove) },
+          { userGroupGuid: guid },
+        );
+      }
+
+      return {
+        message: '用户组成员已更新',
+        moved_user_count: guidsToMove.length,
+      };
+    });
+  }
+
+  private normalizeName(value: string) {
+    const name = value.trim();
+    if (!name) {
+      throw new BadRequestException('用户组名称不能为空');
+    }
+    return { name, normalizedName: name.toLowerCase() };
+  }
+
+  private normalizeNote(value?: string): string | null {
+    if (value === undefined) {
+      return null;
+    }
+    const note = value.trim();
+    return note || null;
+  }
+
+  private async assertNameAvailable(
+    normalizedName: string,
+    ignoredGuid?: string,
+  ): Promise<void> {
+    const existing = await this.userGroupRepository.findOne({
+      where: { normalizedName },
+    });
+    if (existing && existing.guid !== ignoredGuid) {
+      throw new ConflictException('用户组名称已存在');
+    }
+  }
+
+  private isUniqueConstraintError(error: unknown): boolean {
+    return (
+      error instanceof QueryFailedError &&
+      error.message.toUpperCase().includes('UNIQUE')
+    );
+  }
+
+  private rethrowUniqueName(error: unknown): never {
+    if (this.isUniqueConstraintError(error)) {
+      throw new ConflictException('用户组名称已存在');
+    }
+    throw error;
+  }
+
+  private toGroupResponse(group: UserGroup, userCount: number) {
+    return {
+      guid: group.guid,
+      name: group.name,
+      note: group.note || '',
+      user_count: userCount,
+      is_default: group.isDefault,
+      created_at: group.createdAt,
+      updated_at: group.updatedAt,
+    };
+  }
+}

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -29,7 +29,9 @@ export class AdminUserService {
     } = query;
     const skip = (current - 1) * pageSize;
 
-    const queryBuilder = this.userRepository.createQueryBuilder('user');
+    const queryBuilder = this.userRepository
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.userGroup', 'userGroup');
 
     if (status !== undefined) {
       queryBuilder.andWhere('user.status = :status', { status });
@@ -98,6 +100,8 @@ export class AdminUserService {
         strategy_name: u.strategyGuid
           ? strategyMap.get(u.strategyGuid) || ''
           : '',
+        user_group_guid: u.userGroupGuid || '',
+        user_group_name: u.userGroup?.name || '',
         avatar: u.avatar || '',
         created_at: u.createdAt,
         updated_at: u.updatedAt,

--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -8,6 +8,7 @@ import {
   Min,
   IsInt,
   MinLength,
+  IsUUID,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { UserStatus } from '../entities/user.entity';
@@ -22,6 +23,10 @@ export class CreateUserDto {
   @IsString()
   @IsOptional()
   group_name?: string;
+
+  @IsUUID('4')
+  @IsOptional()
+  user_group_guid?: string;
 
   @IsString()
   @IsOptional()
@@ -42,6 +47,10 @@ export class InviteUserDto {
   @IsString()
   @IsOptional()
   group_name?: string;
+
+  @IsUUID('4')
+  @IsOptional()
+  user_group_guid?: string;
 
   @IsString()
   @IsOptional()
@@ -106,6 +115,10 @@ export class UserQueryDto {
   @IsInt()
   @Type(() => Number)
   pageSize: number;
+
+  @IsString()
+  @IsOptional()
+  accessible?: string;
 
   @IsString()
   @IsOptional()

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { UserToken } from './user-token.entity';
 import { Strategy } from '../../strategy/entities/strategy.entity';
+import { UserGroup } from '../../user-group/entities/user-group.entity';
 
 /**
  * 用户状态枚举
@@ -148,6 +149,17 @@ export class User {
   @ManyToOne('Strategy', () => Strategy, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'strategyGuid' })
   strategy: any;
+
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  userGroupGuid: string | null;
+
+  @ManyToOne(() => UserGroup, (userGroup) => userGroup.users, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'userGroupGuid' })
+  userGroup: UserGroup | null;
 
   @OneToMany(() => UserToken, (token) => token.user, { cascade: true })
   tokens: UserToken[];

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -13,6 +13,7 @@ import { DeviceGroup } from '../device-group/entities/device-group.entity';
 import { DeviceGroupUserPermission } from '../device-group/entities/device-group-user-permission.entity';
 import { UserUserPermission } from '../device-group/entities/user-user-permission.entity';
 import { Strategy } from '../strategy/entities/strategy.entity';
+import { UserGroupModule } from '../user-group/user-group.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { Strategy } from '../strategy/entities/strategy.entity';
       Strategy,
     ]),
     AuthModule,
+    UserGroupModule,
   ],
   controllers: [UserController, AvatarController, AdminUserController],
   providers: [UserService, AdminUserService],

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -24,6 +24,7 @@ import {
   BatchSecurityDto,
   ChangePasswordDto,
 } from './dto/user.dto';
+import { UserGroupService } from '../user-group/user-group.service';
 
 const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
 const AVATAR_SIZE = 256;
@@ -41,6 +42,7 @@ export class UserService {
     private deviceGroupUserPermissionRepository: Repository<DeviceGroupUserPermission>,
     @InjectRepository(UserUserPermission)
     private userUserPermissionRepository: Repository<UserUserPermission>,
+    private readonly userGroupService: UserGroupService,
   ) {}
 
   async getAccessibleUsers(
@@ -60,6 +62,7 @@ export class UserService {
     if (isAdmin) {
       const queryBuilder = this.userRepository
         .createQueryBuilder('user')
+        .leftJoinAndSelect('user.userGroup', 'userGroup')
         .where('user.status = :status', {
           status: parseInt(status || '1') || UserStatus.ACTIVE,
         });
@@ -88,26 +91,14 @@ export class UserService {
         .getManyAndCount();
 
       return {
-        data: users.map((u) => {
-          const item: Record<string, unknown> = {
-            guid: u.guid,
-            name: u.username,
-            email: u.email || '',
-            note: u.note || '',
-            status: u.status,
-            is_admin: u.isAdmin,
-          };
-          if (u.avatar) {
-            item.avatar = u.avatar;
-          }
-          return item;
-        }),
+        data: users.map((user) => this.buildUserResponse(user)),
         total,
       };
     }
 
     const queryBuilder = this.userRepository
       .createQueryBuilder('user')
+      .leftJoinAndSelect('user.userGroup', 'userGroup')
       .where('user.status = :status', {
         status: parseInt(status || '1') || UserStatus.ACTIVE,
       })
@@ -148,26 +139,16 @@ export class UserService {
       .getManyAndCount();
 
     return {
-      data: users.map((u) => {
-        const item: Record<string, unknown> = {
-          guid: u.guid,
-          name: u.username,
-          email: u.email || '',
-          note: u.note || '',
-          status: u.status,
-          is_admin: u.isAdmin,
-        };
-        if (u.avatar) {
-          item.avatar = u.avatar;
-        }
-        return item;
-      }),
+      data: users.map((user) => this.buildUserResponse(user)),
       total,
     };
   }
 
   async createUser(dto: CreateUserDto) {
     const { name, password, email, note } = dto;
+    const userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
+      dto.user_group_guid,
+    );
 
     const existingUser = await this.userRepository.findOne({
       where: { username: name },
@@ -193,6 +174,7 @@ export class UserService {
     user.note = note || '';
     user.status = UserStatus.ACTIVE;
     user.isAdmin = false;
+    user.userGroupGuid = userGroupGuid;
 
     await this.userRepository.save(user);
 
@@ -201,6 +183,9 @@ export class UserService {
 
   async inviteUser(dto: InviteUserDto) {
     const { email, name, note } = dto;
+    const userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
+      dto.user_group_guid,
+    );
 
     const existingUser = await this.userRepository.findOne({
       where: { email },
@@ -217,6 +202,7 @@ export class UserService {
     user.note = note || '';
     user.status = UserStatus.UNVERIFIED;
     user.isAdmin = false;
+    user.userGroupGuid = userGroupGuid;
 
     await this.userRepository.save(user);
 
@@ -226,6 +212,7 @@ export class UserService {
   async getUser(guid: string) {
     const user = await this.userRepository.findOne({
       where: { guid },
+      relations: ['userGroup'],
     });
     if (!user) {
       throw new NotFoundException('用户不存在');
@@ -240,6 +227,8 @@ export class UserService {
       is_admin: user.isAdmin,
       third_auth_type: user.thirdAuthType || '',
       strategy_guid: user.strategyGuid || '',
+      user_group_guid: user.userGroupGuid || '',
+      user_group_name: user.userGroup?.name || '',
       created_at: user.createdAt,
       updated_at: user.updatedAt,
       ...(user.avatar ? { avatar: user.avatar } : {}),
@@ -510,6 +499,8 @@ export class UserService {
       note: user.note || '',
       status: user.status,
       is_admin: user.isAdmin,
+      user_group_guid: user.userGroupGuid || '',
+      user_group_name: user.userGroup?.name || '',
     };
     if (user.avatar) {
       response.avatar = user.avatar;


### PR DESCRIPTION
## Background

The web console already contains user-group management surfaces, but the corresponding backend contract is incomplete. The missing routes cause those workflows to return 404 responses, and there is currently no persistent membership model connecting users to groups.

Address-book rules also expose a group target, but that target is not backed by a validated user-group relation or included in effective permission resolution. As a result, group grants cannot be managed or enforced safely.

This change implements the backend contract end to end while keeping user groups separate from the existing device-group domain.

## Summary

- Add persistent user groups with a protected default group.
- Assign every user to exactly one user group.
- Add administrator-only group CRUD, member listing, and atomic bulk moves.
- Expose group assignment in user create, invite, list, and detail contracts.
- Validate and enforce group-based address-book grants.
- Preserve existing RustDesk client and device-group compatibility behavior.
- Document the complete API and upgrade contract.

## API Contract

| Method | Endpoint | Behavior |
| --- | --- | --- |
| `GET` | `/api/user-groups` | Return a stable paginated list with search, member counts, and default-group metadata. |
| `POST` | `/api/user-groups` | Create a group with a trimmed, case-insensitively unique name. |
| `PUT` | `/api/user-groups/:guid` | Rename a group or update its note. |
| `DELETE` | `/api/user-groups/:guid` | Delete a non-default group, move its users to the default group, and remove its grants atomically. |
| `GET` | `/api/user-groups/:guid/users` | Return paginated members with search support. |
| `POST` | `/api/user-groups/:guid/users` | Move the supplied `user_guids` into the target group as one validated operation. |

All user-group routes require an authenticated administrator.

Administrator-controlled user create and invite requests accept an optional `user_group_guid`. When it is omitted, the default group is assigned. User list and detail responses expose both `user_group_guid` and `user_group_name`.

## Data Model and Invariants

- Store a normalized name separately so uniqueness is enforced case-insensitively while preserving display casing.
- Maintain exactly one protected default group.
- Require every valid user assignment to resolve to an existing group.
- Allow the default group to be renamed or annotated, but never deleted.
- Treat posting users to the default group as the canonical way to remove them from another group.
- Validate every user in a bulk move before writing so partial membership updates cannot occur.

Public registration, default-administrator creation, LDAP JIT provisioning, and OIDC JIT provisioning resolve the default group internally. They do not accept an externally selected group.

## Address-Book Access

The existing `POST /api/ab/rule` endpoint now accepts a validated user-group GUID in the `group` field. A rule may target either a user or a group, but never both.

Effective permission is the strongest applicable value from:

1. address-book ownership, which always grants full control;
2. a direct user rule;
3. a rule for the user's current group; and
4. an everyone rule.

Membership is evaluated when access is requested. Moving a user therefore changes access immediately without copying rules to individual users.

Deleting a group removes its address-book rules in the same transaction that moves its members to the default group. Rule listing, update, and deletion continue to use the existing paginated API contract.

## Upgrade Behavior

- Create a default group during startup when none exists.
- Backfill users with missing or invalid group assignments.
- Normalize legacy empty-string address-book targets to SQL `NULL`.
- Remove rules that reference unknown groups so they cannot be interpreted as everyone rules after the upgrade.
- Keep startup idempotent under the existing TypeORM `synchronize: true` schema flow.

As with existing releases, operators should back up the SQLite database before upgrading.

## Compatibility

- Legacy `group_name` remains accepted by create/invite DTOs as a deprecated no-op. It is not mapped to a user group because the same field is already used by device-group-derived filters.
- The existing device-group model and filter behavior are unchanged.
- RustDesk compatibility queries using `accessible=` continue to be accepted by the user and peer endpoints.
- Existing direct-user and everyone address-book rules retain their behavior.
- Existing `GET` and `POST /api/ab/shared/profiles` RustDesk client endpoints continue to resolve accessible books through the same effective-permission calculation.

## Scope Boundaries

This change does not add nested groups, RBAC roles, device ownership, group-to-device assignment, strategy inheritance, or automatic conversion from legacy `group_name` values.

## Validation

- `npm test -- --runInBand` - 10 tests passed.
- `npx tsc --noEmit` - passed.
- `npm run lint` - passed.
- `npm run build` - passed.
- Exercised group CRUD, membership changes, and address-book permission changes against a running local backend.
- Verified the RustDesk client's group query against the local server, including the `accessible=` compatibility form.
- `docker build .` was not run locally because the Docker daemon was unavailable; the repository CI Docker job remains the publication gate.

## Frontend Integration

The matching management workflows are implemented in [databk/rustdesk-console-web#188](https://github.com/databk/rustdesk-console-web/pull/188).
