### PR TITLE
feat(user): adapt display_name field in user APIs

### DIFF
--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -38,7 +38,10 @@ export class AdminUserService {
     }
 
     if (name) {
-      queryBuilder.andWhere('user.username LIKE :name', { name: `%${name}%` });
+      queryBuilder.andWhere(
+        '(user.username LIKE :name OR user.displayName LIKE :name)',
+        { name: `%${name}%` },
+      );
     }
 
     if (email) {
@@ -91,6 +94,7 @@ export class AdminUserService {
       data: users.map((u) => ({
         guid: u.guid,
         name: u.username,
+        display_name: u.displayName || '',
         email: u.email || '',
         note: u.note || '',
         status: u.status,

--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -18,6 +18,10 @@ export class CreateUserDto {
   name: string;
 
   @IsString()
+  @IsOptional()
+  display_name?: string;
+
+  @IsString()
   password: string;
 
   @IsString()
@@ -46,6 +50,10 @@ export class InviteUserDto {
 
   @IsString()
   @IsOptional()
+  display_name?: string;
+
+  @IsString()
+  @IsOptional()
   group_name?: string;
 
   @IsUUID('4')
@@ -61,6 +69,10 @@ export class UpdateUserDto {
   @IsString()
   @IsOptional()
   name?: string;
+
+  @IsString()
+  @IsOptional()
+  display_name?: string;
 
   @IsString()
   @IsOptional()
@@ -90,10 +102,6 @@ export class UpdateUserSecurityDto {
 }
 
 export class UpdateCurrentUserDto {
-  @IsString()
-  @IsOptional()
-  name?: string;
-
   @IsString()
   @IsOptional()
   email?: string;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -68,9 +68,10 @@ export class UserService {
         });
 
       if (name) {
-        queryBuilder.andWhere('user.username LIKE :name', {
-          name: `%${name}%`,
-        });
+        queryBuilder.andWhere(
+          '(user.username LIKE :name OR user.displayName LIKE :name)',
+          { name: `%${name}%` },
+        );
       }
 
       if (group_name) {
@@ -118,7 +119,10 @@ export class UserService {
       );
 
     if (name) {
-      queryBuilder.andWhere('user.username LIKE :name', { name: `%${name}%` });
+      queryBuilder.andWhere(
+        '(user.username LIKE :name OR user.displayName LIKE :name)',
+        { name: `%${name}%` },
+      );
     }
 
     if (group_name) {
@@ -145,7 +149,7 @@ export class UserService {
   }
 
   async createUser(dto: CreateUserDto) {
-    const { name, password, email, note } = dto;
+    const { name, password, email, note, display_name } = dto;
     const userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
       dto.user_group_guid,
     );
@@ -169,6 +173,7 @@ export class UserService {
     const user = new User();
     user.guid = uuidv4();
     user.username = name;
+    user.displayName = display_name || null;
     user.email = email || null;
     user.password = await bcrypt.hash(password, 10);
     user.note = note || '';
@@ -182,7 +187,7 @@ export class UserService {
   }
 
   async inviteUser(dto: InviteUserDto) {
-    const { email, name, note } = dto;
+    const { email, name, note, display_name } = dto;
     const userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
       dto.user_group_guid,
     );
@@ -197,6 +202,7 @@ export class UserService {
     const user = new User();
     user.guid = uuidv4();
     user.username = name;
+    user.displayName = display_name || null;
     user.email = email;
     user.password = '';
     user.note = note || '';
@@ -221,6 +227,7 @@ export class UserService {
     return {
       guid: user.guid,
       name: user.username,
+      display_name: user.displayName || '',
       email: user.email || '',
       note: user.note || '',
       status: user.status,
@@ -251,6 +258,10 @@ export class UserService {
         throw new BadRequestException('用户名已存在');
       }
       user.username = dto.name;
+    }
+
+    if (dto.display_name !== undefined) {
+      user.displayName = dto.display_name || null;
     }
 
     if (dto.email !== undefined) {
@@ -288,16 +299,6 @@ export class UserService {
     });
     if (!user) {
       throw new NotFoundException('用户不存在');
-    }
-
-    if (dto.name !== undefined) {
-      const existingUser = await this.userRepository.findOne({
-        where: { username: dto.name },
-      });
-      if (existingUser && existingUser.guid !== userId) {
-        throw new BadRequestException('用户名已存在');
-      }
-      user.username = dto.name;
     }
 
     if (dto.email !== undefined) {
@@ -495,6 +496,7 @@ export class UserService {
     const response: Record<string, unknown> = {
       guid: user.guid,
       name: user.username,
+      display_name: user.displayName || '',
       email: user.email || '',
       note: user.note || '',
       status: user.status,


### PR DESCRIPTION
## Summary
- Add `display_name` field support to user creation, invitation, and admin update APIs
- Remove `name` (username) field from user self-update endpoint — username changes are now admin-only
- Include `display_name` in all user response payloads (admin user list, user detail, accessible users)
- Update user search to match against both `username` and `displayName` fields

## Changes

### DTOs (`user.dto.ts`)
- `CreateUserDto`: added optional `display_name` field
- `InviteUserDto`: added optional `display_name` field
- `UpdateUserDto` (admin): added optional `display_name` field
- `UpdateCurrentUserDto`: removed `name` field (username is now admin-only)

### Admin User Service (`admin-user.service.ts`)
- Response now includes `display_name`
- Name search filter now matches both `username` and `displayName`

### User Service (`user.service.ts`)
- `createUser`: sets `displayName` from DTO
- `inviteUser`: sets `displayName` from DTO
- `updateUser` (admin): handles `display_name` update
- `updateCurrentUser`: removed username update logic (admin-only restriction)
- `getUser`: includes `display_name` in response
- `buildUserResponse`: includes `display_name` in response
- `getAccessibleUsers`: name search now matches both `username` and `displayName`

## Test plan
- [ ] Verify admin can create user with `display_name`
- [ ] Verify admin can invite user with `display_name`
- [ ] Verify admin can update user's `display_name` and `name`
- [ ] Verify regular user cannot update their `name` via `PATCH /users/me`
- [ ] Verify `display_name` appears in all user response payloads
- [ ] Verify user search matches both `username` and `displayName`