### PR TITLE
feat(auth): add Passkey (WebAuthn) login support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "rustdesk-console",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nestjs-modules/mailer": "^2.0.2",
@@ -20,6 +20,8 @@
         "@nestjs/serve-static": "^5.0.5",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
+        "@simplewebauthn/server": "^11.0.0",
+        "@simplewebauthn/types": "^11.0.0",
         "@types/cookie-parser": "^1.4.10",
         "bcryptjs": "^3.0.3",
         "class-transformer": "^0.5.1",
@@ -1619,6 +1621,12 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3257,6 +3265,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -3904,6 +3918,73 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.8.0.tgz",
+      "integrity": "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmmirror.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3940,6 +4021,33 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-11.0.0.tgz",
+      "integrity": "sha512-zu8dxKcPiRUNSN2kmrnNOzNbRI8VaR/rL4ENCHUfC6PEE7SAAdIql9g5GBOd/wOVZolIsaZz3ccFxuGoVP0iaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^11.0.0",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-11.0.0.tgz",
+      "integrity": "sha512-b2o0wC5u2rWts31dTgBkAtSNKGX0cvL6h8QedNsKmj8O4QoLFQFR3DBVBUlpyVEhYKA+mXGUaXbcOc4JdQ3HzA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -5560,6 +5668,20 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assert-never": {
       "version": "1.4.0",
       "resolved": "https://registry.npmmirror.com/assert-never/-/assert-never-1.4.0.tgz",
@@ -6727,6 +6849,15 @@
       "funding": {
         "type": "ko-fi",
         "url": "https://ko-fi.com/intcreator"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -12053,7 +12184,6 @@
       "resolved": "https://registry.npmmirror.com/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -13250,6 +13380,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -14961,8 +15109,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmmirror.com/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -15901,8 +16048,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.106.2",
@@ -16076,7 +16222,6 @@
       "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@nestjs/serve-static": "^5.0.5",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
+    "@simplewebauthn/server": "^11.0.0",
+    "@simplewebauthn/types": "^11.0.0",
     "@types/cookie-parser": "^1.4.10",
     "bcryptjs": "^3.0.3",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { DeviceGroupUserPermission } from './modules/device-group/entities/devic
 import { UserUserPermission } from './modules/device-group/entities/user-user-permission.entity';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 import { LoginSession } from './modules/auth/entities/login-session.entity';
+import { PasskeyCredential } from './modules/auth/entities/passkey-credential.entity';
 import { SystemSetting } from './modules/settings/entities/system-setting.entity';
 import { ActiveConnection } from './modules/heartbeat/entities/active-connection.entity';
 import { SettingsModule } from './modules/settings/settings.module';
@@ -100,6 +101,7 @@ import { UserGroup } from './modules/user-group/entities/user-group.entity';
         DeviceGroupUserPermission,
         UserUserPermission,
         LoginSession,
+        PasskeyCredential,
         SystemSetting,
         ActiveConnection,
         Strategy,

--- a/src/common/interfaces/login-response.interface.ts
+++ b/src/common/interfaces/login-response.interface.ts
@@ -1,9 +1,10 @@
 import { UserInfo } from '../../modules/user/entities/user.entity';
+import type { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/types';
 
 /**
  * 登录响应接口
  * 定义登录成功后返回的数据结构
- * 适用于所有认证方式（密码登录、TFA、邮箱验证码、OIDC等）
+ * 适用于所有认证方式（密码登录、TFA、邮箱验证码、OIDC、Passkey等）
  */
 export interface LoginResponse {
   /** 访问令牌，仅在登录成功时返回 */
@@ -14,6 +15,8 @@ export interface LoginResponse {
   tfa_type?: string;
   /** 登录会话标识符（UUID），由服务端在需要二次验证时返回，客户端在后续请求中回传，用于跟踪一次登录 */
   secret?: string;
+  /** Passkey 认证选项，仅在需要 Passkey 验证时返回，供浏览器调用 navigator.credentials.get() */
+  passkey_options?: PublicKeyCredentialRequestOptionsJSON;
   /** 用户信息 */
   user?: {
     /** 用户名 */

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,7 +2,9 @@ import {
   Controller,
   Post,
   Delete,
+  Get,
   Body,
+  Param,
   HttpCode,
   HttpStatus,
   Req,
@@ -10,6 +12,7 @@ import {
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './services';
 import { AuthTfaService } from './services/auth-tfa.service';
+import { AuthPasskeyService } from './services/auth-passkey.service';
 import {
   LoginDto,
   CurrentUserDto,
@@ -18,6 +21,11 @@ import {
   VerifyTfaDto,
   DisableTfaDto,
 } from './dto/auth.dto';
+import {
+  VerifyPasskeyRegistrationDto,
+  VerifyPasskeyAuthDto,
+  TogglePasskeyTfaDto,
+} from './dto/passkey.dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import type { Request } from 'express';
@@ -27,6 +35,7 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly tfaService: AuthTfaService,
+    private readonly passkeyService: AuthPasskeyService,
   ) {}
 
   @Public()
@@ -62,6 +71,8 @@ export class AuthController {
     return this.authService.getCurrentUser(userId, currentUserDto);
   }
 
+  // ==================== TOTP 2FA ====================
+
   @Post('2fa/setup')
   @HttpCode(HttpStatus.OK)
   async setupTfa(@CurrentUser('id') userId: string, @Body() dto: SetupTfaDto) {
@@ -84,5 +95,74 @@ export class AuthController {
     @Body() dto: DisableTfaDto,
   ) {
     return this.tfaService.disableTfa(userId, dto.code);
+  }
+
+  // ==================== Passkey 注册 ====================
+
+  @Post('passkey/register/begin')
+  @HttpCode(HttpStatus.OK)
+  async beginPasskeyRegistration(@CurrentUser('id') userId: string) {
+    return this.passkeyService.beginRegistration(userId);
+  }
+
+  @Post('passkey/register/verify')
+  @HttpCode(HttpStatus.OK)
+  async verifyPasskeyRegistration(
+    @CurrentUser('id') userId: string,
+    @Body() dto: VerifyPasskeyRegistrationDto,
+  ) {
+    return this.passkeyService.verifyRegistration(userId, dto.response, dto.name);
+  }
+
+  // ==================== Passkey 无密码登录 ====================
+
+  @Public()
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Post('passkey/auth/begin')
+  @HttpCode(HttpStatus.OK)
+  async beginPasskeyAuth() {
+    return this.passkeyService.beginAuthLogin();
+  }
+
+  @Public()
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Post('passkey/auth/verify')
+  @HttpCode(HttpStatus.OK)
+  async verifyPasskeyAuth(@Body() dto: VerifyPasskeyAuthDto) {
+    return this.passkeyService.verifyAuthLogin(
+      dto.secret,
+      dto.response,
+      dto.id,
+      dto.uuid,
+      dto.deviceInfo,
+    );
+  }
+
+  // ==================== Passkey 凭证管理 ====================
+
+  @Get('passkey/list')
+  async listPasskeys(@CurrentUser('id') userId: string) {
+    return this.passkeyService.listCredentials(userId);
+  }
+
+  @Delete('passkey/:guid')
+  @HttpCode(HttpStatus.OK)
+  async deletePasskey(
+    @CurrentUser('id') userId: string,
+    @Param('guid') guid: string,
+  ) {
+    await this.passkeyService.deleteCredential(userId, guid);
+    return { message: '凭证已删除' };
+  }
+
+  // ==================== Passkey 双因素认证 ====================
+
+  @Post('passkey/tfa')
+  @HttpCode(HttpStatus.OK)
+  async togglePasskeyTfa(
+    @CurrentUser('id') userId: string,
+    @Body() dto: TogglePasskeyTfaDto,
+  ) {
+    return this.passkeyService.setPasskeyTfaEnabled(userId, dto.enabled);
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,6 +9,8 @@ import {
   AuthTfaService,
   AuthEmailService,
   AuthDeviceService,
+  AuthPasskeyService,
+  WebAuthnConfigService,
   TokenCleanupService,
 } from './services';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -16,6 +18,8 @@ import { User } from '../user/entities/user.entity';
 import { UserToken } from '../user/entities/user-token.entity';
 import { Peer } from '../../common/entities';
 import { LoginSession } from './entities/login-session.entity';
+import { PasskeyCredential } from './entities/passkey-credential.entity';
+import { SystemSetting } from '../settings/entities/system-setting.entity';
 import { EmailModule } from '../email/email.module';
 import { LdapModule } from '../ldap/ldap.module';
 import { UserGroupModule } from '../user-group/user-group.module';
@@ -41,7 +45,14 @@ import { UserGroupModule } from '../user-group/user-group.module';
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, UserToken, Peer, LoginSession]),
+    TypeOrmModule.forFeature([
+      User,
+      UserToken,
+      Peer,
+      LoginSession,
+      PasskeyCredential,
+      SystemSetting,
+    ]),
     EmailModule,
     LdapModule,
     UserGroupModule,
@@ -62,6 +73,8 @@ import { UserGroupModule } from '../user-group/user-group.module';
     AuthTfaService,
     AuthEmailService,
     AuthDeviceService,
+    AuthPasskeyService,
+    WebAuthnConfigService,
     TokenCleanupService,
     JwtStrategy,
   ],

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -53,7 +53,14 @@ export class LoginDto {
   autoLogin?: boolean;
 
   @IsOptional()
-  @IsIn(['account', 'mobile', 'sms_code', 'email_code', 'tfa_code'])
+  @IsIn([
+    'account',
+    'mobile',
+    'sms_code',
+    'email_code',
+    'tfa_code',
+    'passkey_check',
+  ])
   type?: string;
 
   @IsOptional()

--- a/src/modules/auth/dto/passkey.dto.ts
+++ b/src/modules/auth/dto/passkey.dto.ts
@@ -1,0 +1,94 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsObject,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/types';
+
+/**
+ * Passkey 注册验证 DTO
+ * 客户端在 navigator.credentials.create() 后提交此数据
+ */
+export class VerifyPasskeyRegistrationDto {
+  @IsObject()
+  response!: RegistrationResponseJSON;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+/**
+ * Passkey 登录发起 DTO
+ * 可选传入设备信息
+ */
+export class BeginPasskeyAuthDto {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsOptional()
+  @IsString()
+  uuid?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PasskeyAuthDeviceInfoDto)
+  deviceInfo?: PasskeyAuthDeviceInfoDto;
+}
+
+/**
+ * Passkey 登录验证 DTO
+ * 客户端在 navigator.credentials.get() 后提交此数据
+ */
+export class VerifyPasskeyAuthDto {
+  @IsString()
+  secret!: string;
+
+  @IsObject()
+  response!: AuthenticationResponseJSON;
+
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsOptional()
+  @IsString()
+  uuid?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PasskeyAuthDeviceInfoDto)
+  deviceInfo?: PasskeyAuthDeviceInfoDto;
+}
+
+/**
+ * Passkey 登录设备信息
+ */
+class PasskeyAuthDeviceInfoDto {
+  @IsOptional()
+  @IsString()
+  os?: string;
+
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+/**
+ * Passkey 双因素认证开关 DTO
+ */
+export class TogglePasskeyTfaDto {
+  @IsBoolean()
+  enabled!: boolean;
+}

--- a/src/modules/auth/dto/passkey.dto.ts
+++ b/src/modules/auth/dto/passkey.dto.ts
@@ -12,6 +12,23 @@ import type {
 } from '@simplewebauthn/types';
 
 /**
+ * Passkey 登录设备信息
+ */
+class PasskeyAuthDeviceInfoDto {
+  @IsOptional()
+  @IsString()
+  os?: string;
+
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}
+
+/**
  * Passkey 注册验证 DTO
  * 客户端在 navigator.credentials.create() 后提交此数据
  */
@@ -66,23 +83,6 @@ export class VerifyPasskeyAuthDto {
   @ValidateNested()
   @Type(() => PasskeyAuthDeviceInfoDto)
   deviceInfo?: PasskeyAuthDeviceInfoDto;
-}
-
-/**
- * Passkey 登录设备信息
- */
-class PasskeyAuthDeviceInfoDto {
-  @IsOptional()
-  @IsString()
-  os?: string;
-
-  @IsOptional()
-  @IsString()
-  type?: string;
-
-  @IsOptional()
-  @IsString()
-  name?: string;
 }
 
 /**

--- a/src/modules/auth/entities/login-session.entity.ts
+++ b/src/modules/auth/entities/login-session.entity.ts
@@ -37,9 +37,12 @@ export class LoginSession {
    * 验证方式
    * 'email' - 邮箱验证码登录
    * 'tfa' - 双因素认证登录
+   * 'passkey_reg' - Passkey 注册（存储 challenge）
+   * 'passkey' - Passkey 无密码登录（存储 challenge）
+   * 'passkey_tfa' - Passkey 双因素认证登录（存储 challenge）
    */
   @Column({ default: 'email' })
-  method: 'email' | 'tfa';
+  method: 'email' | 'tfa' | 'passkey_reg' | 'passkey' | 'passkey_tfa';
 
   /**
    * 邮箱地址

--- a/src/modules/auth/entities/passkey-credential.entity.ts
+++ b/src/modules/auth/entities/passkey-credential.entity.ts
@@ -33,14 +33,14 @@ export class PasskeyCredential {
    * base64url 编码，由认证器生成，全局唯一
    * 登录时通过此字段反查用户，实现无密码登录
    */
-  @Column({ unique: true })
+  @Column({ type: 'varchar', unique: true })
   credentialId: string;
 
   /**
    * 凭证公钥
    * base64url 编码，用于验证认证器签名
    */
-  @Column()
+  @Column({ type: 'varchar' })
   credentialPublicKey: string;
 
   /**
@@ -55,7 +55,7 @@ export class PasskeyCredential {
    * JSON 数组，如 ["internal", "hybrid"]
    * 浏览器据此选择如何唤醒认证器
    */
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   transports: string | null;
 
   /**
@@ -63,7 +63,7 @@ export class PasskeyCredential {
    * 'singleDevice' - 单设备凭证（如安全密钥）
    * 'multiDevice' - 多设备凭证（如 Touch ID、Windows Hello，支持云端同步）
    */
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   deviceType: string;
 
   /**
@@ -77,7 +77,7 @@ export class PasskeyCredential {
    * 用户自定义凭证名称
    * 用于在管理界面中识别不同的凭证
    */
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   name: string | null;
 
   /**

--- a/src/modules/auth/entities/passkey-credential.entity.ts
+++ b/src/modules/auth/entities/passkey-credential.entity.ts
@@ -1,0 +1,94 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Passkey 凭证实体
+ * 存储用户绑定的 WebAuthn 凭证信息，用于无密码登录和双因素认证
+ */
+@Entity('passkey_credentials')
+export class PasskeyCredential {
+  /**
+   * 凭证唯一标识符
+   * UUID格式
+   */
+  @PrimaryColumn()
+  guid: string;
+
+  /**
+   * 所属用户唯一标识符
+   * 关联到 users 表的 guid 字段
+   */
+  @Column()
+  @Index()
+  userGuid: string;
+
+  /**
+   * WebAuthn 凭证 ID
+   * base64url 编码，由认证器生成，全局唯一
+   * 登录时通过此字段反查用户，实现无密码登录
+   */
+  @Column({ unique: true })
+  credentialId: string;
+
+  /**
+   * 凭证公钥
+   * base64url 编码，用于验证认证器签名
+   */
+  @Column()
+  credentialPublicKey: string;
+
+  /**
+   * 签名计数器
+   * 认证器每次认证自增，服务端校验递增以检测凭证克隆
+   */
+  @Column({ default: 0 })
+  counter: number;
+
+  /**
+   * 传输方式
+   * JSON 数组，如 ["internal", "hybrid"]
+   * 浏览器据此选择如何唤醒认证器
+   */
+  @Column({ nullable: true })
+  transports: string | null;
+
+  /**
+   * 设备类型
+   * 'singleDevice' - 单设备凭证（如安全密钥）
+   * 'multiDevice' - 多设备凭证（如 Touch ID、Windows Hello，支持云端同步）
+   */
+  @Column({ nullable: true })
+  deviceType: string;
+
+  /**
+   * 是否已备份
+   * 多设备凭证通常已备份到云端（iCloud/Google）
+   */
+  @Column({ default: false })
+  backedUp: boolean;
+
+  /**
+   * 用户自定义凭证名称
+   * 用于在管理界面中识别不同的凭证
+   */
+  @Column({ nullable: true })
+  name: string | null;
+
+  /**
+   * 创建时间
+   */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * 更新时间
+   */
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -1,0 +1,607 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  UnauthorizedException,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, In } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/types';
+import { User, UserStatus } from '../../user/entities/user.entity';
+import { PasskeyCredential } from '../entities/passkey-credential.entity';
+import { LoginSession } from '../entities/login-session.entity';
+import { LoginResponse } from '../../../common/interfaces';
+import { DeviceInfoDto } from '../dto/auth.dto';
+import { WebAuthnConfigService } from './webauthn-config.service';
+import { AuthTokenService } from './auth-token.service';
+import { AuthDeviceService } from './auth-device.service';
+
+/** Passkey 会话有效期（分钟） */
+const SESSION_EXPIRY_MINUTES = 5;
+
+@Injectable()
+export class AuthPasskeyService {
+  private readonly logger = new Logger(AuthPasskeyService.name);
+
+  constructor(
+    @InjectRepository(PasskeyCredential)
+    private credentialRepository: Repository<PasskeyCredential>,
+    @InjectRepository(LoginSession)
+    private loginSessionRepository: Repository<LoginSession>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    private readonly configService: WebAuthnConfigService,
+    private readonly tokenService: AuthTokenService,
+    private readonly deviceService: AuthDeviceService,
+  ) {}
+
+  // ==================== 注册 ====================
+
+  /**
+   * 发起 Passkey 注册
+   * 生成注册选项，包含 challenge，存入临时会话
+   *
+   * @param userGuid 当前登录用户的 guid
+   * @returns 注册选项，供浏览器调用 navigator.credentials.create()
+   */
+  async beginRegistration(
+    userGuid: string,
+  ): Promise<PublicKeyCredentialCreationOptionsJSON> {
+    const config = await this.configService.getConfig();
+    if (!config.enabled) {
+      throw new BadRequestException({ error: 'Passkey 功能未启用' });
+    }
+
+    const user = await this.userRepository.findOne({
+      where: { guid: userGuid },
+    });
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    // 查询已绑定的凭证，防止同一认证器重复注册
+    const existingCredentials = await this.credentialRepository.find({
+      where: { userGuid },
+    });
+
+    const options = await generateRegistrationOptions({
+      rpName: config.rpName,
+      rpID: config.rpId,
+      userName: user.username,
+      userDisplayName: user.displayName || user.username,
+      // 要求可发现凭证（Passkey），支持无用户名登录
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+      excludeCredentials: existingCredentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports ? JSON.parse(cred.transports) : undefined,
+      })),
+    });
+
+    // 创建临时会话存储 challenge
+    await this.createSession(
+      userGuid,
+      'passkey_reg',
+      options.challenge,
+    );
+
+    this.logger.log(`用户 ${user.username} 发起 Passkey 注册`);
+
+    return options;
+  }
+
+  /**
+   * 验证 Passkey 注册
+   * 验证认证器返回的 attestation，通过后保存凭证
+   *
+   * @param userGuid 当前登录用户的 guid
+   * @param response 浏览器返回的注册响应
+   * @param name 用户自定义凭证名称
+   */
+  async verifyRegistration(
+    userGuid: string,
+    response: RegistrationResponseJSON,
+    name?: string,
+  ): Promise<{ message: string }> {
+    const config = await this.configService.getConfig();
+    if (!config.enabled) {
+      throw new BadRequestException({ error: 'Passkey 功能未启用' });
+    }
+
+    // 查找注册会话获取 challenge
+    const session = await this.findValidSession(userGuid, 'passkey_reg');
+    if (!session) {
+      throw new BadRequestException({ error: '注册会话已过期，请重新发起注册' });
+    }
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge: session.code!,
+        expectedOrigin: config.rpOrigins,
+        expectedRPID: config.rpId,
+        requireUserVerification: true,
+      });
+    } catch (error) {
+      this.logger.error(`Passkey 注册验证失败: ${error}`);
+      throw new BadRequestException({ error: 'Passkey 注册验证失败' });
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new BadRequestException({ error: 'Passkey 注册验证失败' });
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } =
+      verification.registrationInfo;
+
+    // 检查凭证是否已存在（防止重复注册）
+    const existing = await this.credentialRepository.findOne({
+      where: { credentialId: credential.id },
+    });
+    if (existing) {
+      throw new BadRequestException({ error: '该凭证已存在' });
+    }
+
+    // 保存凭证
+    const passkeyCredential = this.credentialRepository.create({
+      guid: uuidv4(),
+      userGuid,
+      credentialId: credential.id,
+      credentialPublicKey: Buffer.from(credential.publicKey).toString(
+        'base64url',
+      ),
+      counter: credential.counter,
+      transports: credential.transports
+        ? JSON.stringify(credential.transports)
+        : null,
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      name: name || null,
+    });
+
+    await this.credentialRepository.save(passkeyCredential);
+
+    // 标记会话已使用
+    await this.markSessionUsed(session);
+
+    this.logger.log(`用户 ${userGuid} 成功绑定 Passkey 凭证`);
+
+    return { message: 'Passkey 绑定成功' };
+  }
+
+  // ==================== 无密码登录 ====================
+
+  /**
+   * 发起 Passkey 无密码登录
+   * 生成认证选项，不指定 allowCredentials，浏览器自动列出可用凭证
+   *
+   * @returns 会话标识符和认证选项
+   */
+  async beginAuthLogin(): Promise<{
+    secret: string;
+    options: PublicKeyCredentialRequestOptionsJSON;
+  }> {
+    const config = await this.configService.getConfig();
+    if (!config.enabled) {
+      throw new BadRequestException({ error: 'Passkey 功能未启用' });
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: config.rpId,
+      // 不指定 allowCredentials，支持发现式凭证（无用户名登录）
+      userVerification: 'preferred',
+    });
+
+    // 创建临时会话存储 challenge，userGuid 暂为空（登录时通过凭证反查）
+    const session = await this.createSession(
+      'pending',
+      'passkey',
+      options.challenge,
+    );
+
+    this.logger.log(`发起 Passkey 无密码登录，会话 ${session.guid}`);
+
+    return { secret: session.guid, options };
+  }
+
+  /**
+   * 验证 Passkey 登录
+   * 通过 credentialId 反查用户，验证签名，签发 JWT
+   * 同时处理无密码登录和双因素认证登录
+   *
+   * @param secret 会话标识符
+   * @param response 浏览器返回的认证响应
+   * @param deviceId 设备 ID
+   * @param deviceUuid 设备 UUID
+   * @param deviceInfo 设备信息
+   * @returns 登录响应，包含 JWT token
+   */
+  async verifyAuthLogin(
+    secret: string,
+    response: AuthenticationResponseJSON,
+    deviceId?: string,
+    deviceUuid?: string,
+    deviceInfo?: DeviceInfoDto,
+  ): Promise<LoginResponse> {
+    const config = await this.configService.getConfig();
+    if (!config.enabled) {
+      throw new BadRequestException({ error: 'Passkey 功能未启用' });
+    }
+
+    // 查找会话
+    const session = await this.loginSessionRepository.findOne({
+      where: {
+        guid: secret,
+        used: false,
+        expiresAt: MoreThan(new Date()),
+      },
+    });
+
+    if (!session) {
+      throw new UnauthorizedException({
+        error: '登录会话已过期或无效，请重新登录',
+      });
+    }
+
+    if (session.method !== 'passkey' && session.method !== 'passkey_tfa') {
+      throw new UnauthorizedException({ error: '会话类型不匹配' });
+    }
+
+    // 通过 credentialId 查找凭证
+    const credential = await this.credentialRepository.findOne({
+      where: { credentialId: response.id },
+    });
+
+    if (!credential) {
+      throw new UnauthorizedException({ error: '未找到匹配的凭证' });
+    }
+
+    // 对于双因素认证，校验凭证所属用户与会话用户一致
+    if (session.method === 'passkey_tfa' && session.userGuid !== credential.userGuid) {
+      throw new UnauthorizedException({ error: '凭证与用户不匹配' });
+    }
+
+    // 查找用户
+    const user = await this.userRepository.findOne({
+      where: { guid: credential.userGuid },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException({ error: '用户不存在' });
+    }
+
+    if (user.status === UserStatus.DISABLED) {
+      throw new UnauthorizedException({ error: '账户已被禁用' });
+    }
+
+    // 验证认证响应
+    const transports = credential.transports
+      ? (JSON.parse(credential.transports) as string[])
+      : undefined;
+
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: session.code!,
+        expectedOrigin: config.rpOrigins,
+        expectedRPID: config.rpId,
+        credential: {
+          id: credential.credentialId,
+          publicKey: Buffer.from(credential.credentialPublicKey, 'base64url'),
+          counter: credential.counter,
+          transports: transports as never,
+        },
+        requireUserVerification: true,
+      });
+    } catch (error) {
+      this.logger.error(`Passkey 登录验证失败: ${error}`);
+      throw new UnauthorizedException({ error: 'Passkey 认证失败' });
+    }
+
+    if (!verification.verified) {
+      throw new UnauthorizedException({ error: 'Passkey 认证失败' });
+    }
+
+    // 更新计数器（防克隆检测）
+    credential.counter = verification.authenticationInfo.newCounter;
+    await this.credentialRepository.save(credential);
+
+    // 标记会话已使用
+    await this.markSessionUsed(session);
+
+    // 创建/更新设备记录
+    if (deviceId || deviceUuid) {
+      await this.deviceService.createOrUpdateDevice(
+        user.guid,
+        deviceId,
+        deviceUuid,
+        deviceInfo,
+      );
+    }
+
+    // 生成 JWT Token
+    const token = await this.tokenService.generateToken(
+      user,
+      deviceId,
+      deviceUuid,
+    );
+
+    this.logger.log(`用户 ${user.username} 通过 Passkey 登录成功`);
+
+    return {
+      access_token: token,
+      type: 'access_token',
+      user: this.buildUserPayload(user),
+    };
+  }
+
+  // ==================== 双因素认证 ====================
+
+  /**
+   * 发起 Passkey 双因素认证
+   * 密码校验通过后调用，生成认证选项并返回给客户端
+   *
+   * @param user 已通过密码校验的用户
+   * @param buildUserPayload 构建用户信息载荷的回调函数
+   * @returns 登录响应，包含会话标识符和认证选项
+   */
+  async initiatePasskeyTfa(
+    user: User,
+    buildUserPayload: (user: User) => Record<string, unknown>,
+  ): Promise<LoginResponse> {
+    const config = await this.configService.getConfig();
+    if (!config.enabled) {
+      throw new BadRequestException({ error: 'Passkey 功能未启用' });
+    }
+
+    // 查找用户绑定的凭证，用于 allowCredentials
+    const credentials = await this.credentialRepository.find({
+      where: { userGuid: user.guid },
+    });
+
+    if (credentials.length === 0) {
+      throw new BadRequestException({
+        error: '未绑定 Passkey 凭证，无法进行双因素认证',
+      });
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: config.rpId,
+      allowCredentials: credentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports
+          ? JSON.parse(cred.transports)
+          : undefined,
+      })),
+      userVerification: 'preferred',
+    });
+
+    // 清除该用户之前未使用的会话
+    await this.loginSessionRepository.delete({
+      userGuid: user.guid,
+      used: false,
+    });
+
+    // 创建 TFA 会话
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + SESSION_EXPIRY_MINUTES);
+
+    const session = this.loginSessionRepository.create({
+      guid: uuidv4(),
+      userGuid: user.guid,
+      method: 'passkey_tfa',
+      code: options.challenge,
+      expiresAt,
+      used: false,
+    });
+    await this.loginSessionRepository.save(session);
+
+    this.logger.log(`用户 ${user.username} 登录需要 Passkey 双因素认证`);
+
+    return {
+      type: 'passkey_check',
+      secret: session.guid,
+      passkey_options: options,
+      user: buildUserPayload(user) as LoginResponse['user'],
+    };
+  }
+
+  // ==================== 凭证管理 ====================
+
+  /**
+   * 列出用户的所有 Passkey 凭证
+   */
+  async listCredentials(userGuid: string): Promise<PasskeyCredential[]> {
+    return this.credentialRepository.find({
+      where: { userGuid },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * 删除指定 Passkey 凭证
+   */
+  async deleteCredential(
+    userGuid: string,
+    credentialGuid: string,
+  ): Promise<void> {
+    const credential = await this.credentialRepository.findOne({
+      where: { guid: credentialGuid, userGuid },
+    });
+
+    if (!credential) {
+      throw new NotFoundException('凭证不存在');
+    }
+
+    await this.credentialRepository.remove(credential);
+
+    // 如果删除后没有凭证了，自动关闭 Passkey TFA
+    const remaining = await this.credentialRepository.count({
+      where: { userGuid },
+    });
+    if (remaining === 0) {
+      await this.setPasskeyTfaEnabled(userGuid, false);
+    }
+
+    this.logger.log(`用户 ${userGuid} 删除了 Passkey 凭证 ${credentialGuid}`);
+  }
+
+  /**
+   * 检查用户是否有 Passkey 凭证
+   */
+  async hasCredentials(userGuid: string): Promise<boolean> {
+    const count = await this.credentialRepository.count({
+      where: { userGuid },
+    });
+    return count > 0;
+  }
+
+  /**
+   * 启用/禁用 Passkey 双因素认证
+   * 存储在 UserInfo.other.passkey_tfa_enabled 中
+   */
+  async setPasskeyTfaEnabled(
+    userGuid: string,
+    enabled: boolean,
+  ): Promise<{ message: string }> {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userGuid })
+      .addSelect('user.info')
+      .getOne();
+
+    if (!user) {
+      throw new NotFoundException('用户不存在');
+    }
+
+    if (enabled) {
+      // 启用前检查是否已绑定凭证
+      const hasCredential = await this.hasCredentials(userGuid);
+      if (!hasCredential) {
+        throw new BadRequestException({
+          error: '请先绑定 Passkey 凭证再启用双因素认证',
+        });
+      }
+    }
+
+    const userInfo = user.getUserInfo();
+    userInfo.other = userInfo.other || {};
+    userInfo.other.passkey_tfa_enabled = enabled;
+    user.setUserInfo(userInfo);
+
+    await this.userRepository.save(user);
+
+    this.logger.log(
+      `用户 ${userGuid} ${enabled ? '启用' : '禁用'}了 Passkey 双因素认证`,
+    );
+
+    return {
+      message: enabled
+        ? 'Passkey 双因素认证已启用'
+        : 'Passkey 双因素认证已禁用',
+    };
+  }
+
+  /**
+   * 检查用户是否启用了 Passkey 双因素认证
+   */
+  async isPasskeyTfaEnabled(userGuid: string): Promise<boolean> {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: userGuid })
+      .addSelect('user.info')
+      .getOne();
+
+    if (!user) {
+      return false;
+    }
+
+    const userInfo = user.getUserInfo();
+    return !!userInfo?.other?.passkey_tfa_enabled;
+  }
+
+  // ==================== 私有辅助方法 ====================
+
+  /**
+   * 创建临时会话
+   */
+  private async createSession(
+    userGuid: string,
+    method: LoginSession['method'],
+    challenge: string,
+  ): Promise<LoginSession> {
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + SESSION_EXPIRY_MINUTES);
+
+    const session = this.loginSessionRepository.create({
+      guid: uuidv4(),
+      userGuid,
+      method,
+      code: challenge,
+      expiresAt,
+      used: false,
+    });
+
+    return this.loginSessionRepository.save(session);
+  }
+
+  /**
+   * 查找有效的未使用会话
+   */
+  private async findValidSession(
+    userGuid: string,
+    method: LoginSession['method'],
+  ): Promise<LoginSession | null> {
+    return this.loginSessionRepository.findOne({
+      where: {
+        userGuid,
+        method,
+        used: false,
+        expiresAt: MoreThan(new Date()),
+      },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * 标记会话已使用
+   */
+  private async markSessionUsed(session: LoginSession): Promise<void> {
+    session.used = true;
+    await this.loginSessionRepository.save(session);
+  }
+
+  /**
+   * 构建用户信息载荷
+   */
+  private buildUserPayload(user: User) {
+    return {
+      name: user.username,
+      display_name: user.displayName || undefined,
+      email: user.email || undefined,
+      note: user.note || undefined,
+      status: user.status,
+      info: user.getUserInfo(),
+      is_admin: user.isAdmin,
+      third_auth_type: user.thirdAuthType || undefined,
+      ...(user.avatar ? { avatar: user.avatar } : {}),
+    };
+  }
+}

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan, In } from 'typeorm';
+import { Repository, MoreThan } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import {
   generateRegistrationOptions,
@@ -15,10 +15,15 @@ import {
   verifyAuthenticationResponse,
 } from '@simplewebauthn/server';
 import type {
+  VerifiedRegistrationResponse,
+  VerifiedAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
   PublicKeyCredentialCreationOptionsJSON,
   PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
 } from '@simplewebauthn/types';
 import { User, UserStatus } from '../../user/entities/user.entity';
 import { PasskeyCredential } from '../entities/passkey-credential.entity';
@@ -89,16 +94,14 @@ export class AuthPasskeyService {
       },
       excludeCredentials: existingCredentials.map((cred) => ({
         id: cred.credentialId,
-        transports: cred.transports ? JSON.parse(cred.transports) : undefined,
+        transports: cred.transports
+          ? (JSON.parse(cred.transports) as AuthenticatorTransportFuture[])
+          : undefined,
       })),
     });
 
     // 创建临时会话存储 challenge
