### PR TITLE
feat(user): add user group update to updateUser API

### DIFF
--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -89,6 +89,10 @@ export class UpdateUserDto {
   @IsBoolean()
   @IsOptional()
   is_admin?: boolean;
+
+  @IsUUID('4')
+  @IsOptional()
+  user_group_guid?: string;
 }
 
 export class UpdateUserSecurityDto {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -288,6 +288,12 @@ export class UserService {
       user.isAdmin = dto.is_admin;
     }
 
+    if (dto.user_group_guid !== undefined) {
+      user.userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
+        dto.user_group_guid,
+      );
+    }
+
     await this.userRepository.save(user);
 
     return { message: '用户已更新' };


### PR DESCRIPTION
## Summary

Add the ability to modify user group in the admin `updateUser` API (`PATCH /users/:guid`).

## Changes

- **UpdateUserDto**: Added optional `user_group_guid` field with `@IsUUID('4')` validation
- **UserService.updateUser**: Added logic to update `user.userGroupGuid` using `resolveUserGroupGuid` for group existence validation

## Details

When `user_group_guid` is provided in the request body:
- The value is validated as a UUID v4 format
- `resolveUserGroupGuid` verifies the group exists (throws `NotFoundException` if not)
- The user's `userGroupGuid` is updated accordingly

This follows the same pattern used in `createUser` and `inviteUser` methods.