### PR TITLE
docs: update README to remove outdated feature status descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,7 @@ backend and frontend may not yet be feature-complete for the items below.
 | Area | Current Status | Notes |
 |------|----------------|-------|
 | **Role management / RBAC** | Frontend scaffold only | The frontend exposes `/roles` and calls `/api/roles` and `/api/permissions`, but the backend does not currently include role or permission modules/controllers. Access control is currently based on `isAdmin` plus device/user/group permission mappings rather than a complete role-permission system. |
-| **User groups** | Backend implemented, frontend partial | `/api/user-groups` supports CRUD, membership, default assignment, and address-book group grants. The current frontend supports group CRUD; member and grant-management UI remains follow-up work. |
-| **Generic system settings** | Partially implemented | The backend implements the narrow console appearance contract under `/api/settings/general` and SMTP settings under `/api/settings/smtp`. Arbitrary endpoints such as `/api/settings`, `/api/settings/:key`, and `/api/settings/batch` are intentionally not implemented. |
 | **Dashboard online-user and alarm counters** | Partially implemented | Some dashboard metrics are placeholders: online users, active connections, unread alarms, and critical alarms currently require additional session/alarm-state tracking fields. |
-| **SMS-code login** | Placeholder | The login flow recognizes `sms_code`, but SMS verification is not implemented and currently returns a "feature under development" error. |
 | **Console operation auditing** | Query surface only | The audit module exposes a console-audit query endpoint, but full recording of management-console operations is still expected to be completed. |
 | **Database migrations** | Planned production hardening | The project currently relies on TypeORM `synchronize: true`; production-grade migrations are still expected for safer upgrades. |
 


### PR DESCRIPTION
Removed obsolete status descriptions in the README regarding user groups, system settings, and SMS login, so that the documentation better reflects the current project progress.