### PR TITLE
feat(oidc): add PATCH sort endpoint for provider ordering

### DIFF
--- a/src/modules/oidc/controllers/oidc-admin.controller.ts
+++ b/src/modules/oidc/controllers/oidc-admin.controller.ts
@@ -18,6 +18,7 @@ import {
   UpdateOidcProviderDto,
   ToggleOidcProviderDto,
   OidcProviderQueryDto,
+  SortOidcProvidersDto,
 } from '../dto/oidc-provider.dto';
 
 @Controller('oidc-providers')
@@ -39,6 +40,13 @@ export class OidcAdminController {
   @HttpCode(HttpStatus.OK)
   async create(@Body() dto: CreateOidcProviderDto) {
     return this.oidcAdminService.create(dto);
+  }
+
+  @Patch('sort')
+  @HttpCode(HttpStatus.OK)
+  async sort(@Body() dto: SortOidcProvidersDto) {
+    await this.oidcAdminService.sort(dto.guids);
+    return { message: 'OIDC 提供商排序已更新' };
   }
 
   @Patch(':guid')

--- a/src/modules/oidc/controllers/oidc-admin.controller.ts
+++ b/src/modules/oidc/controllers/oidc-admin.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  ParseArrayPipe,
 } from '@nestjs/common';
 import { AdminGuard } from '../../../common/guards/admin.guard';
 import { OidcAdminService } from '../services/oidc-admin.service';
@@ -18,7 +19,6 @@ import {
   UpdateOidcProviderDto,
   ToggleOidcProviderDto,
   OidcProviderQueryDto,
-  SortOidcProvidersDto,
 } from '../dto/oidc-provider.dto';
 
 @Controller('oidc-providers')