-    await this.createSession(
-      userGuid,
-      'passkey_reg',
-      options.challenge,
-    );
+    await this.createSession(userGuid, 'passkey_reg', options.challenge);
 
     this.logger.log(`用户 ${user.username} 发起 Passkey 注册`);
 
@@ -126,10 +129,12 @@ export class AuthPasskeyService {
     // 查找注册会话获取 challenge
     const session = await this.findValidSession(userGuid, 'passkey_reg');
     if (!session) {
-      throw new BadRequestException({ error: '注册会话已过期，请重新发起注册' });
+      throw new BadRequestException({
+        error: '注册会话已过期，请重新发起注册',
+      });
     }
 
-    let verification;
+    let verification: VerifiedRegistrationResponse;
     try {
       verification = await verifyRegistrationResponse({
         response,
@@ -273,7 +278,10 @@ export class AuthPasskeyService {
     }
 
     // 对于双因素认证，校验凭证所属用户与会话用户一致
-    if (session.method === 'passkey_tfa' && session.userGuid !== credential.userGuid) {
+    if (
+      session.method === 'passkey_tfa' &&
+      session.userGuid !== credential.userGuid
+    ) {
       throw new UnauthorizedException({ error: '凭证与用户不匹配' });
     }
 
@@ -292,10 +300,10 @@ export class AuthPasskeyService {
 
     // 验证认证响应
     const transports = credential.transports
-      ? (JSON.parse(credential.transports) as string[])
+      ? (JSON.parse(credential.transports) as AuthenticatorTransportFuture[])
       : undefined;
 
-    let verification;
+    let verification: VerifiedAuthenticationResponse;
     try {
       verification = await verifyAuthenticationResponse({
         response,
@@ -306,7 +314,7 @@ export class AuthPasskeyService {
           id: credential.credentialId,
           publicKey: Buffer.from(credential.credentialPublicKey, 'base64url'),
           counter: credential.counter,
-          transports: transports as never,
+          transports,
         },
         requireUserVerification: true,
       });
@@ -387,7 +395,7 @@ export class AuthPasskeyService {
       allowCredentials: credentials.map((cred) => ({
         id: cred.credentialId,
         transports: cred.transports
-          ? JSON.parse(cred.transports)
+          ? (JSON.parse(cred.transports) as AuthenticatorTransportFuture[])
           : undefined,
       })),
       userVerification: 'preferred',

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -26,6 +26,7 @@ import { JwtPayload } from '../../../common/services/token.service';
 import { AuthTfaService } from './auth-tfa.service';
 import { AuthEmailService } from './auth-email.service';
 import { AuthDeviceService } from './auth-device.service';
+import { AuthPasskeyService } from './auth-passkey.service';
 import { LdapService } from '../../ldap/ldap.service';
 import { UserGroupService } from '../../user-group/user-group.service';
 
@@ -56,6 +57,7 @@ export class AuthService {
     private readonly tfaService: AuthTfaService,
     private readonly emailAuthService: AuthEmailService,
     private readonly deviceService: AuthDeviceService,
+    private readonly passkeyService: AuthPasskeyService,
     private readonly ldapService: LdapService,
     private readonly userGroupService: UserGroupService,
   ) {}
@@ -304,6 +306,16 @@ export class AuthService {
       return this.emailAuthService.initiateEmailVerification(user, (u) =>
         this.buildUserPayload(u),
       );
+    }
+
+    // 检查是否需要 Passkey 双因素认证
+    if (userInfo?.other?.passkey_tfa_enabled) {
+      const hasPasskey = await this.passkeyService.hasCredentials(user.guid);
+      if (hasPasskey) {
+        return this.passkeyService.initiatePasskeyTfa(user, (u) =>
+          this.buildUserPayload(u),
+        );
+      }
     }
 
     // 检查是否需要双因素认证

--- a/src/modules/auth/services/index.ts
+++ b/src/modules/auth/services/index.ts
@@ -3,4 +3,6 @@ export { AuthTokenService } from './auth-token.service';
 export { AuthTfaService } from './auth-tfa.service';
 export { AuthEmailService } from './auth-email.service';
 export { AuthDeviceService } from './auth-device.service';
+export { AuthPasskeyService } from './auth-passkey.service';
+export { WebAuthnConfigService } from './webauthn-config.service';
 export { TokenCleanupService } from './token-cleanup.service';

--- a/src/modules/auth/services/webauthn-config.service.ts
+++ b/src/modules/auth/services/webauthn-config.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SystemSetting } from '../../settings/entities/system-setting.entity';
+
+const CATEGORY = 'webauthn';
+const RP_ID_KEY = 'webauthn.rpId';
+const RP_NAME_KEY = 'webauthn.rpName';
+const RP_ORIGINS_KEY = 'webauthn.rpOrigins';
+const ENABLED_KEY = 'webauthn.enabled';
+
+export interface WebAuthnConfig {
+  rpId: string;
+  rpName: string;
+  rpOrigins: string[];
+  enabled: boolean;
+}
+
+/**
+ * WebAuthn 配置服务
+ * 从 system_settings 表读取 RP 配置，支持环境变量回退
+ *
+ * 管理员配置接口由后续单独实现，当前通过环境变量或直接写入数据库配置
+ */
+@Injectable()
+export class WebAuthnConfigService {
+  private readonly logger = new Logger(WebAuthnConfigService.name);
+  private cachedConfig: WebAuthnConfig | null = null;
+  private lastCacheTime = 0;
+  private readonly CACHE_TTL_MS = 60_000;
+
+  constructor(
+    @InjectRepository(SystemSetting)
+    private readonly settingRepository: Repository<SystemSetting>,
+  ) {}
+
+  /**
+   * 获取 WebAuthn RP 配置
+   * 优先从数据库读取，未配置时回退到环境变量
+   */
+  async getConfig(): Promise<WebAuthnConfig> {
+    if (this.cachedConfig && Date.now() - this.lastCacheTime < this.CACHE_TTL_MS) {
+      return this.cachedConfig;
+    }
+
+    const settings = await this.settingRepository.find({
+      where: {
+        key: [
+          RP_ID_KEY,
+          RP_NAME_KEY,
+          RP_ORIGINS_KEY,
+          ENABLED_KEY,
+        ] as never,
+      },
+    });
+    const values = new Map(settings.map((s) => [s.key, s.value]));
+
+    const rpId =
+      values.get(RP_ID_KEY) ||
+      process.env.WEBAUTHN_RP_ID ||
+      'localhost';
+
+    const rpName =
+      values.get(RP_NAME_KEY) ||
+      process.env.WEBAUTHN_RP_NAME ||
+      'RustDesk Console';
+
+    const rpOriginsStr =
+      values.get(RP_ORIGINS_KEY) ||
+      process.env.WEBAUTHN_RP_ORIGINS ||
+      'http://localhost:3000';
+    const rpOrigins = rpOriginsStr.startsWith('[')
+      ? (JSON.parse(rpOriginsStr) as string[])
+      : rpOriginsStr.split(',').map((s) => s.trim());
+
+    const enabledStr =
+      values.get(ENABLED_KEY) || process.env.WEBAUTHN_ENABLED || 'false';
+    const enabled = enabledStr === 'true';
+
+    this.cachedConfig = { rpId, rpName, rpOrigins, enabled };
+    this.lastCacheTime = Date.now();
+
+    return this.cachedConfig;
+  }
+
+  /**
+   * 检查 WebAuthn 是否已启用
+   */
+  async isEnabled(): Promise<boolean> {
+    const config = await this.getConfig();
+    return config.enabled;
+  }
+
+  /**
+   * 使配置缓存失效
+   * 管理员更新配置后调用
+   */
+  invalidateCache(): void {
+    this.cachedConfig = null;
+    this.lastCacheTime = 0;
+  }
+}

--- a/src/modules/auth/services/webauthn-config.service.ts
+++ b/src/modules/auth/services/webauthn-config.service.ts
@@ -3,7 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SystemSetting } from '../../settings/entities/system-setting.entity';
 
-const CATEGORY = 'webauthn';
 const RP_ID_KEY = 'webauthn.rpId';
 const RP_NAME_KEY = 'webauthn.rpName';
 const RP_ORIGINS_KEY = 'webauthn.rpOrigins';
@@ -39,26 +38,22 @@ export class WebAuthnConfigService {
    * 优先从数据库读取，未配置时回退到环境变量
    */
   async getConfig(): Promise<WebAuthnConfig> {
-    if (this.cachedConfig && Date.now() - this.lastCacheTime < this.CACHE_TTL_MS) {
+    if (
+      this.cachedConfig &&
+      Date.now() - this.lastCacheTime < this.CACHE_TTL_MS
+    ) {
       return this.cachedConfig;
     }
 
     const settings = await this.settingRepository.find({
       where: {
-        key: [
-          RP_ID_KEY,
-          RP_NAME_KEY,
-          RP_ORIGINS_KEY,
-          ENABLED_KEY,
-        ] as never,
+        key: [RP_ID_KEY, RP_NAME_KEY, RP_ORIGINS_KEY, ENABLED_KEY] as never,
       },
     });
     const values = new Map(settings.map((s) => [s.key, s.value]));
 
     const rpId =
-      values.get(RP_ID_KEY) ||
-      process.env.WEBAUTHN_RP_ID ||
-      'localhost';
+      values.get(RP_ID_KEY) || process.env.WEBAUTHN_RP_ID || 'localhost';
 
     const rpName =
       values.get(RP_NAME_KEY) ||

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -349,6 +349,7 @@ describe('User group integration', () => {
       undefined as never,
       undefined as never,
       undefined as never,
+      undefined as never,
       userGroupService,
     );
     const databaseInitService = new DatabaseInitService(


### PR DESCRIPTION
## Summary

Add Passkey (WebAuthn) login support to the RustDesk Console, enabling passwordless authentication and Passkey as a second factor (TFA).

## Changes

### New Features
- **Passwordless login** via discoverable credentials (no username required, browser auto-prompts Passkey selector)
- **Passkey as TFA** — after password login, user verifies with Passkey as the second step
- **Credential management** — list and delete registered Passkeys; auto-disables TFA when last credential is removed
- **WebAuthn RP config** read from `system_settings` table (category: `webauthn`) with environment variable fallback

### New Entities
- `PasskeyCredential` — stores credential ID, public key, counter (clone detection), transports, device type, backup status
- `LoginSession` extended with `passkey` / `passkey_tfa` / `passkey_reg` methods for challenge storage

### New API Endpoints
| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| POST | `/api/passkey/register/begin` | JWT | Begin Passkey registration |
| POST | `/api/passkey/register/verify` | JWT | Verify and save credential |
| POST | `/api/passkey/auth/begin` | Public | Begin passwordless login |
| POST | `/api/passkey/auth/verify` | Public | Verify assertion, return JWT |
| GET | `/api/passkey/list` | JWT | List user's credentials |
| DELETE | `/api/passkey/:guid` | JWT | Delete a credential |
| POST | `/api/passkey/tfa` | JWT | Toggle Passkey TFA |

### Dependencies
- `@simplewebauthn/server@^11` — server-side WebAuthn verification
- `@simplewebauthn/types@^11` — TypeScript type definitions

### Configuration
WebAuthn RP config is read from `system_settings` (category: `webauthn`), with env var fallback:
- `webauthn.rpId` / `WEBAUTHN_RP_ID` (default: `localhost`)
- `webauthn.rpName` / `WEBAUTHN_RP_NAME` (default: `RustDesk Console`)
- `webauthn.rpOrigins` / `WEBAUTHN_RP_ORIGINS` (default: `http://localhost:3000`)
- `webauthn.enabled` / `WEBAUTHN_ENABLED` (default: `false`)

> **Note:** Admin endpoints for managing RP config are intentionally omitted — they will be added separately.

## Test Plan
- [x] Build passes (`npm run build`)
- [x] All existing tests pass (`npm test` — 19/19)
- [ ] Manual testing with browser Passkey flow (registration, login, TFA)
- [ ] Test with different authenticators (platform, security key)