### PR TITLE
feat: support user_group_guid/user_group_name filter on admin/users

### DIFF
--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -26,6 +26,8 @@ export class AdminUserService {
       is_admin,
       third_auth_type,
       strategy_name,
+      user_group_guid,
+      user_group_name,
     } = query;
     const skip = (current - 1) * pageSize;
 
@@ -68,6 +70,18 @@ export class AdminUserService {
         )`,
         { strategyName: `%${strategy_name}%` },
       );
+    }
+
+    if (user_group_guid) {
+      queryBuilder.andWhere('user.userGroupGuid = :userGroupGuid', {
+        userGroupGuid: user_group_guid,
+      });
+    }
+
+    if (user_group_name && !user_group_guid) {
+      queryBuilder.andWhere('userGroup.name LIKE :userGroupName', {
+        userGroupName: `%${user_group_name}%`,
+      });
     }
 
     const [users, total] = await queryBuilder

--- a/src/modules/user/dto/admin-user.dto.ts
+++ b/src/modules/user/dto/admin-user.dto.ts
@@ -49,4 +49,12 @@ export class AdminUserQueryDto {
   @IsString()
   @IsOptional()
   strategy_name?: string;
+
+  @IsString()
+  @IsOptional()
+  user_group_guid?: string;
+
+  @IsString()
+  @IsOptional()
+  user_group_name?: string;
 }


### PR DESCRIPTION
## Summary

Add `user_group_guid` and `user_group_name` as optional query parameters to the `GET /admin/users` endpoint to support filtering users by their user group.

## Changes

- `src/modules/user/dto/admin-user.dto.ts`: add optional `user_group_guid` and `user_group_name` string fields to `AdminUserQueryDto`.
- `src/modules/user/admin-user.service.ts`:
  - `user_group_guid` filters by exact match on `user.userGroupGuid`.
  - `user_group_name` filters by fuzzy match (`LIKE`) on the joined `userGroup.name`, and is ignored when `user_group_guid` is provided (guid takes precedence).

## Notes

- The response already returned `user_group_guid` / `user_group_name`, and the `leftJoinAndSelect('user.userGroup', 'userGroup')` was already in place, so no response shape or join changes were needed.
- Behavior mirrors the existing `device_group_guid` / `device_group_name` filter in `device-group/peer.service.ts`.
- No database schema change required (`users.userGroupGuid` column already exists).