### PR TITLE
fix: reorder routes to prevent devices/status from matching devices/:guid

### DIFF
--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -246,27 +246,6 @@ export class DeviceGroupController {
   }
 
   /**
-   * 更新设备属性
-   * 管理员可以部分更新设备的用户、设备组、策略和备注
-   * 传字符串值 -> 按名称查找并关联
-   * 传 null -> 清除关联
-   * 不传某字段 -> 不修改该属性
-   *
-   * @param guid 设备GUID
-   * @param dto 更新数据
-   * @returns 更新结果
-   */
-  @Patch('devices/:guid')
-  @UseGuards(AdminGuard)
-  async updateDevice(
-    @Param('guid') guid: string,
-    @Body() dto: UpdateDeviceDto,
-  ) {
-    await this.deviceGroupService.updateDevice(guid, dto);
-    return { message: '设备更新成功' };
-  }
-
-  /**
    * 批量更新设备状态
    * 管理员可以批量启用或禁用设备
    *
@@ -286,6 +265,27 @@ export class DeviceGroupController {
       success: result.failedCount === 0,
       data: result,
     };
+  }
+
+  /**
+   * 更新设备属性
+   * 管理员可以部分更新设备的用户、设备组、策略和备注
+   * 传字符串值 -> 按名称查找并关联
+   * 传 null -> 清除关联
+   * 不传某字段 -> 不修改该属性
+   *
+   * @param guid 设备GUID
+   * @param dto 更新数据
+   * @returns 更新结果
+   */
+  @Patch('devices/:guid')
+  @UseGuards(AdminGuard)
+  async updateDevice(
+    @Param('guid') guid: string,
+    @Body() dto: UpdateDeviceDto,
+  ) {
+    await this.deviceGroupService.updateDevice(guid, dto);
+    return { message: '设备更新成功' };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix route ordering issue where `PATCH devices/status` was incorrectly matched by `PATCH devices/:guid` (with `:guid = "status"`)
- Move the static route `devices/status` before the parameterized route `devices/:guid` to ensure correct matching

## Problem

When sending `PATCH /api/devices/status` with body `{"guids":["..."],"status":"disabled"}`, the response was:

```json
{
  "message": ["property guids should not exist", "property status should not exist"],
  "error": "Bad Request",
  "statusCode": 400
}
```

## Root Cause

In `device-group.controller.ts`, `@Patch('devices/:guid')` was defined before `@Patch('devices/status')`. NestJS (Express) matches routes in definition order, so the parameterized route captured the request with `:guid = "status"`, causing the body to be validated against `UpdateDeviceDto` instead of `UpdateDeviceStatusDto`.

## Fix

Reorder the two route definitions so that the static route `devices/status` comes before the parameterized route `devices/:guid`.

## Test Plan

- Send `PATCH /api/devices/status` with `{"guids":["<valid-guid>"],"status":"disabled"}` and verify it returns success
- Send `PATCH /api/devices/:guid` with valid `UpdateDeviceDto` body and verify it still works correctly