### PR TITLE
feat(ab): support adding IP devices to address book

### DIFF
--- a/src/common/utils/ip.util.ts
+++ b/src/common/utils/ip.util.ts
@@ -1,0 +1,26 @@
+/**
+ * 检测给定的ID是否为IP地址格式
+ * 支持以下格式：
+ * - IPv4: "192.168.1.94"
+ * - IPv4 + 端口: "192.168.1.94:21118"
+ * - IPv6: "[::1]" 或 "[::1]:21118"
+ *
+ * @param id 设备ID
+ * @returns 如果是IP格式返回true，否则返回false
+ */
+export function isIpDevice(id: string): boolean {
+  if (!id || typeof id !== 'string') {
+    return false;
+  }
+
+  // IPv6 格式: [::1] 或 [::1]:port
+  if (id.startsWith('[')) {
+    return true;
+  }
+
+  // IPv4 格式: 包含点号，如 192.168.1.94 或 192.168.1.94:21118
+  // 通过正则匹配 IPv4 或 IPv4:port
+  const ipv4WithOptionalPort =
+    /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?$/;
+  return ipv4WithOptionalPort.test(id);
+}

--- a/src/common/utils/ip.util.ts
+++ b/src/common/utils/ip.util.ts
@@ -20,7 +20,6 @@ export function isIpDevice(id: string): boolean {
 
   // IPv4 格式: 包含点号，如 192.168.1.94 或 192.168.1.94:21118
   // 通过正则匹配 IPv4 或 IPv4:port
-  const ipv4WithOptionalPort =
-    /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?$/;
+  const ipv4WithOptionalPort = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d+)?$/;
   return ipv4WithOptionalPort.test(id);
 }

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -10,7 +10,6 @@ import {
 } from '../entities';
 import { Sysinfo, Peer } from '../../../common/entities';
 import { mapOsToPlatform } from '../../../common/utils/platform.util';
-import { isIpDevice } from '../../../common/utils/ip.util';
 
 @Injectable()
 /**

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -91,16 +91,14 @@ export class AddressBookLegacyService {
 
     const sysinfoMap = new Map(sysinfos.map((s) => [s.uuid, s]));
 
-    // 从 peers 表获取设备 ID 映射（deviceId -> RustDesk ID）
-    // 对于通过新 API 添加的设备，deviceId 是 peers.uuid，需要解析为 peers.id
-    // 对于通过旧版 API 添加的设备，deviceId 直接是原始 ID，peers 表中可能无对应记录
+    // 从 peers 表获取设备信息（deviceId 引用 peers.uuid，需要解析为 peers.id）
     const peerRecords =
       deviceIds.length > 0
         ? await this.peerRepository.find({
             where: { uuid: In(deviceIds) },
           })
         : [];
-    const peerMap = new Map(peerRecords.map((p) => [p.uuid, p.id]));
+    const peerMap = new Map(peerRecords.map((p) => [p.uuid, p]));
 
     // 如果地址簿为空，返回 "null"
     if (tags.length === 0 && peers.length === 0) {
@@ -116,10 +114,9 @@ export class AddressBookLegacyService {
     // 构建设备列表
     const peersData = peers.map((p) => {
       const sysinfo = sysinfoMap.get(p.deviceId);
-      // 优先从 peers 表解析 ID，若无记录则使用 deviceId 本身（兼容旧版 API 数据）
-      const resolvedId = peerMap.get(p.deviceId) || p.deviceId;
+      const peerRecord = peerMap.get(p.deviceId);
       return {
-        id: resolvedId,
+        id: peerRecord?.id || '',
         hash: p.hash || '',
         username: sysinfo?.username || '',
         hostname: sysinfo?.hostname || '',

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -10,6 +10,7 @@ import {
 } from '../entities';
 import { Sysinfo, Peer } from '../../../common/entities';
 import { mapOsToPlatform } from '../../../common/utils/platform.util';
+import { isIpDevice } from '../../../common/utils/ip.util';
 
 @Injectable()
 /**
@@ -246,11 +247,15 @@ export class AddressBookLegacyService {
     // 创建新设备
     if (parsedData.peers && parsedData.peers.length > 0) {
       for (const peerData of parsedData.peers) {
+        // 通过 findOrCreatePeer 查找或创建 peer 记录，获取 uuid 作为 deviceId
+        // 与新版 API 保持一致：deviceId 始终引用 peers.uuid
+        const peerRecord = await this.findOrCreatePeer(peerData.id);
+
         const peerGuid = uuidv4();
         const peer = this.addressBookPeerRepository.create({
           guid: peerGuid,
           addressBookGuid,
-          deviceId: peerData.id,
+          deviceId: peerRecord.uuid,
           hash: peerData.hash || '',
           alias: peerData.alias || '',
         });
@@ -273,5 +278,34 @@ export class AddressBookLegacyService {
     }
 
     return 'null';
+  }
+
+  /**
+   * 查找或创建设备记录
+   * 在 peers 表中查找指定 id 的设备，如果找不到则自动创建
+   *
+   * @param id 设备ID（RustDesk 数字 ID、IP 地址或已有记录的任何格式）
+   * @returns Peer 记录
+   */
+  private async findOrCreatePeer(id: string): Promise<Peer> {
+    const peerRecord = await this.peerRepository.findOne({
+      where: { id },
+    });
+
+    if (peerRecord) {
+      return peerRecord;
+    }
+
+    // 对于不在 peers 表中的设备，自动创建 peer 记录
+    // 这包括 IP 格式设备（如 192.168.1.94）以及尚未发送心跳的数字 ID 设备
+    const newPeer = this.peerRepository.create({
+      uuid: uuidv4(),
+      id,
+      ver: 0,
+      modifiedAt: 0,
+      lastHeartbeat: null,
+    });
+    await this.peerRepository.save(newPeer);
+    return newPeer;
   }
 }

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -8,7 +8,7 @@ import {
   AddressBookTag,
   AddressBookPeerTag,
 } from '../entities';
