### PR TITLE
chore(ci): adjust changelog-action configuration parameters

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,9 +117,9 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@v6
         with:
+          tag-prefix: ''
           skip-tag: 'true'
           skip-commit: 'true'
-          skip-on-empty: 'false'
 
       - name: Prepare release body
         env:


### PR DESCRIPTION
- Remove `skip-on-empty` option to allow changelog generation even when there are no changes.
- Set `tag-prefix` to an empty string to strip the version tag prefix, ensuring the nightly release workflow runs correctly.