### PR TITLE
feat(auth): associate deviceInfo with login sessions and add session management APIs

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './services';
 import { AuthTfaService } from './services/auth-tfa.service';
 import { AuthPasskeyService } from './services/auth-passkey.service';
+import { AuthTokenService } from './services/auth-token.service';
 import {
   LoginDto,
   CurrentUserDto,
@@ -36,6 +37,7 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly tfaService: AuthTfaService,
     private readonly passkeyService: AuthPasskeyService,
+    private readonly tokenService: AuthTokenService,
   ) {}
 
   @Public()
@@ -111,7 +113,11 @@ export class AuthController {
     @CurrentUser('id') userId: string,
     @Body() dto: VerifyPasskeyRegistrationDto,
   ) {
-    return this.passkeyService.verifyRegistration(userId, dto.response, dto.name);
+    return this.passkeyService.verifyRegistration(
+      userId,
+      dto.response,
+      dto.name,
+    );
   }
 
   // ==================== Passkey 无密码登录 ====================
@@ -164,5 +170,23 @@ export class AuthController {
     @Body() dto: TogglePasskeyTfaDto,
   ) {
     return this.passkeyService.setPasskeyTfaEnabled(userId, dto.enabled);
+  }
+
+  // ==================== 登录会话管理 ====================
+
+  @Get('sessions')
+  async listSessions(@CurrentUser('id') userId: string) {
+    const sessions = await this.tokenService.listSessions(userId);
+    return sessions;
+  }
+
+  @Delete('sessions/:jti')
+  @HttpCode(HttpStatus.OK)
+  async revokeSession(
+    @CurrentUser('id') userId: string,
+    @Param('jti') jti: string,
+  ) {
+    await this.tokenService.revokeSession(userId, jti);
+    return { message: '会话已撤销' };
   }
 }

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -349,6 +349,7 @@ export class AuthPasskeyService {
       user,
       deviceId,
       deviceUuid,
+      deviceInfo,
     );
 
     this.logger.log(`用户 ${user.username} 通过 Passkey 登录成功`);

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -1,11 +1,23 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, MoreThan } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import { User } from '../../user/entities/user.entity';
 import { UserToken } from '../../user/entities/user-token.entity';
 import { JwtPayload } from '../../../common/services/token.service';
+import { DeviceInfoDto } from '../dto/auth.dto';
+
+export interface SessionInfo {
+  jti: string;
+  deviceId: string | null;
+  deviceUuid: string | null;
+  deviceOs: string | null;
+  deviceType: string | null;
+  deviceName: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+}
 
 @Injectable()
 /**
@@ -35,12 +47,14 @@ export class AuthTokenService {
    * @param user 用户对象
    * @param deviceId 设备ID（可选）
    * @param deviceUuid 设备UUID（可选）
+   * @param deviceInfo 设备信息（可选），包含操作系统、来源类型和设备名称
    * @returns 生成的JWT Token字符串
    */
   async generateToken(
     user: User,
     deviceId?: string,
     deviceUuid?: string,
+    deviceInfo?: DeviceInfoDto,
   ): Promise<string> {
     const jti = uuidv4();
 
@@ -64,6 +78,9 @@ export class AuthTokenService {
       jti,
       deviceId,
       deviceUuid,
+      deviceOs: deviceInfo?.os,
+      deviceType: deviceInfo?.type,
+      deviceName: deviceInfo?.name,
       expiresAt,
     });
 
@@ -140,5 +157,54 @@ export class AuthTokenService {
       },
       { isRevoked: true },
     );