-import { Sysinfo } from '../../../common/entities';
+import { Sysinfo, Peer } from '../../../common/entities';
 import { mapOsToPlatform } from '../../../common/utils/platform.util';
 
 @Injectable()
@@ -34,6 +34,8 @@ export class AddressBookLegacyService {
     private addressBookPeerTagRepository: Repository<AddressBookPeerTag>,
     @InjectRepository(Sysinfo)
     private sysinfoRepository: Repository<Sysinfo>,
+    @InjectRepository(Peer)
+    private peerRepository: Repository<Peer>,
   ) {}
 
   /**
@@ -88,6 +90,17 @@ export class AddressBookLegacyService {
 
     const sysinfoMap = new Map(sysinfos.map((s) => [s.uuid, s]));
 
+    // 从 peers 表获取设备 ID 映射（deviceId -> RustDesk ID）
+    // 对于通过新 API 添加的设备，deviceId 是 peers.uuid，需要解析为 peers.id
+    // 对于通过旧版 API 添加的设备，deviceId 直接是原始 ID，peers 表中可能无对应记录
+    const peerRecords =
+      deviceIds.length > 0
+        ? await this.peerRepository.find({
+            where: { uuid: In(deviceIds) },
+          })
+        : [];
+    const peerMap = new Map(peerRecords.map((p) => [p.uuid, p.id]));
+
     // 如果地址簿为空，返回 "null"
     if (tags.length === 0 && peers.length === 0) {
       return 'null';
@@ -102,8 +115,10 @@ export class AddressBookLegacyService {
     // 构建设备列表
     const peersData = peers.map((p) => {
       const sysinfo = sysinfoMap.get(p.deviceId);
+      // 优先从 peers 表解析 ID，若无记录则使用 deviceId 本身（兼容旧版 API 数据）
+      const resolvedId = peerMap.get(p.deviceId) || p.deviceId;
       return {
-        id: p.deviceId,
+        id: resolvedId,
         hash: p.hash || '',
         username: sysinfo?.username || '',
         hostname: sysinfo?.hostname || '',

--- a/src/modules/address-book/services/address-book-peer.service.ts
+++ b/src/modules/address-book/services/address-book-peer.service.ts
@@ -15,6 +15,7 @@ import {
 import { AddPeerDto, UpdatePeerDto, PeersQueryDto, TagMatchMode } from '../dto';
 import { Sysinfo, Peer } from '../../../common/entities';
 import { mapOsToPlatform } from '../../../common/utils/platform.util';
+import { isIpDevice } from '../../../common/utils/ip.util';
 
 @Injectable()
 /**
@@ -220,13 +221,8 @@ export class AddressBookPeerService {
     }
 
     // 通过客户端发送的 id 查找 peers 表获取 uuid (deviceId)
-    const peerRecord = await this.peerRepository.findOne({
-      where: { id: dto.id },
-    });
-
-    if (!peerRecord) {
-      throw new NotFoundException('设备不存在');
-    }
+    // 对于 IP 格式的设备，如果不在 peers 表中则自动创建记录
+    const peerRecord = await this.findOrCreatePeer(dto.id);
 
     const deviceId = peerRecord.uuid;
 
@@ -300,13 +296,8 @@ export class AddressBookPeerService {
     }
 
     // 通过客户端发送的 id 查找 peers 表获取 uuid (deviceId)
-    const peerRecord = await this.peerRepository.findOne({
-      where: { id: dto.id },
-    });
-
-    if (!peerRecord) {
-      throw new NotFoundException('设备不存在');
-    }
+    // 对于 IP 格式的设备，如果不在 peers 表中则自动创建记录
+    const peerRecord = await this.findOrCreatePeer(dto.id);
 
     const deviceId = peerRecord.uuid;
 
@@ -399,5 +390,39 @@ export class AddressBookPeerService {
     }
 
     return {};
+  }
+
+  /**
+   * 查找或创建设备记录
+   * 在 peers 表中查找指定 id 的设备，如果找不到且 id 为 IP 格式则自动创建
+   *
+   * @param id 设备ID（RustDesk 数字 ID 或 IP 地址）
+   * @returns Peer 记录
+   * @throws NotFoundException 当设备不存在且 id 不为 IP 格式时抛出
+   */
+  private async findOrCreatePeer(id: string): Promise<Peer> {
+    const peerRecord = await this.peerRepository.findOne({
+      where: { id },
+    });
+
+    if (peerRecord) {
+      return peerRecord;
+    }
+
+    // 对于 IP 格式的设备（如 192.168.1.94 或 192.168.1.94:21118），
+    // 自动创建 peer 记录，因为这些设备通过直连 IP 访问，不会通过心跳注册
+    if (isIpDevice(id)) {
+      const newPeer = this.peerRepository.create({
+        uuid: uuidv4(),
+        id,
+        ver: 0,
+        modifiedAt: 0,
+        lastHeartbeat: null,
+      });
+      await this.peerRepository.save(newPeer);
+      return newPeer;
+    }
+
+    throw new NotFoundException('设备不存在');
   }
 }


