### PR TITLE
refactor(auth): extract shared login logic into reusable helpers

### DIFF
--- a/src/modules/auth/auth.constants.ts
+++ b/src/modules/auth/auth.constants.ts
@@ -1,0 +1,42 @@
+/**
+ * 认证模块常量
+ * 集中管理登录相关配置，避免魔法数字和散落的字符串字面量
+ */
+
+/** JWT Token 有效期（天） */
+export const TOKEN_EXPIRY_DAYS = 30;
+
+/** TFA 登录会话有效期（分钟） */
+export const TFA_LOGIN_SESSION_EXPIRY_MINUTES = 5;
+
+/** 邮箱验证码有效期（分钟） */
+export const EMAIL_VERIFICATION_CODE_EXPIRY_MINUTES = 5;
+
+/** Passkey 会话有效期（分钟） */
+export const PASSKEY_SESSION_EXPIRY_MINUTES = 5;
+
+/** JWT 默认密钥（仅用于开发环境，生产环境必须通过 JWT_SECRET 覆盖） */
+export const JWT_DEFAULT_SECRET =
+  'rustdesk-api-secret-key-change-in-production';
+
+/**
+ * 登录类型枚举
+ * 对应 LoginDto.type 字段，标识客户端请求的登录流程
+ */
+export enum LoginType {
+  /** 标准账号密码登录 */
+  ACCOUNT = 'account',
+  /** 手机号登录 */
+  MOBILE = 'mobile',
+  /** 短信验证码登录 */
+  SMS_CODE = 'sms_code',
+  /** 邮箱验证码登录（二次验证） */
+  EMAIL_CODE = 'email_code',
+  /** TFA 验证码登录（二次验证） */
+  TFA_CODE = 'tfa_code',
+  /** Passkey 双因素认证检查 */
+  PASSKEY_CHECK = 'passkey_check',
+}
+
+/** LoginDto.type 允许的取值列表，供 class-validator @IsIn 使用 */
+export const LOGIN_TYPE_VALUES: string[] = Object.values(LoginType);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -29,6 +29,7 @@ import {
 } from './dto/passkey.dto';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
+import { extractBearerToken } from './auth.utils';
 import type { Request } from 'express';
 
 @Controller()
@@ -55,10 +56,7 @@ export class AuthController {
     @Body() logoutDto: LogoutDto,
     @Req() req: Request,
   ) {
-    const authHeader = req.headers.authorization;
-    const token = authHeader?.startsWith('Bearer ')
-      ? authHeader.substring(7)
-      : null;
+    const token = extractBearerToken(req);
 
     await this.authService.logout(userId, logoutDto, token);
     return { message: '登出成功' };

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -12,6 +12,10 @@ import {
   AuthPasskeyService,
   WebAuthnConfigService,
   TokenCleanupService,
+  AuthResponseHelper,
+  LoginSessionService,
+  AuthUserHelper,
+  AuthLoginHelper,
 } from './services';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { User } from '../user/entities/user.entity';
@@ -23,6 +27,7 @@ import { SystemSetting } from '../settings/entities/system-setting.entity';
 import { EmailModule } from '../email/email.module';
 import { LdapModule } from '../ldap/ldap.module';
 import { UserGroupModule } from '../user-group/user-group.module';
+import { JWT_DEFAULT_SECRET } from './auth.constants';
 
 /**
  * 认证模块
@@ -58,11 +63,9 @@ import { UserGroupModule } from '../user-group/user-group.module';
     UserGroupModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
-      secret:
-        process.env.JWT_SECRET ||
-        'rustdesk-api-secret-key-change-in-production',
+      secret: process.env.JWT_SECRET || JWT_DEFAULT_SECRET,
       signOptions: {
-        expiresIn: '30d', // Token 有效期 30 天
+        expiresIn: '30d',
       },
     }),
   ],
@@ -76,6 +79,10 @@ import { UserGroupModule } from '../user-group/user-group.module';
     AuthPasskeyService,
     WebAuthnConfigService,
     TokenCleanupService,
+    AuthResponseHelper,
+    LoginSessionService,
+    AuthUserHelper,
+    AuthLoginHelper,
     JwtStrategy,
   ],
   exports: [AuthService, AuthTokenService, AuthDeviceService, JwtModule],

--- a/src/modules/auth/auth.utils.ts
+++ b/src/modules/auth/auth.utils.ts
@@ -1,0 +1,15 @@
+import type { Request } from 'express';
+
+/**
+ * 从请求的 Authorization header 中提取 Bearer Token
+ *
+ * @param req Express 请求对象
+ * @returns Token 字符串，不存在或格式不正确时返回 null
+ */
+export function extractBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  return authHeader.substring(7);
+}

