### PR TITLE
fix(auth): prevent TFA secret exposure in login flow

### DIFF
--- a/src/common/interfaces/login-response.interface.ts
+++ b/src/common/interfaces/login-response.interface.ts
@@ -12,7 +12,7 @@ export interface LoginResponse {
   type: string;
   /** 双因素认证类型，仅在需要TFA时返回 */
   tfa_type?: string;
-  /** TFA密钥，仅在需要TFA时返回 */
+  /** 登录会话标识符（UUID），由服务端在需要二次验证时返回，客户端在后续请求中回传，用于跟踪一次登录 */
   secret?: string;
   /** 用户信息 */
   user?: {

--- a/src/modules/auth/entities/email-verification-session.entity.ts
+++ b/src/modules/auth/entities/email-verification-session.entity.ts
@@ -8,8 +8,12 @@ import {
 } from 'typeorm';
 
 /**
- * 邮箱验证会话实体
- * 管理邮箱验证的临时会话
+ * 登录验证会话实体
+ * 管理登录二次验证（邮箱验证码 / TFA）的临时会话
+ *
+ * 安全说明：
+ * secret 字段是服务端生成的 UUID 会话标识符，仅用于跟踪一次登录，
+ * 绝不是 TFA 密钥本身。TFA 密钥始终保留在服务端，不会返回给客户端。
  */
 @Entity('email_verification_sessions')
 export class EmailVerificationSession {
@@ -22,7 +26,8 @@ export class EmailVerificationSession {
 
   /**
    * 会话密钥
-   * 用于关联验证请求的唯一密钥
+   * 服务端生成的 UUID，用于关联两次登录请求（发起验证 / 提交验证码）
+   * 注意：此字段不是 TFA 密钥，仅为一次性会话标识符
    */
   @Column({ unique: true })
   @Index()
@@ -37,18 +42,26 @@ export class EmailVerificationSession {
   userGuid: string;
 
   /**
-   * 邮箱地址
-   * 待验证的邮箱地址
+   * 验证方式
+   * 'email' - 邮箱验证码登录
+   * 'tfa' - 双因素认证登录
    */
-  @Column()
-  email: string;
+  @Column({ default: 'email' })
+  method: 'email' | 'tfa';
+
+  /**
+   * 邮箱地址
+   * 待验证的邮箱地址（仅邮箱验证方式使用，TFA 方式可空）
+   */
+  @Column({ nullable: true })
+  email?: string;
 
   /**
    * 验证码
-   * 发送到邮箱的验证码
+   * 发送到邮箱的验证码（仅邮箱验证方式使用，TFA 方式可空）
    */
-  @Column()
-  code: string;
+  @Column({ nullable: true })
+  code?: string;
 
   /**
    * 过期时间

--- a/src/modules/auth/services/auth-email.service.ts
+++ b/src/modules/auth/services/auth-email.service.ts
@@ -79,6 +79,7 @@ export class AuthEmailService {
       guid: uuidv4(),
       secret,
       userGuid: user.guid,
+      method: 'email',
       email: user.email,
       code,
       expiresAt,
@@ -141,10 +142,11 @@ export class AuthEmailService {
       throw new BadRequestException({ error: '验证参数不完整' });
     }
 
-    // 查找验证会话
+    // 查找验证会话（仅匹配邮箱验证方式，避免与 TFA 会话混淆）
     const session = await this.verificationSessionRepository.findOne({
       where: {
         secret,
+        method: 'email',
         used: false,
         expiresAt: MoreThan(new Date()),
       },

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -6,19 +6,25 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, MoreThan } from 'typeorm';
 import { authenticator } from 'otplib';
+import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../../user/entities/user.entity';
+import { EmailVerificationSession } from '../entities/email-verification-session.entity';
 import { LoginDto, DeviceInfoDto } from '../dto/auth.dto';
 import { LoginResponse } from '../../../common/interfaces';
 
 @Injectable()
 export class AuthTfaService {
   private readonly logger = new Logger(AuthTfaService.name);
+  /** TFA 登录会话有效期（分钟） */
+  private readonly TFA_LOGIN_SESSION_EXPIRY_MINUTES = 5;
 
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(EmailVerificationSession)
+    private verificationSessionRepository: Repository<EmailVerificationSession>,
   ) {}
 
   verifyTfaCode(secret: string, code: string): boolean {
@@ -31,20 +37,6 @@ export class AuthTfaService {
       this.logger.error('TFA 验证失败', error);
       return false;
     }
-  }
-
-  /**
-   * 验证字符串是否为有效的 TFA 密钥格式（Base32）
-   * 用于区分 TFA secret 和邮箱验证的 UUID secret，
-   * 防止用户通过伪造 tfaCode 控制安全敏感路由
-   *
-   * @param secret 待验证的字符串
-   * @returns 是否为有效的 Base32 格式 TFA 密钥
-   */
-  isTfaSecret(secret: string): boolean {
-    // TFA 密钥为 Base32 编码（仅包含 A-Z, 2-7），长度通常为 16 或 32
-    // 邮箱验证的 secret 为 UUID 格式（包含小写字母和连字符）
-    return /^[A-Z2-7]+=*$/i.test(secret) && secret.length >= 16;
   }
 
   async setupTfa(
@@ -177,6 +169,55 @@ export class AuthTfaService {
     return { message: '2FA已禁用' };
   }
 
+  /**
+   * 发起 TFA 登录验证
+   * 密码校验通过后，当用户启用了 TFA 时调用。
+   *
+   * 安全说明：
+   * 创建一个一次性的登录会话，返回的 secret 是服务端生成的 UUID 会话标识符，
+   * 仅用于在第二步中回传定位本次登录。TFA 密钥（tfaSecret）始终保留在服务端，
+   * 绝不返回给客户端，避免被抓包窃取导致 2FA 失效。
+   *
+   * @param user 已通过密码校验的用户
+   * @param buildUserPayload 构建用户信息载荷的回调函数
+   * @returns 登录响应，包含会话标识符 secret（UUID），type 为 email_check 兼容客户端
+   */
+  async initiateTfaLogin(
+    user: User,
+    buildUserPayload: (user: User) => Record<string, unknown>,
+  ): Promise<LoginResponse> {
+    // 删除该用户之前未使用的验证会话，避免会话堆积
+    await this.verificationSessionRepository.delete({
+      userGuid: user.guid,
+      used: false,
+    });
+
+    const secret = uuidv4();
+    const expiresAt = new Date();
+    expiresAt.setMinutes(
+      expiresAt.getMinutes() + this.TFA_LOGIN_SESSION_EXPIRY_MINUTES,
+    );
+
+    const session = this.verificationSessionRepository.create({
+      guid: uuidv4(),
+      secret,
+      userGuid: user.guid,
+      method: 'tfa',
+      expiresAt,
+      used: false,
+    });
+    await this.verificationSessionRepository.save(session);
+
+    this.logger.log(`用户 ${user.username} 登录需要 TFA 验证，已创建会话`);
+
+    return {
+      type: 'email_check',
+      tfa_type: 'tfa_check',
+      secret,
+      user: buildUserPayload(user) as LoginResponse['user'],
+    };
+  }
+
   async handleTfaLogin(
     loginDto: LoginDto,
     generateToken: (
@@ -198,17 +239,26 @@ export class AuthTfaService {
       throw new BadRequestException({ error: '双因素认证参数不完整' });
     }
 
-    const isValidTfa = this.verifyTfaCode(secret, tfaCode);
-    if (!isValidTfa) {
-      throw new UnauthorizedException({ error: '双因素认证验证码错误' });
+    // 通过会话标识符定位本次登录，secret 仅为 UUID，不参与 TFA 验证
+    const session = await this.verificationSessionRepository.findOne({
+      where: {
+        secret,
+        method: 'tfa',
+        used: false,
+        expiresAt: MoreThan(new Date()),
+      },
+    });
+
+    if (!session) {
+      throw new UnauthorizedException({
+        error: '登录会话已过期或无效，请重新登录',
+      });
     }
 
+    // 按会话绑定的用户查找，确保登录主体由服务端会话决定
     const user = await this.userRepository
       .createQueryBuilder('user')
-      .where('user.username = :username OR user.email = :email', {
-        username,
-        email: username,
-      })
+      .where('user.guid = :guid', { guid: session.userGuid })
       .addSelect('user.tfaSecret')
       .addSelect('user.info')
       .addSelect('user.thirdAuthType')
@@ -219,13 +269,28 @@ export class AuthTfaService {
       throw new UnauthorizedException({ error: '用户不存在' });
     }
 
-    if (user.tfaSecret !== secret) {
+    // 若客户端回传了用户名，校验与会话用户一致，防止会话替换攻击
+    if (username && user.username !== username && user.email !== username) {
+      throw new UnauthorizedException({ error: '用户信息不匹配' });
+    }
+
+    if (!user.tfaSecret) {
       throw new UnauthorizedException({ error: '双因素认证参数无效' });
+    }
+
+    // 对照服务端存储的 tfaSecret 验证 TFA 验证码
+    const isValidTfa = this.verifyTfaCode(user.tfaSecret, tfaCode);
+    if (!isValidTfa) {
+      throw new UnauthorizedException({ error: '双因素认证验证码错误' });
     }
 
     if (user.status === UserStatus.DISABLED) {
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
+
+    // 标记会话为已使用，防止重放
+    session.used = true;
+    await this.verificationSessionRepository.save(session);
 
     if (createOrUpdateDevice && (id || uuid)) {
       await createOrUpdateDevice(user.guid, id, uuid, deviceInfo);
@@ -233,7 +298,7 @@ export class AuthTfaService {
 
     const token = await generateToken(user, id, uuid);
 
-    this.logger.log(`用户 ${username} TFA认证成功，已登录`);
+    this.logger.log(`用户 ${user.username} TFA认证成功，已登录`);
 
     return {
       access_token: token,

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -124,27 +124,23 @@ export class AuthService {
 
     // 处理邮箱验证码登录（第二步）
     // 兼容 RustDesk 客户端：客户端使用 type: "email_code" + tfaCode 提交 2FA 验证码
-    // 当同时提交 tfaCode 和 secret 时，走 2FA 验证路径
-    // 必须同时检查 tfaCode 和 secret，避免仅凭用户输入的 tfaCode 控制安全敏感路由
+    // secret 为服务端下发的会话标识符（UUID），TFA 与邮箱验证均使用此机制跟踪一次登录
+    // 通过 tfaCode 字段区分 TFA 登录与邮箱验证码登录（邮箱验证码使用 verificationCode 字段）
     if (type === 'email_code') {
       if (tfaCode && loginDto.secret) {
-        // 验证 secret 是否为有效的 TFA 密钥格式（Base32），防止通过伪造 secret 绕过
-        const isTfaSecret = this.tfaService.isTfaSecret(loginDto.secret);
-        if (isTfaSecret) {
-          return this.tfaService.handleTfaLogin(
-            loginDto,
-            (user, deviceId, deviceUuid) =>
-              this.tokenService.generateToken(user, deviceId, deviceUuid),
-            (userGuid, deviceId, deviceUuid, deviceInfo) =>
-              this.deviceService.createOrUpdateDevice(
-                userGuid,
-                deviceId,
-                deviceUuid,
-                deviceInfo,
-              ),
-            (user) => this.buildUserPayload(user),
-          );
-        }
+        return this.tfaService.handleTfaLogin(
+          loginDto,
+          (user, deviceId, deviceUuid) =>
+            this.tokenService.generateToken(user, deviceId, deviceUuid),
+          (userGuid, deviceId, deviceUuid, deviceInfo) =>
+            this.deviceService.createOrUpdateDevice(
+              userGuid,
+              deviceId,
+              deviceUuid,
+              deviceInfo,
+            ),
+          (user) => this.buildUserPayload(user),
+        );
       }
       return this.emailAuthService.handleEmailCodeLogin(
         loginDto,
@@ -293,21 +289,18 @@ export class AuthService {
     // 检查是否需要邮箱验证（用户设置中开启了email_verification）
     const userInfo = user.getUserInfo();
     if (userInfo?.email_verification && user.email) {
-      return this.emailAuthService.initiateEmailVerification(
-        user,
-        (u) => this.buildUserPayload(u),
+      return this.emailAuthService.initiateEmailVerification(user, (u) =>
+        this.buildUserPayload(u),
       );
     }
 
     // 检查是否需要双因素认证
     if (user.tfaSecret) {
       if (!tfaCode) {
-        return {
-          type: 'email_check',
-          tfa_type: 'tfa_check',
-          secret: user.tfaSecret,
-          user: this.buildUserPayload(user),
-        };
+        // 返回会话标识符（UUID）而非 TFA 密钥，避免密钥泄露导致 2FA 失效
+        return this.tfaService.initiateTfaLogin(user, (u) =>
+          this.buildUserPayload(u),
+        );
       }
       const isValidTfa = this.tfaService.verifyTfaCode(user.tfaSecret, tfaCode);
       if (!isValidTfa) {


### PR DESCRIPTION
## Summary

Critical security fix: the login flow leaked the TOTP (TFA) secret to the client, allowing anyone who captures a login request/response to obtain the long-lived secret and generate valid 2FA codes indefinitely, making 2FA ineffective.

## Problem

When a user with TFA enabled logged in, the server returned the actual TOTP secret as the `secret` field (`secret: user.tfaSecret`) in the TFA challenge response. The client then sent this same secret back in the follow-up request, where it was used directly to verify the TFA code (`verifyTfaCode(secret, tfaCode)`) and matched against `user.tfaSecret`.

An attacker capturing either the challenge response or the verification request obtained the TOTP secret and could bypass the second factor permanently.

## Fix

`secret` is now a server-issued login session identifier (UUID) used only to track a single login attempt, mirroring the existing email verification flow. The TOTP secret never leaves the server.

- **`EmailVerificationSession` entity**: generalized to serve both email and TFA challenges — added a `method` column (`'email' | 'tfa'`) and made `code`/`email` nullable since TFA sessions don't use them.
- **`AuthTfaService.initiateTfaLogin`** (new): creates a one-time login session and returns its UUID `secret` instead of the TOTP secret.
- **`AuthTfaService.handleTfaLogin`** (rewritten): looks up the user via the session `secret`, verifies the TFA code against the server-stored `user.tfaSecret`, and marks the session used to prevent replay. Also cross-checks the returned username against the session user.
- **`AuthService.login`**: TFA challenge now calls `initiateTfaLogin`; the `email_code` compatibility path routes by the `tfaCode` field instead of sniffing the secret format.
- **`isTfaSecret` removed**: no longer needed since `secret` is always a UUID session id. Session lookups are scoped by `method` so the email and TFA flows cannot cross.

## Verification

- `npm run build` passes
- `eslint` passes on all changed files

## Security impact

TOTP secret is no longer transmitted to the client at any point. Capturing a login request/response only yields a short-lived (5 min), single-use session identifier, which cannot be used to generate valid TFA codes.