### PR TITLE
ci: build docker once and push to both registries, add MAJOR.MINOR tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
           # Login to GitHub Container Registry
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          # Build once and push to both Docker Hub and GitHub Container Registry
+          # Build and push to Docker Hub and GitHub Container Registry
           docker buildx build --push \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=$VERSION \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,19 +92,11 @@ jobs:
           # Login to GitHub Container Registry
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          # Build and push to Docker Hub
+          # Build once and push to both Docker Hub and GitHub Container Registry
           docker buildx build --push \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=$VERSION \
             --tag databk/rustdesk-console:nightly \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            .
-
-          # Build and push to GitHub Container Registry
-          docker buildx build --push \
-            --platform linux/amd64,linux/arm64 \
-            --build-arg APP_VERSION=$VERSION \
             --tag ghcr.io/databk/rustdesk-console:nightly \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           # Login to GitHub Container Registry
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           
-          # Build once and push to both Docker Hub and GitHub Container Registry
+          # Build and push to Docker Hub and GitHub Container Registry
           docker buildx build --push \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=$VERSION \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         run: |
           VERSION=${{ steps.changelog.outputs.version }}
           MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          MAJOR_MINOR="${MAJOR}.${MINOR}"
           
           docker buildx create --use
           
@@ -66,23 +68,17 @@ jobs:
           # Login to GitHub Container Registry
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           
-          # Build and push to Docker Hub
+          # Build once and push to both Docker Hub and GitHub Container Registry
           docker buildx build --push \
             --platform linux/amd64,linux/arm64 \
             --build-arg APP_VERSION=$VERSION \
             --tag databk/rustdesk-console:latest \
             --tag databk/rustdesk-console:$VERSION \
+            --tag databk/rustdesk-console:$MAJOR_MINOR \
             --tag databk/rustdesk-console:$MAJOR \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            .
-          
-          # Build and push to GitHub Container Registry
-          docker buildx build --push \
-            --platform linux/amd64,linux/arm64 \
-            --build-arg APP_VERSION=$VERSION \
             --tag ghcr.io/databk/rustdesk-console:latest \
             --tag ghcr.io/databk/rustdesk-console:$VERSION \
+            --tag ghcr.io/databk/rustdesk-console:$MAJOR_MINOR \
             --tag ghcr.io/databk/rustdesk-console:$MAJOR \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \


### PR DESCRIPTION
## Summary

- Merge two separate `docker buildx build` calls (Docker Hub + GHCR) into a single build with all tags, eliminating redundant multi-platform builds
- Add `$MAJOR.$MINOR` Docker tag (e.g., `1.2`) in release workflow alongside existing `$MAJOR` and `$VERSION` tags