### PR DESCRIPTION
## Summary

- Fix "设备不存在" error when adding IP-based devices (e.g. `192.168.1.94`, `192.168.1.94:21118`) to the address book
- Auto-create a peer record in the `peers` table for IP devices that don't exist (since they connect directly and never register via heartbeat)
- Fix legacy address book API to properly resolve `deviceId` for consistent ID display

## Changes

- **New**: `src/common/utils/ip.util.ts` — `isIpDevice()` utility to detect IP address formats (IPv4, IPv4:port, IPv6)
- **Modified**: `address-book-peer.service.ts` — Add `findOrCreatePeer()` method; use it in `addPeer()` and `updatePeer()` to auto-create peer records for IP devices
- **Modified**: `address-book-legacy.service.ts` — Fix `getLegacyAddressBook()` to resolve `deviceId` through `peers` table (with fallback for legacy API data)

## Test plan

- [ ] Add an IP device (e.g. `192.168.1.94`) to address book via `POST /api/ab/peer/add/:guid` — should succeed and auto-create peer record
- [ ] Add an IP device with port (e.g. `192.168.1.94:21118`) — should succeed
- [ ] Add a non-existent numeric ID device — should still return 404 "设备不存在"
- [ ] Add a registered device (with existing peer record) — should work as before
- [ ] Update/delete IP devices — should work normally
- [ ] Verify legacy API (`GET /api/ab`) correctly displays both IP and numeric devices

Closes #196