+  }
+
+  /**
+   * 列出用户的有效登录会话
+   * 返回未过期且未撤销的令牌及其设备信息
+   *
+   * @param userGuid 用户GUID
+   * @returns 有效会话列表
+   */
+  async listSessions(userGuid: string): Promise<SessionInfo[]> {
+    const tokens = await this.tokenRepository.find({
+      where: {
+        userGuid,
+        isRevoked: false,
+        expiresAt: MoreThan(new Date()),
+      },
+      order: { createdAt: 'DESC' },
+    });
+
+    return tokens.map((t) => ({
+      jti: t.jti,
+      deviceId: t.deviceId,
+      deviceUuid: t.deviceUuid,
+      deviceOs: t.deviceOs,
+      deviceType: t.deviceType,
+      deviceName: t.deviceName,
+      createdAt: t.createdAt,
+      expiresAt: t.expiresAt,
+    }));
+  }
+
+  /**
+   * 撤销指定会话
+   * 通过 jti 撤销用户的一个登录会话
+   *
+   * @param userGuid 用户GUID
+   * @param jti 令牌唯一标识符
+   */
+  async revokeSession(userGuid: string, jti: string): Promise<void> {
+    const token = await this.tokenRepository.findOne({
+      where: { userGuid, jti },
+    });
+
+    if (!token) {
+      throw new NotFoundException('会话不存在');
+    }
+
+    token.isRevoked = true;
+    await this.tokenRepository.save(token);
   }
 }

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -18,6 +18,7 @@ import {
   RegisterDto,
   CurrentUserDto,
   LogoutDto,
+  DeviceInfoDto,
 } from '../dto/auth.dto';
 import { LoginSession } from '../entities/login-session.entity';
 import { EmailService } from '../../email/email.service';
