### PR TITLE
ci: use .nvmrc file instead of hardcoded node version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Replace hardcoded Node.js version with .nvmrc file reference in CI workflows
- Update both ci.yml and release.yml to use node-version-file parameter

## Changes
- Modified `.github/workflows/ci.yml`: Updated all Setup Node.js steps to use `node-version-file: '.nvmrc'`
- Modified `.github/workflows/release.yml`: Updated all Setup Node.js steps to use `node-version-file: '.nvmrc'`

## Benefits
- Centralized Node.js version management through .nvmrc file
- Easier version updates - only need to change .nvmrc file
- Consistent Node.js version across local development and CI environments