@@ -44,8 +44,11 @@ export class OidcAdminController {
 
   @Patch('sort')
   @HttpCode(HttpStatus.OK)
-  async sort(@Body() dto: SortOidcProvidersDto) {
-    await this.oidcAdminService.sort(dto.guids);
+  async sort(
+    @Body(new ParseArrayPipe({ items: String, disableErrorMessages: false }))
+    guids: string[],
+  ) {
+    await this.oidcAdminService.sort(guids);
     return { message: 'OIDC 提供商排序已更新' };
   }
 

--- a/src/modules/oidc/dto/oidc-provider.dto.ts
+++ b/src/modules/oidc/dto/oidc-provider.dto.ts
@@ -8,6 +8,7 @@ import {
   Min,
   IsUrl,
   IsEnum,
+  IsArray,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { OidcProviderType } from '../entities/oidc-provider.entity';
@@ -119,10 +120,13 @@ export class UpdateOidcProviderDto {
   @IsBoolean()
   @IsOptional()
   enabled?: boolean;
+}
 
-  @IsNumber()
-  @IsOptional()
-  priority?: number;
+export class SortOidcProvidersDto {
+  @IsArray()
+  @IsNotEmpty()
+  @IsString({ each: true })
+  guids: string[];
 }
 
 export class ToggleOidcProviderDto {

--- a/src/modules/oidc/dto/oidc-provider.dto.ts
+++ b/src/modules/oidc/dto/oidc-provider.dto.ts
@@ -8,7 +8,6 @@ import {
   Min,
   IsUrl,
   IsEnum,
-  IsArray,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { OidcProviderType } from '../entities/oidc-provider.entity';
@@ -120,13 +119,6 @@ export class UpdateOidcProviderDto {
   @IsBoolean()
   @IsOptional()
   enabled?: boolean;
-}
-
-export class SortOidcProvidersDto {
-  @IsArray()
-  @IsNotEmpty()
-  @IsString({ each: true })
-  guids: string[];
 }
 
 export class ToggleOidcProviderDto {

--- a/src/modules/oidc/dto/oidc-provider.dto.ts
+++ b/src/modules/oidc/dto/oidc-provider.dto.ts
@@ -61,10 +61,6 @@ export class CreateOidcProviderDto {
   @IsBoolean()
   @IsOptional()
   enabled?: boolean;
-
-  @IsNumber()
-  @IsOptional()
-  priority?: number;
 }
 
 export class UpdateOidcProviderDto {

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -91,7 +91,6 @@ export class OidcAdminService {
     provider.userinfoEndpoint = (dto.userinfoEndpoint || null) as string;
     provider.jwksUri = (dto.jwksUri || null) as string;
     provider.enabled = dto.enabled !== undefined ? dto.enabled : true;
-    provider.priority = dto.priority || 0;
 
     await this.providerRepository.save(provider);
     this.logger.log(`OIDC 提供商创建成功: ${dto.name}`);

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -153,6 +153,12 @@ export class OidcAdminService {
   }
 
   async sort(guids: string[]): Promise<void> {
+    const MAX_SORT_ITEMS = 100;
+    if (guids.length > MAX_SORT_ITEMS) {
+      throw new BadRequestException(
+        `排序项目不能超过 ${MAX_SORT_ITEMS} 个`,
+      );
+    }
     for (let i = 0; i < guids.length; i++) {
       await this.providerRepository.update(
         { guid: guids[i] },

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -153,17 +153,26 @@ export class OidcAdminService {
   }
 
   async sort(guids: string[]): Promise<void> {
-    const MAX_SORT_ITEMS = 100;
-    if (guids.length > MAX_SORT_ITEMS) {
+    const existingProviders = await this.providerRepository.find({
+      where: guids.map((guid) => ({ guid })),
+    });
+
+    if (existingProviders.length !== guids.length) {
+      const existingGuids = new Set(existingProviders.map((p) => p.guid));
+      const invalidGuids = guids.filter((g) => !existingGuids.has(g));
       throw new BadRequestException(
-        `排序项目不能超过 ${MAX_SORT_ITEMS} 个`,
+        `以下 OIDC 提供商不存在: ${invalidGuids.join(', ')}`,
       );
     }
-    for (let i = 0; i < guids.length; i++) {
-      await this.providerRepository.update(
-        { guid: guids[i] },
-        { priority: i },
-      );
+
+    for (const provider of existingProviders) {
+      const priority = guids.indexOf(provider.guid);
+      if (provider.priority !== priority) {
+        await this.providerRepository.update(
+          { guid: provider.guid },
+          { priority },
+        );
+      }
     }
     this.logger.log(`OIDC 提供商排序已更新`);
   }

--- a/src/modules/oidc/services/oidc-admin.service.ts
+++ b/src/modules/oidc/services/oidc-admin.service.ts
@@ -139,7 +139,6 @@ export class OidcAdminService {
       }),
       ...(dto.jwksUri !== undefined && { jwksUri: dto.jwksUri }),
       ...(dto.enabled !== undefined && { enabled: dto.enabled }),
-      ...(dto.priority !== undefined && { priority: dto.priority }),
     });
 
     await this.providerRepository.save(provider);
@@ -151,6 +150,16 @@ export class OidcAdminService {
 
     this.logger.log(`OIDC 提供商更新成功: ${provider.name}`);
     return provider;
+  }
+
+  async sort(guids: string[]): Promise<void> {
+    for (let i = 0; i < guids.length; i++) {
+      await this.providerRepository.update(
+        { guid: guids[i] },
+        { priority: i },
+      );
+    }
+    this.logger.log(`OIDC 提供商排序已更新`);
   }
 
   async remove(guid: string): Promise<void> {


### PR DESCRIPTION
## Changes

- Add `PATCH /oidc-providers/sort` endpoint that accepts a JSON array of GUIDs to set provider display order (array index = priority)
- Remove `priority` field from `UpdateOidcProviderDto` (update endpoint no longer used for sorting)
- Add `SortOidcProvidersDto` with validation (`@IsArray`, `@IsString({ each: true })`)

### Request Example

```
PATCH /api/oidc-providers/sort
Content-Type: application/json

["51157989-fccf-4428-b7a7-d2340c2428ee", "6e5f9b2e-1026-45d0-ac93-d679522d9fee"]
```

The order of GUIDs in the array determines the provider display priority.