@@ -147,7 +148,12 @@ export class AuthService {
         return this.tfaService.handleTfaLogin(
           loginDto,
           (user, deviceId, deviceUuid) =>
-            this.tokenService.generateToken(user, deviceId, deviceUuid),
+            this.tokenService.generateToken(
+              user,
+              deviceId,
+              deviceUuid,
+              loginDto.deviceInfo,
+            ),
           (userGuid, deviceId, deviceUuid, deviceInfo) =>
             this.deviceService.createOrUpdateDevice(
               userGuid,
@@ -161,7 +167,12 @@ export class AuthService {
       return this.emailAuthService.handleEmailCodeLogin(
         loginDto,
         (user, deviceId, deviceUuid) =>
-          this.tokenService.generateToken(user, deviceId, deviceUuid),
+          this.tokenService.generateToken(
+            user,
+            deviceId,
+            deviceUuid,
+            loginDto.deviceInfo,
+          ),
         (userGuid, deviceId, deviceUuid, deviceInfo) =>
           this.deviceService.createOrUpdateDevice(
             userGuid,
@@ -185,7 +196,12 @@ export class AuthService {
       return this.tfaService.handleTfaLogin(
         loginDto,
         (user, deviceId, deviceUuid) =>
-          this.tokenService.generateToken(user, deviceId, deviceUuid),
+          this.tokenService.generateToken(
+            user,
+            deviceId,
+            deviceUuid,
+            loginDto.deviceInfo,
+          ),
         (userGuid, deviceId, deviceUuid, deviceInfo) =>
           this.deviceService.createOrUpdateDevice(
             userGuid,
@@ -205,11 +221,11 @@ export class AuthService {
     // 尝试 LDAP 认证
     const ldapUser = await this.tryLdapAuthentication(username, password);
     if (ldapUser) {
-      return this.buildLoginResponse(ldapUser, id, uuid);
+      return this.buildLoginResponse(ldapUser, id, uuid, loginDto.deviceInfo);
     }
 
     // 回退到本地账号密码认证
-    return this.localLogin(username, password, id, uuid);
+    return this.localLogin(username, password, id, uuid, loginDto.deviceInfo);
   }
 
   /**
@@ -266,6 +282,7 @@ export class AuthService {
     password: string,
     id?: string,
     uuid?: string,
+    deviceInfo?: DeviceInfoDto,
   ): Promise<LoginResponse> {
     // 查找用户（支持用户名或邮箱登录）
     const user = await this.userRepository
@@ -332,7 +349,7 @@ export class AuthService {
       };
     }
 
-    return this.buildLoginResponse(user, id, uuid);
+    return this.buildLoginResponse(user, id, uuid, deviceInfo);
   }
 
   /**
@@ -342,6 +359,7 @@ export class AuthService {
     user: User,
     id?: string,
     uuid?: string,
+    deviceInfo?: DeviceInfoDto,
   ): Promise<LoginResponse> {
     // 创建或更新设备记录
     if (id || uuid) {
@@ -349,12 +367,17 @@ export class AuthService {
         user.guid,
         id,
         uuid,
-        undefined,
+        deviceInfo,
       );
     }
 
     // 生成JWT Token
-    const token = await this.tokenService.generateToken(user, id, uuid);
+    const token = await this.tokenService.generateToken(
+      user,
+      id,
+      uuid,
+      deviceInfo,
+    );
 
     this.logger.log(`用户登录成功: ${user.username}`);
 

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -102,7 +102,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Token 已失效或被撤销');
     }
 
-    const { sub, username, email, isAdmin } = payload;
+    const { sub, username, email, isAdmin, jti } = payload;
 
     // 保持原有字段名 id，实际值是用户的 guid
     return {
@@ -110,6 +110,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       username,
       email,
       isAdmin,
+      jti, // 令牌唯一标识，用于会话管理
     };
   }
 }

--- a/src/modules/user/entities/user-token.entity.ts
+++ b/src/modules/user/entities/user-token.entity.ts
@@ -69,6 +69,27 @@ export class UserToken {
   isRevoked: boolean;
 
   /**
+   * 设备操作系统
+   * 登录时由客户端提交，如 linux, windows, android
+   */
+  @Column({ type: 'varchar', nullable: true })
+  deviceOs: string;
+
+  /**
+   * 设备来源类型
+   * "client" 表示 RustDesk 客户端，"browser" 表示浏览器
+   */
+  @Column({ type: 'varchar', nullable: true })
+  deviceType: string;
+
+  /**
+   * 设备名称
+   * 客户端取自主机名 hostname，浏览器取自 navigator.userAgent
+   */
+  @Column({ type: 'varchar', nullable: true })
+  deviceName: string;
+
+  /**
    * 关联的用户实体
    * 多对一关系，关联到 User
    */


### PR DESCRIPTION
## Summary

Store `deviceInfo` (os, type, name) from login requests in the `UserToken` entity, and provide API endpoints for users to query and manage their active login sessions.

## Changes

### Entity
- `UserToken` entity: added `deviceOs`, `deviceType`, `deviceName` nullable varchar columns

### Token Service
- `AuthTokenService.generateToken`: added optional `deviceInfo` parameter, persists device metadata
- `AuthTokenService.listSessions`: returns active (non-expired, non-revoked) sessions with device info
- `AuthTokenService.revokeSession`: revokes a session by `jti`

### Login Flow Updates
Pass `deviceInfo` through all login paths to `generateToken`:
- Password login (local + LDAP)
- TFA login (TOTP)
- Email verification code login
- Passkey login (passwordless + TFA)

### JWT Strategy
- Added `jti` to the validated user object returned by `JwtStrategy.validate`, enabling controllers to identify the current session

### New API Endpoints
| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| GET | `/api/sessions` | JWT | List current user's active login sessions |
| DELETE | `/api/sessions/:jti` | JWT | Revoke a specific login session |

### Session List Response Example
```json
[
  {
    "jti": "uuid-token-id",
    "deviceId": null,
    "deviceUuid": null,
    "deviceOs": "macos",
    "deviceType": "browser",
    "deviceName": "MacBook Pro",
    "createdAt": "2026-07-25T02:00:00.000Z",
    "expiresAt": "2026-08-24T02:00:00.000Z"
  }
]
```

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] All existing tests pass (19/19)
- [ ] Manual testing: login with deviceInfo, verify session appears in list, revoke session