--- a/src/modules/auth/dto/auth.dto.ts
+++ b/src/modules/auth/dto/auth.dto.ts
@@ -7,6 +7,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { LOGIN_TYPE_VALUES } from '../auth.constants';
 
 /**
  * DeviceInfoDto
@@ -53,14 +54,7 @@ export class LoginDto {
   autoLogin?: boolean;
 
   @IsOptional()
-  @IsIn([
-    'account',
-    'mobile',
-    'sms_code',
-    'email_code',
-    'tfa_code',
-    'passkey_check',
-  ])
+  @IsIn(LOGIN_TYPE_VALUES)
   type?: string;
 
   @IsOptional()

--- a/src/modules/auth/services/auth-email.service.ts
+++ b/src/modules/auth/services/auth-email.service.ts
@@ -4,14 +4,15 @@ import {
   UnauthorizedException,
   BadRequestException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
-import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../../user/entities/user.entity';
-import { LoginSession } from '../entities/login-session.entity';
-import { LoginDto, DeviceInfoDto } from '../dto/auth.dto';
+import { LoginDto } from '../dto/auth.dto';
 import { EmailService } from '../../email/email.service';
 import { LoginResponse } from '../../../common/interfaces';
+import { EMAIL_VERIFICATION_CODE_EXPIRY_MINUTES } from '../auth.constants';
+import { LoginSessionService } from './login-session.service';
+import { AuthUserHelper } from './auth-user.helper';
+import { AuthLoginHelper, LoginContext } from './auth-login.helper';
+import { UserPayload } from './auth-response.helper';
 
 @Injectable()
 /**
@@ -26,14 +27,11 @@ import { LoginResponse } from '../../../common/interfaces';
  */
 export class AuthEmailService {
   private readonly logger = new Logger(AuthEmailService.name);
-  /** 验证码有效期（分钟） */
-  private readonly VERIFICATION_CODE_EXPIRY_MINUTES = 5;
 
   constructor(
-    @InjectRepository(LoginSession)
-    private loginSessionRepository: Repository<LoginSession>,
-    @InjectRepository(User)
-    private userRepository: Repository<User>,
+    private readonly loginSessionService: LoginSessionService,
+    private readonly authUserHelper: AuthUserHelper,
+    private readonly authLoginHelper: AuthLoginHelper,
     private emailService: EmailService,
   ) {}
 
@@ -48,7 +46,7 @@ export class AuthEmailService {
    */
   async initiateEmailVerification(
     user: User,
-    buildUserPayload: (user: User) => Record<string, unknown>,
+    buildUserPayload: (user: User) => UserPayload,
   ): Promise<LoginResponse> {
     if (!user.email) {
       throw new BadRequestException({
@@ -56,37 +54,17 @@ export class AuthEmailService {
       });
     }
 
-    // 生成6位随机验证码
     const code = Math.random().toString().slice(-6);
 
-    // 生成会话 guid（返回给客户端作为会话标识符）
-    const guid = uuidv4();
-
-    // 计算过期时间
-    const expiresAt = new Date();
-    expiresAt.setMinutes(
-      expiresAt.getMinutes() + this.VERIFICATION_CODE_EXPIRY_MINUTES,
-    );
-
-    // 删除该用户之前的验证会话
-    await this.loginSessionRepository.delete({
-      userGuid: user.guid,
-      used: false,
-    });
-
-    // 创建验证会话
-    const session = this.loginSessionRepository.create({
-      guid,
+    const session = await this.loginSessionService.createSession({
       userGuid: user.guid,
       method: 'email',
       email: user.email,
       code,
-      expiresAt,
-      used: false,
+      expiryMinutes: EMAIL_VERIFICATION_CODE_EXPIRY_MINUTES,
+      deleteExisting: true,
     });
-    await this.loginSessionRepository.save(session);
 
-    // 发送验证码邮件
     const sent = await this.emailService.sendVerificationCode(user.email, code);
     if (!sent) {
       throw new BadRequestException({
@@ -98,12 +76,11 @@ export class AuthEmailService {
       `用户 ${user.username} 登录需要邮箱验证，验证码已发送至 ${user.email}`,
     );
 
-    // 返回 guid 作为会话标识符（通过 secret 字段，保持 API 兼容）
     return {
       type: 'email_check',
       tfa_type: 'email_check',
-      secret: guid,
-      user: buildUserPayload(user) as LoginResponse['user'],
+      secret: session.guid,
+      user: buildUserPayload(user),
     };
   }
 
@@ -112,45 +89,26 @@ export class AuthEmailService {
    * 验证用户输入的验证码并完成登录流程
    *
    * @param loginDto 登录信息
-   * @param generateToken Token生成函数
-   * @param createOrUpdateDevice 设备创建/更新函数（可选）
-   * @param buildUserPayload 构建用户信息载荷的回调函数
+   * @param context 登录上下文（回调集合）
    * @returns 登录响应
    * @throws BadRequestException 当验证参数不完整时抛出
    * @throws UnauthorizedException 当验证失败或用户状态异常时抛出
    */
   async handleEmailCodeLogin(
     loginDto: LoginDto,
-    generateToken: (
-      user: User,
-      deviceId?: string,
-      deviceUuid?: string,
-    ) => Promise<string>,
-    createOrUpdateDevice?: (
-      userGuid: string,
-      deviceId?: string,
-      deviceUuid?: string,
-      deviceInfo?: DeviceInfoDto,
-    ) => Promise<void>,
-    buildUserPayload?: (user: User) => Record<string, unknown>,
+    context: LoginContext,
   ): Promise<LoginResponse> {
     const { username, verificationCode, secret, id, uuid, deviceInfo } =
       loginDto;
 
-    // 验证参数完整性
     if (!username || !verificationCode || !secret) {
       throw new BadRequestException({ error: '验证参数不完整' });
     }
 
-    // 查找验证会话（仅匹配邮箱验证方式，避免与 TFA 会话混淆）
-    // secret 字段实际是会话 guid
-    const session = await this.loginSessionRepository.findOne({
-      where: {
-        guid: secret,
-        method: 'email',
-        used: false,
-        expiresAt: MoreThan(new Date()),
-      },
+    const session = await this.loginSessionService.findByGuid(secret, {
+      method: 'email',
+      used: false,
+      checkExpiry: true,
     });
 
     if (!session) {
@@ -159,61 +117,28 @@ export class AuthEmailService {
       });
     }
 
-    // 验证验证码
     if (session.code !== verificationCode) {
       throw new UnauthorizedException({ error: '验证码错误' });
     }
 
-    // 查找用户
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.username = :username OR user.email = :email', {
-        username,
-        email: username,
-      })
-      .addSelect('user.info')
-      .addSelect('user.thirdAuthType')
-      .addSelect('user.avatar')
-      .getOne();
+    const user = await this.authUserHelper.findByUsernameOrEmail(username);
 
     if (!user || user.guid !== session.userGuid) {
       throw new UnauthorizedException({ error: '用户信息不匹配' });
     }
 
-    // 检查用户状态
     if (user.status === UserStatus.DISABLED) {
-      // UserStatus.DISABLED
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
 
-    // 标记验证会话为已使用
-    session.used = true;
-    await this.loginSessionRepository.save(session);
-
-    // 创建设备记录
-    if (createOrUpdateDevice && (id || uuid)) {
-      await createOrUpdateDevice(user.guid, id, uuid, deviceInfo);
-    }
-
-    // 生成Token
-    const token = await generateToken(user, id, uuid);
-
-    this.logger.log(`用户 ${user.username} 邮箱验证成功，已登录`);
-
-    return {
-      access_token: token,
-      type: 'access_token',
-      user: buildUserPayload
-        ? (buildUserPayload(user) as LoginResponse['user'])
-        : {
-            name: user.username,
-            email: user.email || undefined,
-            note: user.note || undefined,
-            status: user.status,
-            info: user.getUserInfo(),
-            is_admin: user.isAdmin,
-            third_auth_type: user.thirdAuthType || undefined,
-          },
-    };
+    return this.authLoginHelper.completeLogin({
+      user,
+      session,
+      context,
+      deviceId: id,
+      deviceUuid: uuid,
+      deviceInfo,
+      successMessage: `用户 ${user.username} 邮箱验证成功，已登录`,
+    });
   }
 }

--- a/src/modules/auth/services/auth-login.helper.ts
+++ b/src/modules/auth/services/auth-login.helper.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { User } from '../../user/entities/user.entity';
+import { LoginSession } from '../entities/login-session.entity';
+import { LoginResponse } from '../../../common/interfaces';
+import { DeviceInfoDto } from '../dto/auth.dto';
+import { LoginSessionService } from './login-session.service';
+import { UserPayload } from './auth-response.helper';
+
+/**
+ * 登录上下文
+ * 封装完成登录所需的三个回调，替代原先在 handleTfaLogin / handleEmailCodeLogin
+ * 中散落的三个独立回调参数
+ *
+ * - generateToken: 生成 JWT Token（deviceInfo 由上下文内部处理）
+ * - createOrUpdateDevice: 创建或更新设备绑定记录
+ * - buildUserPayload: 构建登录响应中的用户信息载荷
+ */
+export interface LoginContext {
+  generateToken: (
+    user: User,
+    deviceId?: string,
+    deviceUuid?: string,
+  ) => Promise<string>;
+  createOrUpdateDevice: (
+    userGuid: string,
+    deviceId?: string,
+    deviceUuid?: string,
+    deviceInfo?: DeviceInfoDto,
+  ) => Promise<void>;
+  buildUserPayload: (user: User) => UserPayload;
+}
+
+/** completeLogin 方法的参数 */
+export interface CompleteLoginParams {
+  /** 已通过认证的用户 */
+  user: User;
+  /** 待标记为已使用的登录会话 */
+  session: LoginSession;
+  /** 登录上下文（回调集合） */
+  context: LoginContext;
+  /** 设备 ID */
+  deviceId?: string;
+  /** 设备 UUID */
+  deviceUuid?: string;
+  /** 设备信息 */
+  deviceInfo?: DeviceInfoDto;
+  /** 成功日志消息 */
+  successMessage: string;
+}
+
+/**
+ * 认证登录助手
+ * 统一二次验证通过后的登录完成流程：
+ * 标记会话已使用 → 创建/更新设备 → 生成 Token → 构建响应
+ *
+ * 消除 AuthTfaService / AuthEmailService / AuthPasskeyService 中的重复逻辑
+ */
+@Injectable()
+export class AuthLoginHelper {
+  private readonly logger = new Logger(AuthLoginHelper.name);
+
+  constructor(private readonly loginSessionService: LoginSessionService) {}
+
+  /**
+   * 完成登录流程
+   * 在二次验证（TFA / 邮箱验证码 / Passkey）通过后调用，
+   * 统一处理会话标记、设备绑定、Token 生成和响应构建
+   */
+  async completeLogin(params: CompleteLoginParams): Promise<LoginResponse> {
+    const {
+      user,
+      session,
+      context,
+      deviceId,
+      deviceUuid,
+      deviceInfo,
+      successMessage,
+    } = params;
+
+    await this.loginSessionService.markSessionUsed(session);
+
+    if (deviceId || deviceUuid) {
+      await context.createOrUpdateDevice(
+        user.guid,
+        deviceId,
+        deviceUuid,
+        deviceInfo,
+      );
+    }
+
+    const token = await context.generateToken(user, deviceId, deviceUuid);
+
+    this.logger.log(successMessage);
+
+    return {
+      access_token: token,
+      type: 'access_token',
+      user: context.buildUserPayload(user),
+    };
+  }
+}

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
+import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import {
   generateRegistrationOptions,
@@ -27,15 +27,16 @@ import type {
 } from '@simplewebauthn/types';
 import { User, UserStatus } from '../../user/entities/user.entity';
 import { PasskeyCredential } from '../entities/passkey-credential.entity';
-import { LoginSession } from '../entities/login-session.entity';
+
 import { LoginResponse } from '../../../common/interfaces';
 import { DeviceInfoDto } from '../dto/auth.dto';
 import { WebAuthnConfigService } from './webauthn-config.service';
 import { AuthTokenService } from './auth-token.service';
 import { AuthDeviceService } from './auth-device.service';
-
-/** Passkey 会话有效期（分钟） */
-const SESSION_EXPIRY_MINUTES = 5;
+import { LoginSessionService } from './login-session.service';
+import { AuthUserHelper } from './auth-user.helper';
+import { AuthResponseHelper, UserPayload } from './auth-response.helper';
+import { AuthLoginHelper, LoginContext } from './auth-login.helper';
 
 @Injectable()
 export class AuthPasskeyService {
@@ -44,13 +45,15 @@ export class AuthPasskeyService {
   constructor(
     @InjectRepository(PasskeyCredential)
     private credentialRepository: Repository<PasskeyCredential>,
-    @InjectRepository(LoginSession)
-    private loginSessionRepository: Repository<LoginSession>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
     private readonly configService: WebAuthnConfigService,
     private readonly tokenService: AuthTokenService,
     private readonly deviceService: AuthDeviceService,
+    private readonly loginSessionService: LoginSessionService,
+    private readonly authUserHelper: AuthUserHelper,
+    private readonly authResponseHelper: AuthResponseHelper,
+    private readonly authLoginHelper: AuthLoginHelper,
   ) {}
 
   // ==================== 注册 ====================
@@ -77,7 +80,6 @@ export class AuthPasskeyService {
       throw new NotFoundException('用户不存在');
     }
 
-    // 查询已绑定的凭证，防止同一认证器重复注册
     const existingCredentials = await this.credentialRepository.find({
       where: { userGuid },
     });
@@ -87,7 +89,6 @@ export class AuthPasskeyService {
       rpID: config.rpId,
       userName: user.username,
       userDisplayName: user.displayName || user.username,
-      // 要求可发现凭证（Passkey），支持无用户名登录
       authenticatorSelection: {
         residentKey: 'required',
         userVerification: 'preferred',
@@ -100,8 +101,11 @@ export class AuthPasskeyService {
       })),
     });
 
-    // 创建临时会话存储 challenge
-    await this.createSession(userGuid, 'passkey_reg', options.challenge);
+    await this.loginSessionService.createSession({
+      userGuid,
+      method: 'passkey_reg',
+      code: options.challenge,
+    });
 
     this.logger.log(`用户 ${user.username} 发起 Passkey 注册`);
 
@@ -126,8 +130,10 @@ export class AuthPasskeyService {
       throw new BadRequestException({ error: 'Passkey 功能未启用' });
     }
 
-    // 查找注册会话获取 challenge
-    const session = await this.findValidSession(userGuid, 'passkey_reg');
+    const session = await this.loginSessionService.findValidSession(
+      userGuid,
+      'passkey_reg',
+    );
     if (!session) {
       throw new BadRequestException({
         error: '注册会话已过期，请重新发起注册',
@@ -155,7 +161,6 @@ export class AuthPasskeyService {
     const { credential, credentialDeviceType, credentialBackedUp } =
       verification.registrationInfo;
 
-    // 检查凭证是否已存在（防止重复注册）
     const existing = await this.credentialRepository.findOne({
       where: { credentialId: credential.id },
     });
@@ -163,7 +168,6 @@ export class AuthPasskeyService {
       throw new BadRequestException({ error: '该凭证已存在' });
     }
 
-    // 保存凭证
     const passkeyCredential = this.credentialRepository.create({
       guid: uuidv4(),
       userGuid,
@@ -182,8 +186,7 @@ export class AuthPasskeyService {
 
     await this.credentialRepository.save(passkeyCredential);
 
-    // 标记会话已使用
-    await this.markSessionUsed(session);
+    await this.loginSessionService.markSessionUsed(session);
 
     this.logger.log(`用户 ${userGuid} 成功绑定 Passkey 凭证`);
 
@@ -209,16 +212,14 @@ export class AuthPasskeyService {
 
     const options = await generateAuthenticationOptions({
       rpID: config.rpId,
-      // 不指定 allowCredentials，支持发现式凭证（无用户名登录）
       userVerification: 'preferred',
     });
 
-    // 创建临时会话存储 challenge，userGuid 暂为空（登录时通过凭证反查）
-    const session = await this.createSession(
-      'pending',
-      'passkey',
-      options.challenge,
-    );
+    const session = await this.loginSessionService.createSession({
+      userGuid: 'pending',
+      method: 'passkey',
+      code: options.challenge,
+    });
 
     this.logger.log(`发起 Passkey 无密码登录，会话 ${session.guid}`);
 
@@ -249,13 +250,9 @@ export class AuthPasskeyService {
       throw new BadRequestException({ error: 'Passkey 功能未启用' });
     }
 
-    // 查找会话
-    const session = await this.loginSessionRepository.findOne({
-      where: {
-        guid: secret,
-        used: false,
-        expiresAt: MoreThan(new Date()),
-      },
+    const session = await this.loginSessionService.findByGuid(secret, {
+      used: false,
+      checkExpiry: true,
     });
 
     if (!session) {
@@ -268,7 +265,6 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: '会话类型不匹配' });
     }
 
-    // 通过 credentialId 查找凭证
     const credential = await this.credentialRepository.findOne({
       where: { credentialId: response.id },
     });
@@ -277,7 +273,6 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: '未找到匹配的凭证' });
     }
 
-    // 对于双因素认证，校验凭证所属用户与会话用户一致
     if (
       session.method === 'passkey_tfa' &&
       session.userGuid !== credential.userGuid
@@ -285,7 +280,6 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: '凭证与用户不匹配' });
     }
 
-    // 查找用户
     const user = await this.userRepository.findOne({
       where: { guid: credential.userGuid },
     });
@@ -298,7 +292,6 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
 
-    // 验证认证响应
     const transports = credential.transports
       ? (JSON.parse(credential.transports) as AuthenticatorTransportFuture[])
       : undefined;
@@ -327,38 +320,26 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: 'Passkey 认证失败' });
     }
 
-    // 更新计数器（防克隆检测）
     credential.counter = verification.authenticationInfo.newCounter;
     await this.credentialRepository.save(credential);
 
-    // 标记会话已使用
-    await this.markSessionUsed(session);
+    const context: LoginContext = {
+      generateToken: (u, devId, devUuid) =>
+        this.tokenService.generateToken(u, devId, devUuid, deviceInfo),
+      createOrUpdateDevice: (userGuid, devId, devUuid, info) =>
+        this.deviceService.createOrUpdateDevice(userGuid, devId, devUuid, info),
+      buildUserPayload: (u) => this.authResponseHelper.buildUserPayload(u),
+    };
 
-    // 创建/更新设备记录
-    if (deviceId || deviceUuid) {
-      await this.deviceService.createOrUpdateDevice(
-        user.guid,
-        deviceId,
-        deviceUuid,
-        deviceInfo,
-      );
-    }
-
-    // 生成 JWT Token
-    const token = await this.tokenService.generateToken(
+    return this.authLoginHelper.completeLogin({
       user,
+      session,
+      context,
       deviceId,
       deviceUuid,
       deviceInfo,
-    );
-
-    this.logger.log(`用户 ${user.username} 通过 Passkey 登录成功`);
-
-    return {
-      access_token: token,
-      type: 'access_token',
-      user: this.buildUserPayload(user),
-    };
+      successMessage: `用户 ${user.username} 通过 Passkey 登录成功`,
+    });
   }
 
   // ==================== 双因素认证 ====================
@@ -373,14 +354,13 @@ export class AuthPasskeyService {
    */
   async initiatePasskeyTfa(
     user: User,
-    buildUserPayload: (user: User) => Record<string, unknown>,
+    buildUserPayload: (user: User) => UserPayload,
   ): Promise<LoginResponse> {
     const config = await this.configService.getConfig();
     if (!config.enabled) {
       throw new BadRequestException({ error: 'Passkey 功能未启用' });
     }
 
-    // 查找用户绑定的凭证，用于 allowCredentials
     const credentials = await this.credentialRepository.find({
       where: { userGuid: user.guid },
     });
@@ -402,25 +382,12 @@ export class AuthPasskeyService {
       userVerification: 'preferred',
     });
 
-    // 清除该用户之前未使用的会话
-    await this.loginSessionRepository.delete({
-      userGuid: user.guid,
-      used: false,
-    });
-
-    // 创建 TFA 会话
-    const expiresAt = new Date();
-    expiresAt.setMinutes(expiresAt.getMinutes() + SESSION_EXPIRY_MINUTES);
-
-    const session = this.loginSessionRepository.create({
-      guid: uuidv4(),
+    const session = await this.loginSessionService.createSession({
       userGuid: user.guid,
       method: 'passkey_tfa',
       code: options.challenge,
-      expiresAt,
-      used: false,
+      deleteExisting: true,
     });
-    await this.loginSessionRepository.save(session);
 
     this.logger.log(`用户 ${user.username} 登录需要 Passkey 双因素认证`);
 
@@ -428,7 +395,7 @@ export class AuthPasskeyService {
       type: 'passkey_check',
       secret: session.guid,
       passkey_options: options,
-      user: buildUserPayload(user) as LoginResponse['user'],
+      user: buildUserPayload(user),
     };
   }
 
@@ -461,7 +428,6 @@ export class AuthPasskeyService {
 
     await this.credentialRepository.remove(credential);
 
-    // 如果删除后没有凭证了，自动关闭 Passkey TFA
     const remaining = await this.credentialRepository.count({
       where: { userGuid },
     });
@@ -490,18 +456,16 @@ export class AuthPasskeyService {
     userGuid: string,
     enabled: boolean,
   ): Promise<{ message: string }> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.info')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withThirdAuthType: false,
+      withAvatar: false,
+    });
 
     if (!user) {
       throw new NotFoundException('用户不存在');
     }
 
     if (enabled) {
-      // 启用前检查是否已绑定凭证
       const hasCredential = await this.hasCredentials(userGuid);
       if (!hasCredential) {
         throw new BadRequestException({
@@ -532,11 +496,10 @@ export class AuthPasskeyService {
    * 检查用户是否启用了 Passkey 双因素认证
    */
   async isPasskeyTfaEnabled(userGuid: string): Promise<boolean> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.info')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withThirdAuthType: false,
+      withAvatar: false,
+    });
 
     if (!user) {
       return false;
@@ -544,73 +507,5 @@ export class AuthPasskeyService {
 
     const userInfo = user.getUserInfo();
     return !!userInfo?.other?.passkey_tfa_enabled;
-  }
-
-  // ==================== 私有辅助方法 ====================
-
-  /**
-   * 创建临时会话
-   */
-  private async createSession(
-    userGuid: string,
-    method: LoginSession['method'],
-    challenge: string,
-  ): Promise<LoginSession> {
-    const expiresAt = new Date();
-    expiresAt.setMinutes(expiresAt.getMinutes() + SESSION_EXPIRY_MINUTES);
-
-    const session = this.loginSessionRepository.create({
-      guid: uuidv4(),
-      userGuid,
-      method,
-      code: challenge,
-      expiresAt,
-      used: false,
-    });
-
-    return this.loginSessionRepository.save(session);
-  }
-
-  /**
-   * 查找有效的未使用会话
-   */
-  private async findValidSession(
-    userGuid: string,
-    method: LoginSession['method'],
-  ): Promise<LoginSession | null> {
-    return this.loginSessionRepository.findOne({
-      where: {
-        userGuid,
-        method,
-        used: false,
-        expiresAt: MoreThan(new Date()),
-      },
-      order: { createdAt: 'DESC' },
-    });
-  }
-
-  /**
-   * 标记会话已使用
-   */
-  private async markSessionUsed(session: LoginSession): Promise<void> {
-    session.used = true;
-    await this.loginSessionRepository.save(session);
-  }
-
-  /**
-   * 构建用户信息载荷
-   */
-  private buildUserPayload(user: User) {
-    return {
-      name: user.username,
-      display_name: user.displayName || undefined,
-      email: user.email || undefined,
-      note: user.note || undefined,
-      status: user.status,
-      info: user.getUserInfo(),
-      is_admin: user.isAdmin,
-      third_auth_type: user.thirdAuthType || undefined,
-      ...(user.avatar ? { avatar: user.avatar } : {}),
-    };
   }
 }

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -27,7 +27,6 @@ import type {
 } from '@simplewebauthn/types';
 import { User, UserStatus } from '../../user/entities/user.entity';
 import { PasskeyCredential } from '../entities/passkey-credential.entity';
-
 import { LoginResponse } from '../../../common/interfaces';
 import { DeviceInfoDto } from '../dto/auth.dto';
 import { WebAuthnConfigService } from './webauthn-config.service';

--- a/src/modules/auth/services/auth-response.helper.ts
+++ b/src/modules/auth/services/auth-response.helper.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '../../user/entities/user.entity';
+import { LoginResponse } from '../../../common/interfaces';
+
+/** 登录响应中的用户载荷类型（去除可选性，保证字段完整） */
+export type UserPayload = NonNullable<LoginResponse['user']>;
+
+/**
+ * 认证响应构建助手
+ * 统一构建登录响应中的用户信息载荷，消除多处重复实现
+ */
+@Injectable()
+export class AuthResponseHelper {
+  /**
+   * 构建登录响应中的用户信息载荷
+   * 用于 login / TFA / 邮箱验证码 / Passkey 等所有登录流程
+   */
+  buildUserPayload(user: User): UserPayload {
+    return {
+      name: user.username,
+      display_name: user.displayName || undefined,
+      email: user.email || undefined,
+      note: user.note || undefined,
+      status: user.status,
+      info: user.getUserInfo(),
+      is_admin: user.isAdmin,
+      third_auth_type: user.thirdAuthType || undefined,
+      ...(user.avatar ? { avatar: user.avatar } : {}),
+    };
+  }
+
+  /**
+   * 构建 currentUser 接口的响应载荷
+   * 在 buildUserPayload 基础上额外包含 verifier 字段
+   */
+  buildCurrentUserPayload(user: User): Record<string, unknown> {
+    return {
+      ...this.buildUserPayload(user),
+      verifier: user.verifier || undefined,
+    };
+  }
+}

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -6,25 +6,27 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan } from 'typeorm';
+import { Repository } from 'typeorm';
 import { authenticator } from 'otplib';
-import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../../user/entities/user.entity';
-import { LoginSession } from '../entities/login-session.entity';
-import { LoginDto, DeviceInfoDto } from '../dto/auth.dto';
+import { LoginDto } from '../dto/auth.dto';
 import { LoginResponse } from '../../../common/interfaces';
+import { TFA_LOGIN_SESSION_EXPIRY_MINUTES } from '../auth.constants';
+import { LoginSessionService } from './login-session.service';
+import { AuthUserHelper } from './auth-user.helper';
+import { AuthLoginHelper, LoginContext } from './auth-login.helper';
+import { UserPayload } from './auth-response.helper';
 
 @Injectable()
 export class AuthTfaService {
   private readonly logger = new Logger(AuthTfaService.name);
-  /** TFA 登录会话有效期（分钟） */
-  private readonly TFA_LOGIN_SESSION_EXPIRY_MINUTES = 5;
 
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
-    @InjectRepository(LoginSession)
-    private loginSessionRepository: Repository<LoginSession>,
+    private readonly loginSessionService: LoginSessionService,
+    private readonly authUserHelper: AuthUserHelper,
+    private readonly authLoginHelper: AuthLoginHelper,
   ) {}
 
   verifyTfaCode(secret: string, code: string): boolean {
@@ -43,12 +45,11 @@ export class AuthTfaService {
     userGuid: string,
     currentCode?: string,
   ): Promise<{ secret: string; otpauth_url: string }> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.tfaSecret')
-      .addSelect('user.info')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withTfaSecret: true,
+      withThirdAuthType: false,
+      withAvatar: false,
+    });
 
     if (!user) {
       throw new NotFoundException('用户不存在');
@@ -93,12 +94,11 @@ export class AuthTfaService {
     userGuid: string,
     code: string,
   ): Promise<{ message: string }> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.tfaSecret')
-      .addSelect('user.info')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withTfaSecret: true,
+      withThirdAuthType: false,
+      withAvatar: false,
+    });
 
     if (!user) {
       throw new NotFoundException('用户不存在');
@@ -138,12 +138,11 @@ export class AuthTfaService {
     userGuid: string,
     code: string,
   ): Promise<{ message: string }> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.tfaSecret')
-      .addSelect('user.info')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withTfaSecret: true,
+      withThirdAuthType: false,
+      withAvatar: false,
+    });
 
     if (!user) {
       throw new NotFoundException('用户不存在');
@@ -184,54 +183,36 @@ export class AuthTfaService {
    */
   async initiateTfaLogin(
     user: User,
-    buildUserPayload: (user: User) => Record<string, unknown>,
+    buildUserPayload: (user: User) => UserPayload,
   ): Promise<LoginResponse> {
-    // 删除该用户之前未使用的验证会话，避免会话堆积
-    await this.loginSessionRepository.delete({
-      userGuid: user.guid,
-      used: false,
-    });
-
-    const guid = uuidv4();
-    const expiresAt = new Date();
-    expiresAt.setMinutes(
-      expiresAt.getMinutes() + this.TFA_LOGIN_SESSION_EXPIRY_MINUTES,
-    );
-
-    const session = this.loginSessionRepository.create({
-      guid,
+    const session = await this.loginSessionService.createSession({
       userGuid: user.guid,
       method: 'tfa',
-      expiresAt,
-      used: false,
+      expiryMinutes: TFA_LOGIN_SESSION_EXPIRY_MINUTES,
+      deleteExisting: true,
     });
-    await this.loginSessionRepository.save(session);
 
     this.logger.log(`用户 ${user.username} 登录需要 TFA 验证，已创建会话`);
 
-    // 返回 guid 作为会话标识符（通过 secret 字段，保持 API 兼容）
     return {
       type: 'email_check',
       tfa_type: 'tfa_check',
-      secret: guid,
-      user: buildUserPayload(user) as LoginResponse['user'],
+      secret: session.guid,
+      user: buildUserPayload(user),
     };
   }
 
+  /**
+   * 处理 TFA 登录（二次验证）
+   * 验证用户提交的 TFA 验证码并完成登录流程
+   *
+   * @param loginDto 登录信息
+   * @param context 登录上下文（回调集合）
+   * @returns 登录响应
+   */
   async handleTfaLogin(
     loginDto: LoginDto,
-    generateToken: (
-      user: User,
-      deviceId?: string,
-      deviceUuid?: string,
-    ) => Promise<string>,
-    createOrUpdateDevice?: (
-      userGuid: string,
-      deviceId?: string,
-      deviceUuid?: string,
-      deviceInfo?: DeviceInfoDto,
-    ) => Promise<void>,
-    buildUserPayload?: (user: User) => Record<string, unknown>,
+    context: LoginContext,
   ): Promise<LoginResponse> {
     const { username, tfaCode, secret, id, uuid, deviceInfo } = loginDto;
 
@@ -239,14 +220,10 @@ export class AuthTfaService {
       throw new BadRequestException({ error: '双因素认证参数不完整' });
     }
 
-    // 通过会话标识符定位本次登录，secret 字段实际是会话 guid
-    const session = await this.loginSessionRepository.findOne({
-      where: {
-        guid: secret,
-        method: 'tfa',
-        used: false,
-        expiresAt: MoreThan(new Date()),
-      },
+    const session = await this.loginSessionService.findByGuid(secret, {
+      method: 'tfa',
+      used: false,
+      checkExpiry: true,
     });
 
     if (!session) {
@@ -255,21 +232,14 @@ export class AuthTfaService {
       });
     }
 
-    // 按会话绑定的用户查找，确保登录主体由服务端会话决定
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: session.userGuid })
-      .addSelect('user.tfaSecret')
-      .addSelect('user.info')
-      .addSelect('user.thirdAuthType')
-      .addSelect('user.avatar')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(session.userGuid, {
+      withTfaSecret: true,
+    });
 
     if (!user) {
       throw new UnauthorizedException({ error: '用户不存在' });
     }
 
-    // 若客户端回传了用户名，校验与会话用户一致，防止会话替换攻击
     if (username && user.username !== username && user.email !== username) {
       throw new UnauthorizedException({ error: '用户信息不匹配' });
     }
@@ -278,7 +248,6 @@ export class AuthTfaService {
       throw new UnauthorizedException({ error: '双因素认证参数无效' });
     }
 
-    // 对照服务端存储的 tfaSecret 验证 TFA 验证码
     const isValidTfa = this.verifyTfaCode(user.tfaSecret, tfaCode);
     if (!isValidTfa) {
       throw new UnauthorizedException({ error: '双因素认证验证码错误' });
@@ -288,32 +257,14 @@ export class AuthTfaService {
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
 
-    // 标记会话为已使用，防止重放
-    session.used = true;
-    await this.loginSessionRepository.save(session);
-
-    if (createOrUpdateDevice && (id || uuid)) {
-      await createOrUpdateDevice(user.guid, id, uuid, deviceInfo);
-    }
-
-    const token = await generateToken(user, id, uuid);
-
-    this.logger.log(`用户 ${user.username} TFA认证成功，已登录`);
-
-    return {
-      access_token: token,
-      type: 'access_token',
-      user: buildUserPayload
-        ? (buildUserPayload(user) as LoginResponse['user'])
-        : {
-            name: user.username,
-            email: user.email || undefined,
-            note: user.note || undefined,
-            status: user.status,
-            info: user.getUserInfo(),
-            is_admin: user.isAdmin,
-            third_auth_type: user.thirdAuthType || undefined,
-          },
-    };
+    return this.authLoginHelper.completeLogin({
+      user,
+      session,
+      context,
+      deviceId: id,
+      deviceUuid: uuid,
+      deviceInfo,
+      successMessage: `用户 ${user.username} TFA认证成功，已登录`,
+    });
   }
 }

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -7,6 +7,7 @@ import { User } from '../../user/entities/user.entity';
 import { UserToken } from '../../user/entities/user-token.entity';
 import { JwtPayload } from '../../../common/services/token.service';
 import { DeviceInfoDto } from '../dto/auth.dto';
+import { TOKEN_EXPIRY_DAYS } from '../auth.constants';
 
 export interface SessionInfo {
   jti: string;
@@ -31,9 +32,6 @@ export interface SessionInfo {
  * 包括令牌生成、验证和撤销
  */
 export class AuthTokenService {
-  /** Token有效期（天） */
-  private readonly TOKEN_EXPIRY_DAYS = 30;
-
   constructor(
     @InjectRepository(UserToken)
     private tokenRepository: Repository<UserToken>,
@@ -70,7 +68,7 @@ export class AuthTokenService {
     const token = this.jwtService.sign(payload);
 
     const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + this.TOKEN_EXPIRY_DAYS);
+    expiresAt.setDate(expiresAt.getDate() + TOKEN_EXPIRY_DAYS);
 
     const userToken = this.tokenRepository.create({
       guid: jti,

--- a/src/modules/auth/services/auth-user.helper.ts
+++ b/src/modules/auth/services/auth-user.helper.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+/** 用户查询选项，控制需要额外 select 的敏感字段 */
+export interface UserQueryOptions {
+  /** 是否查询密码字段，默认 false */
+  withPassword?: boolean;
+  /** 是否查询 TFA 密钥字段，默认 false */
+  withTfaSecret?: boolean;
+  /** 是否查询 info 字段，默认 true */
+  withInfo?: boolean;
+  /** 是否查询 thirdAuthType 字段，默认 true */
+  withThirdAuthType?: boolean;
+  /** 是否查询 avatar 字段，默认 true */
+  withAvatar?: boolean;
+}
+
+/**
+ * 认证用户查询助手
+ * 统一封装登录流程中常见的用户查询（含敏感字段 select），
+ * 消除 AuthService / AuthTfaService / AuthEmailService / AuthPasskeyService 中的重复查询构建
+ */
+@Injectable()
+export class AuthUserHelper {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * 通过 GUID 查询用户
+   * 默认包含 info、thirdAuthType、avatar 字段
+   */
+  async findByGuid(
+    guid: string,
+    options: UserQueryOptions = {},
+  ): Promise<User | null> {
+    const queryBuilder = this.userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid });
+
+    this.applySelects(queryBuilder, options);
+
+    return queryBuilder.getOne();
+  }
+
+  /**
+   * 通过用户名或邮箱查询用户
+   * 默认包含 info、thirdAuthType、avatar 字段
+   */
+  async findByUsernameOrEmail(
+    username: string,
+    options: UserQueryOptions = {},
+  ): Promise<User | null> {
+    const queryBuilder = this.userRepository
+      .createQueryBuilder('user')
+      .where('user.username = :username OR user.email = :email', {
+        username,
+        email: username,
+      });
+
+    this.applySelects(queryBuilder, options);
+
+    return queryBuilder.getOne();
+  }
+
+  /**
+   * 根据查询选项添加敏感字段的 addSelect
+   * info、thirdAuthType、avatar 默认查询；password、tfaSecret 默认不查询
+   */
+  private applySelects(
+    queryBuilder: ReturnType<Repository<User>['createQueryBuilder']>,
+    options: UserQueryOptions,
+  ): void {
+    const {
+      withPassword = false,
+      withTfaSecret = false,
+      withInfo = true,
+      withThirdAuthType = true,
+      withAvatar = true,
+    } = options;
+
+    if (withPassword) {
+      queryBuilder.addSelect('user.password');
+    }
+    if (withTfaSecret) {
+      queryBuilder.addSelect('user.tfaSecret');
+    }
+    if (withInfo) {
+      queryBuilder.addSelect('user.info');
+    }
+    if (withThirdAuthType) {
+      queryBuilder.addSelect('user.thirdAuthType');
+    }
+    if (withAvatar) {
+      queryBuilder.addSelect('user.avatar');
+    }
+  }
+}

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -10,8 +10,6 @@ import { Repository } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../../user/entities/user.entity';
-import { UserToken } from '../../user/entities/user-token.entity';
-import { Peer } from '../../../common/entities';
 import { LoginResponse } from '../../../common/interfaces';
 import {
   LoginDto,
@@ -20,8 +18,8 @@ import {
   LogoutDto,
   DeviceInfoDto,
 } from '../dto/auth.dto';
-import { LoginSession } from '../entities/login-session.entity';
-import { EmailService } from '../../email/email.service';
+import { LoginType } from '../auth.constants';
+
 import { AuthTokenService } from './auth-token.service';
 import { JwtPayload } from '../../../common/services/token.service';
 import { AuthTfaService } from './auth-tfa.service';
@@ -30,6 +28,10 @@ import { AuthDeviceService } from './auth-device.service';
 import { AuthPasskeyService } from './auth-passkey.service';
 import { LdapService } from '../../ldap/ldap.service';
 import { UserGroupService } from '../../user-group/user-group.service';
+import { AuthUserHelper } from './auth-user.helper';
+import { AuthResponseHelper } from './auth-response.helper';
+import { LoginSessionService } from './login-session.service';
+import { LoginContext } from './auth-login.helper';
 
 /**
  * 认证服务
@@ -47,13 +49,7 @@ export class AuthService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
-    @InjectRepository(UserToken)
-    private tokenRepository: Repository<UserToken>,
-    @InjectRepository(Peer)
-    private peerRepository: Repository<Peer>,
-    @InjectRepository(LoginSession)
-    private loginSessionRepository: Repository<LoginSession>,
-    private readonly emailService: EmailService,
+
     private readonly tokenService: AuthTokenService,
     private readonly tfaService: AuthTfaService,
     private readonly emailAuthService: AuthEmailService,
@@ -61,6 +57,9 @@ export class AuthService {
     private readonly passkeyService: AuthPasskeyService,
     private readonly ldapService: LdapService,
     private readonly userGroupService: UserGroupService,
+    private readonly authUserHelper: AuthUserHelper,
+    private readonly authResponseHelper: AuthResponseHelper,
+    private readonly loginSessionService: LoginSessionService,
   ) {}
 
   /**
@@ -74,7 +73,6 @@ export class AuthService {
   async register(registerDto: RegisterDto): Promise<{ message: string }> {
     const { username, email, password, note } = registerDto;
 
-    // 检查用户名或邮箱是否已被注册
     const existingUser = await this.userRepository.findOne({
       where: [{ username }, { email }],
     });
@@ -86,11 +84,9 @@ export class AuthService {
       throw new ConflictException('邮箱已被注册');
     }
 
-    // 使用bcrypt加密密码，强度为10
     const hashedPassword = await bcrypt.hash(password, 10);
     const userGroupGuid = await this.userGroupService.resolveUserGroupGuid();
 
-    // 创建新用户
     const user = this.userRepository.create({
       guid: uuidv4(),
       username,
@@ -123,109 +119,99 @@ export class AuthService {
    * @throws UnauthorizedException 当认证失败时抛出
    */
   async login(loginDto: LoginDto): Promise<LoginResponse> {
-    const { username, password, id, uuid, type } = loginDto;
+    const { type } = loginDto;
 
-    // 处理邮箱验证码登录（第二步）
-    // 兼容 RustDesk 客户端：客户端使用 type: "email_code" 提交二次验证
-    // secret 字段传递的是服务端下发的会话 guid（UUID），用于跟踪一次登录
-    // 通过会话的 method 字段区分 TFA 登录与邮箱验证码登录，
-    // 而非使用用户可控的 tfaCode 字段控制流程，避免攻击者通过操控 tfaCode 绕过验证
-    if (type === 'email_code') {
-      // type === 'email_code' 是二次验证请求，secret 必须存在
-      if (!loginDto.secret) {
-        throw new BadRequestException({ error: '缺少会话标识符' });
-      }
-      // 通过 guid（客户端通过 secret 字段传递）查找会话，由服务端会话的 method 决定路由
-      const session = await this.loginSessionRepository.findOne({
-        where: { guid: loginDto.secret, used: false },
-      });
-      if (!session) {
-        throw new UnauthorizedException({
-          error: '登录会话已过期或无效，请重新登录',
+    switch (type) {
+      case LoginType.EMAIL_CODE:
+        return this.handleEmailCodeLogin(loginDto);
+      case LoginType.SMS_CODE:
+        throw new BadRequestException({
+          error: '短信验证码登录功能正在开发中，暂时不可用',
         });
-      }
-      if (session.method === 'tfa') {
+      case LoginType.TFA_CODE:
         return this.tfaService.handleTfaLogin(
           loginDto,
-          (user, deviceId, deviceUuid) =>
-            this.tokenService.generateToken(
-              user,
-              deviceId,
-              deviceUuid,
-              loginDto.deviceInfo,
-            ),
-          (userGuid, deviceId, deviceUuid, deviceInfo) =>
-            this.deviceService.createOrUpdateDevice(
-              userGuid,
-              deviceId,
-              deviceUuid,
-              deviceInfo,
-            ),
-          (user) => this.buildUserPayload(user),
+          this.createLoginContext(loginDto),
         );
-      }
-      return this.emailAuthService.handleEmailCodeLogin(
-        loginDto,
-        (user, deviceId, deviceUuid) =>
-          this.tokenService.generateToken(
-            user,
-            deviceId,
-            deviceUuid,
-            loginDto.deviceInfo,
-          ),
-        (userGuid, deviceId, deviceUuid, deviceInfo) =>
-          this.deviceService.createOrUpdateDevice(
-            userGuid,
-            deviceId,
-            deviceUuid,
-            deviceInfo,
-          ),
-        (user) => this.buildUserPayload(user),
-      );
+      default:
+        return this.handleStandardLogin(loginDto);
+    }
+  }
+
+  /**
+   * 处理邮箱验证码登录（第二步验证）
+   * 通过会话的 method 字段区分 TFA 登录与邮箱验证码登录，
+   * 而非使用用户可控的 tfaCode 字段控制流程，避免攻击者通过操控 tfaCode 绕过验证
+   */
+  private async handleEmailCodeLogin(
+    loginDto: LoginDto,
+  ): Promise<LoginResponse> {
+    if (!loginDto.secret) {
+      throw new BadRequestException({ error: '缺少会话标识符' });
     }
 
-    // 短信验证码登录功能暂未实现
-    if (type === 'sms_code') {
-      throw new BadRequestException({
-        error: '短信验证码登录功能正在开发中，暂时不可用',
+    const session = await this.loginSessionService.findByGuid(loginDto.secret, {
+      used: false,
+    });
+
+    if (!session) {
+      throw new UnauthorizedException({
+        error: '登录会话已过期或无效，请重新登录',
       });
     }
 
-    // 处理双因素认证登录
-    if (type === 'tfa_code') {
-      return this.tfaService.handleTfaLogin(
-        loginDto,
-        (user, deviceId, deviceUuid) =>
-          this.tokenService.generateToken(
-            user,
-            deviceId,
-            deviceUuid,
-            loginDto.deviceInfo,
-          ),
-        (userGuid, deviceId, deviceUuid, deviceInfo) =>
-          this.deviceService.createOrUpdateDevice(
-            userGuid,
-            deviceId,
-            deviceUuid,
-            deviceInfo,
-          ),
-        (user) => this.buildUserPayload(user),
-      );
-    }
+    const context = this.createLoginContext(loginDto);
 
-    // 标准账号密码登录（自动检测 LDAP/本地认证）
+    if (session.method === 'tfa') {
+      return this.tfaService.handleTfaLogin(loginDto, context);
+    }
+    return this.emailAuthService.handleEmailCodeLogin(loginDto, context);
+  }
+
+  /**
+   * 处理标准账号密码登录（自动检测 LDAP/本地认证）
+   */
+  private async handleStandardLogin(
+    loginDto: LoginDto,
+  ): Promise<LoginResponse> {
+    const { username, password, id, uuid, deviceInfo } = loginDto;
+
     if (!username || !password) {
       throw new BadRequestException({ error: '用户名和密码不能为空' });
     }
 
-    // 尝试 LDAP 认证
     const ldapUser = await this.tryLdapAuthentication(username, password);
     if (ldapUser) {
-      return this.buildLoginResponse(ldapUser, id, uuid, loginDto.deviceInfo);
+      return this.buildLoginResponse(ldapUser, id, uuid, deviceInfo);
     }
 
-    // 回退到本地账号密码认证
-    return this.localLogin(username, password, id, uuid, loginDto.deviceInfo);
+    return this.localLogin(username, password, id, uuid, deviceInfo);
+  }
+
+  /**
+   * 创建登录上下文
+   * 封装 generateToken / createOrUpdateDevice / buildUserPayload 三个回调，
+   * 供二次验证（TFA / 邮箱验证码）通过后统一调用
+   */
+  private createLoginContext(loginDto: LoginDto): LoginContext {
+    return {
+      generateToken: (user, deviceId, deviceUuid) =>
+        this.tokenService.generateToken(
+          user,
+          deviceId,
+          deviceUuid,
+          loginDto.deviceInfo,
+        ),
+      createOrUpdateDevice: (userGuid, deviceId, deviceUuid, deviceInfo) =>
+        this.deviceService.createOrUpdateDevice(
+          userGuid,
+          deviceId,
+          deviceUuid,
+          deviceInfo,
+        ),
+      buildUserPayload: (user) =>
+        this.authResponseHelper.buildUserPayload(user),
+    };
   }
 
   /**
@@ -245,21 +231,17 @@ export class AuthService {
     username: string,
     password: string,
   ): Promise<User | null> {
-    // 检查是否为已关联的 LDAP 用户
     const isLinkedLdapUser = await this.ldapService.isLinkedLdapUser(username);
 
     if (isLinkedLdapUser) {
-      // 已关联的 LDAP 用户必须通过 LDAP 认证
       return this.ldapService.authenticate(username, password);
     }
 
-    // LDAP 未启用则跳过
     const ldapEnabled = await this.ldapService.isEnabled();
     if (!ldapEnabled) {
       return null;
     }
 
-    // 尝试 LDAP 认证，失败静默回退本地认证
     try {
       return await this.ldapService.authenticate(username, password);
     } catch {
@@ -284,31 +266,20 @@ export class AuthService {
     uuid?: string,
     deviceInfo?: DeviceInfoDto,
   ): Promise<LoginResponse> {
-    // 查找用户（支持用户名或邮箱登录）
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.username = :username OR user.email = :email', {
-        username,
-        email: username,
-      })
-      .addSelect('user.password')
-      .addSelect('user.tfaSecret')
-      .addSelect('user.info')
-      .addSelect('user.thirdAuthType')
-      .addSelect('user.avatar')
-      .getOne();
+    const user = await this.authUserHelper.findByUsernameOrEmail(username, {
+      withPassword: true,
+      withTfaSecret: true,
+    });
 
     if (!user) {
       throw new UnauthorizedException({ error: '用户名或密码错误' });
     }
 
-    // 验证密码
     const isPasswordValid = await bcrypt.compare(password, user.password);
     if (!isPasswordValid) {
       throw new UnauthorizedException({ error: '用户名或密码错误' });
     }
 
-    // 检查用户状态
     if (user.status === UserStatus.DISABLED) {
       throw new UnauthorizedException({ error: '账户已被禁用' });
     }
@@ -317,35 +288,30 @@ export class AuthService {
       throw new UnauthorizedException({ error: '请先验证邮箱' });
     }
 
-    // 检查是否需要邮箱验证（用户设置中开启了email_verification）
     const userInfo = user.getUserInfo();
+    const buildPayload = (u: User) =>
+      this.authResponseHelper.buildUserPayload(u);
+
     if (userInfo?.email_verification && user.email) {
-      return this.emailAuthService.initiateEmailVerification(user, (u) =>
-        this.buildUserPayload(u),
+      return this.emailAuthService.initiateEmailVerification(
+        user,
+        buildPayload,
       );
     }
 
-    // 检查是否需要 Passkey 双因素认证
     if (userInfo?.other?.passkey_tfa_enabled) {
       const hasPasskey = await this.passkeyService.hasCredentials(user.guid);
       if (hasPasskey) {
-        return this.passkeyService.initiatePasskeyTfa(user, (u) =>
-          this.buildUserPayload(u),
-        );
+        return this.passkeyService.initiatePasskeyTfa(user, buildPayload);
       }
     }
 
-    // 检查是否需要双因素认证
-    // localLogin 仅在首次登录（账号密码）时调用，二次验证通过 tfa_code/email_code 类型处理
-    // 因此这里始终发起 TFA 流程，无需检查 secret
     if (user.tfaSecret) {
-      return this.tfaService.initiateTfaLogin(user, (u) =>
-        this.buildUserPayload(u),
-      );
+      return this.tfaService.initiateTfaLogin(user, buildPayload);
     } else if (userInfo?.other?.tfa_enforce) {
       return {
         type: 'enforce_tfa',
-        user: this.buildUserPayload(user),
+        user: buildPayload(user),
       };
     }
 
@@ -361,7 +327,6 @@ export class AuthService {
     uuid?: string,
     deviceInfo?: DeviceInfoDto,
   ): Promise<LoginResponse> {
-    // 创建或更新设备记录
     if (id || uuid) {
       await this.deviceService.createOrUpdateDevice(
         user.guid,
@@ -371,7 +336,6 @@ export class AuthService {
       );
     }
 
-    // 生成JWT Token
     const token = await this.tokenService.generateToken(
       user,
       id,
@@ -384,24 +348,7 @@ export class AuthService {
     return {
       access_token: token,
       type: 'access_token',
-      user: this.buildUserPayload(user),
-    };
-  }
-
-  /**
-   * 构建用户信息载荷
-   */
-  private buildUserPayload(user: User) {
-    return {
-      name: user.username,
-      display_name: user.displayName || undefined,
-      email: user.email || undefined,
-      note: user.note || undefined,
-      status: user.status,
-      info: user.getUserInfo(),
-      is_admin: user.isAdmin,
-      third_auth_type: user.thirdAuthType || undefined,
-      ...(user.avatar ? { avatar: user.avatar } : {}),
+      user: this.authResponseHelper.buildUserPayload(user),
     };
   }
 
@@ -418,30 +365,13 @@ export class AuthService {
     userGuid: string,
     _currentUserDto?: CurrentUserDto,
   ): Promise<Record<string, unknown>> {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userGuid })
-      .addSelect('user.info')
-      .addSelect('user.thirdAuthType')
-      .addSelect('user.avatar')
-      .getOne();
+    const user = await this.authUserHelper.findByGuid(userGuid);
 
     if (!user) {
       throw new UnauthorizedException('用户不存在');
     }
 
-    return {
-      name: user.username,
-      display_name: user.displayName || undefined,
-      email: user.email || undefined,
-      note: user.note || undefined,
-      verifier: user.verifier || undefined,
-      status: user.status,
-      info: user.getUserInfo(),
-      is_admin: user.isAdmin,
-      third_auth_type: user.thirdAuthType || undefined,
-      ...(user.avatar ? { avatar: user.avatar } : {}),
-    };
+    return this.authResponseHelper.buildCurrentUserPayload(user);
   }
 
   /**
@@ -464,17 +394,13 @@ export class AuthService {
   ): Promise<void> {
     const { id, uuid } = logoutDto;
 
-    // 优先撤销当前token
     if (token) {
       await this.tokenService.revokeToken(userGuid, token);
     }
 
-    // 如果提供了设备信息，撤销该设备的所有token并解除设备绑定
     if (id || uuid) {
-      // 撤销该设备的所有token
       await this.tokenService.revokeDeviceTokens(userGuid, id, uuid);
 
-      // 解除设备与用户的绑定（安全关键：防止退出登录后设备仍关联用户）
       if (uuid) {
         await this.deviceService.unbindDevice(userGuid, uuid);
       }

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -19,7 +19,6 @@ import {
   DeviceInfoDto,
 } from '../dto/auth.dto';
 import { LoginType } from '../auth.constants';
-
 import { AuthTokenService } from './auth-token.service';
 import { JwtPayload } from '../../../common/services/token.service';
 import { AuthTfaService } from './auth-tfa.service';
@@ -49,7 +48,6 @@ export class AuthService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
-
     private readonly tokenService: AuthTokenService,
     private readonly tfaService: AuthTfaService,
     private readonly emailAuthService: AuthEmailService,

--- a/src/modules/auth/services/index.ts
+++ b/src/modules/auth/services/index.ts
@@ -6,3 +6,7 @@ export { AuthDeviceService } from './auth-device.service';
 export { AuthPasskeyService } from './auth-passkey.service';
 export { WebAuthnConfigService } from './webauthn-config.service';
 export { TokenCleanupService } from './token-cleanup.service';
+export { AuthResponseHelper } from './auth-response.helper';
+export { LoginSessionService } from './login-session.service';
+export { AuthUserHelper } from './auth-user.helper';
+export { AuthLoginHelper } from './auth-login.helper';

--- a/src/modules/auth/services/login-session.service.ts
+++ b/src/modules/auth/services/login-session.service.ts
@@ -1,0 +1,133 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { LoginSession } from '../entities/login-session.entity';
+import { PASSKEY_SESSION_EXPIRY_MINUTES } from '../auth.constants';
+
+/** 创建登录会话的参数 */
+export interface CreateSessionParams {
+  /** 所属用户 GUID */
+  userGuid: string;
+  /** 验证方式 */
+  method: LoginSession['method'];
+  /** 验证码 / challenge（邮箱验证码或 WebAuthn challenge） */
+  code?: string;
+  /** 待验证邮箱（仅邮箱验证方式） */
+  email?: string;
+  /** 会话有效期（分钟），默认使用 Passkey 会话有效期常量 */
+  expiryMinutes?: number;
+  /** 是否先删除该用户未使用的会话，默认 false */
+  deleteExisting?: boolean;
+}
+
+/**
+ * 登录会话服务
+ * 统一管理登录二次验证会话的创建、查找、标记和清理，
+ * 消除 AuthTfaService / AuthEmailService / AuthPasskeyService 中的重复逻辑
+ */
+@Injectable()
+export class LoginSessionService {
+  constructor(
+    @InjectRepository(LoginSession)
+    private readonly loginSessionRepository: Repository<LoginSession>,
+  ) {}
+
+  /**
+   * 创建登录会话
+   * 可选先清除该用户之前未使用的会话，避免会话堆积
+   */
+  async createSession(params: CreateSessionParams): Promise<LoginSession> {
+    const {
+      userGuid,
+      method,
+      code,
+      email,
+      expiryMinutes = PASSKEY_SESSION_EXPIRY_MINUTES,
+      deleteExisting = false,
+    } = params;
+
+    if (deleteExisting) {
+      await this.deleteUserUnusedSessions(userGuid);
+    }
+
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + expiryMinutes);
+
+    const session = this.loginSessionRepository.create({
+      guid: uuidv4(),
+      userGuid,
+      method,
+      email,
+      code,
+      expiresAt,
+      used: false,
+    });
+
+    return this.loginSessionRepository.save(session);
+  }
+
+  /**
+   * 查找用户指定方式下最新且有效的未使用会话
+   */
+  async findValidSession(
+    userGuid: string,
+    method: LoginSession['method'],
+  ): Promise<LoginSession | null> {
+    return this.loginSessionRepository.findOne({
+      where: {
+        userGuid,
+        method,
+        used: false,
+        expiresAt: MoreThan(new Date()),
+      },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * 通过会话 GUID 查找会话
+   * 可选按 method / used / 有效期 过滤
+   */
+  async findByGuid(
+    guid: string,
+    options: {
+      method?: LoginSession['method'];
+      used?: boolean;
+      checkExpiry?: boolean;
+    } = {},
+  ): Promise<LoginSession | null> {
+    const where: Record<string, unknown> = { guid };
+
+    if (options.method !== undefined) {
+      where.method = options.method;
+    }
+    if (options.used !== undefined) {
+      where.used = options.used;
+    }
+    if (options.checkExpiry) {
+      where.expiresAt = MoreThan(new Date());
+    }
+
+    return this.loginSessionRepository.findOne({ where });
+  }
+
+  /**
+   * 标记会话为已使用，防止重放攻击
+   */
+  async markSessionUsed(session: LoginSession): Promise<void> {
+    session.used = true;
+    await this.loginSessionRepository.save(session);
+  }
+
+  /**
+   * 删除指定用户所有未使用的会话
+   * 在发起新的二次验证前调用，避免会话堆积
+   */
+  async deleteUserUnusedSessions(userGuid: string): Promise<void> {
+    await this.loginSessionRepository.delete({
+      userGuid,
+      used: false,
+    });
+  }
+}

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -4,6 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { AuthService } from '../services/auth.service';
 import { JwtPayload } from '../../../common/services/token.service';
+import { JWT_DEFAULT_SECRET } from '../auth.constants';
 
 /**
  * 从请求中提取 JWT Token
@@ -51,10 +52,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   private readonly logger = new Logger(JwtStrategy.name);
 
   constructor(private authService: AuthService) {
-    const jwtSecret =
-      process.env.JWT_SECRET || 'rustdesk-api-secret-key-change-in-production';
+    const jwtSecret = process.env.JWT_SECRET || JWT_DEFAULT_SECRET;
 
-    // 检查是否使用默认 JWT 密钥
     if (!process.env.JWT_SECRET) {
       const logger = new Logger('JwtStrategy');
       logger.warn(

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -340,10 +340,6 @@ describe('User group integration', () => {
     const defaultGroup = await userGroupService.initializeStorage();
     const authService = new AuthService(
       userRepository,
-      dataSource.getRepository(UserToken),
-      undefined as never,
-      undefined as never,
-      undefined as never,
       undefined as never,
       undefined as never,
       undefined as never,
@@ -351,6 +347,9 @@ describe('User group integration', () => {
       undefined as never,
       undefined as never,
       userGroupService,
+      undefined as never,
+      undefined as never,
+      undefined as never,
     );
     const databaseInitService = new DatabaseInitService(
       userRepository,


### PR DESCRIPTION
## Summary

Refactor login-related code in the auth module to follow NestJS best practices, improving readability and extracting reusable logic.

## Changes

### New shared helpers/services
- **`AuthResponseHelper`** — unifies `buildUserPayload`, which was previously duplicated in `AuthService`, `AuthPasskeyService`, and as a fallback in `AuthTfaService`/`AuthEmailService`
- **`LoginSessionService`** — centralizes login session CRUD (create, find, mark-used, delete), eliminating duplication across `AuthTfaService`, `AuthEmailService`, `AuthPasskeyService`
- **`AuthUserHelper`** — unifies user queries with sensitive-field selects (`password`, `tfaSecret`, `info`, `thirdAuthType`, `avatar`)
- **`AuthLoginHelper` + `LoginContext`** — encapsulates the three callbacks (`generateToken`, `createOrUpdateDevice`, `buildUserPayload`) previously passed individually to `handleTfaLogin`/`handleEmailCodeLogin`, and unifies the `completeLogin` flow (mark session → create device → generate token → build response)
- **`auth.utils.ts`** — extracts Bearer token parsing from `AuthController.logout`
- **`auth.constants.ts`** — centralizes constants (`TOKEN_EXPIRY_DAYS`, session expiry minutes, `JWT_DEFAULT_SECRET`) and introduces `LoginType` enum

### Refactored services
- **`AuthService.login`** — replaced if-else chain with `switch`-based routing; extracted `handleEmailCodeLogin`, `handleStandardLogin`, `createLoginContext` private methods; removed unused `emailService` dependency
- **`AuthTfaService`** — reuses `LoginSessionService`, `AuthUserHelper`, `AuthLoginHelper`; `handleTfaLogin` now takes a single `LoginContext` instead of three callbacks
- **`AuthEmailService`** — same treatment as `AuthTfaService`
- **`AuthPasskeyService`** — reuses all new helpers; removed private `buildUserPayload`/`createSession`/`findValidSession`/`markSessionUsed` methods

### Result
- **263 insertions, 567 deletions** across modified files — net reduction in code volume
- All lint, build, and tests pass
- No changes to external API behavior or database schema