### PR TITLE
feat: add logo icon above RustDesk Console in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="https://raw.githubusercontent.com/databk/rustdesk-console-web/main/public/logo.svg" alt="RustDesk Console" width="64" />
+
 # RustDesk Console
 
 **Enterprise-grade management platform for the RustDesk ecosystem**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/databk/rustdesk-console-web/main/public/logo.svg" alt="RustDesk Console" width="64" />
+<img src="https://raw.githubusercontent.com/databk/rustdesk-console-web/main/public/logo.svg" alt="RustDesk Console" width="128" />
 
 # RustDesk Console
 


### PR DESCRIPTION
## Summary

- Add logo icon above the "RustDesk Console" heading in README.md
- Logo is referenced from the rustdesk-console-web repository