### PR TITLE
refactor(update-check): replace on-demand check with hourly scheduled caching

### DIFF
--- a/src/modules/update-check/dto/update-check.dto.ts
+++ b/src/modules/update-check/dto/update-check.dto.ts
@@ -1,21 +1,9 @@
-import { IsString, IsOptional } from 'class-validator';
-
 /**
  * 更新通道
  */
 export enum UpdateChannel {
   STABLE = 'stable',
   NIGHTLY = 'nightly',
-}
-
-/**
- * 检查更新请求 DTO
- * 前端在请求时携带自己的版本号
- */
-export class CheckUpdateDto {
-  @IsOptional()
-  @IsString()
-  frontend_version?: string;
 }
 
 /**

--- a/src/modules/update-check/update-check.controller.ts
+++ b/src/modules/update-check/update-check.controller.ts
@@ -1,36 +1,29 @@
 import {
   Controller,
-  Post,
-  Body,
+  Get,
+  Query,
   UseGuards,
-  HttpCode,
-  HttpStatus,
 } from '@nestjs/common';
-import { Throttle } from '@nestjs/throttler';
 import { AdminGuard } from '../../common/guards/admin.guard';
 import { UpdateCheckService } from './update-check.service';
-import { CheckUpdateDto } from './dto/update-check.dto';
 
 /**
  * 更新检查控制器
  *
  * 端点：
- * - POST /api/update-check - 检查更新（管理员），前端通过请求体携带版本号
+ * - GET /api/update-check - 获取缓存的更新检查结果（管理员）
  */
 @Controller('update-check')
 export class UpdateCheckController {
   constructor(private readonly updateCheckService: UpdateCheckService) {}
 
   /**
-   * 检查更新
-   * 收集系统信息并调用第三方 API，返回更新结果
-   * 前端在请求体中携带自己的版本号，无需单独的上报接口
+   * 获取缓存的更新检查结果
+   * 后端每1小时自动检查更新，前端请求时直接返回缓存
    */
-  @Post()
+  @Get()
   @UseGuards(AdminGuard)
-  @HttpCode(HttpStatus.OK)
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
-  async checkUpdate(@Body() dto: CheckUpdateDto) {
-    return this.updateCheckService.checkUpdate(dto.frontend_version);
+  async checkUpdate(@Query('frontend_version') frontendVersion?: string) {
+    return this.updateCheckService.checkUpdate(frontendVersion);
   }
 }

--- a/src/modules/update-check/update-check.service.ts
+++ b/src/modules/update-check/update-check.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Between } from 'typeorm';
+import { Interval } from '@nestjs/schedule';
 import * as si from 'systeminformation';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -19,14 +20,23 @@ import {
 } from './dto/update-check.dto';
 
 const UPDATE_API_URL = 'https://api.databk.top/v1/update/check';
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+const EMPTY_RESPONSE: UpdateCheckResponse = {
+  backend: { has_update: false },
+  frontend: { has_update: false },
+};
 
 /**
  * 更新检查服务
- * 收集系统信息和业务统计，调用更新检查 API 检查更新
+ * 每1小时自动检查更新并缓存结果，前端请求时直接返回缓存
  */
 @Injectable()
-export class UpdateCheckService {
+export class UpdateCheckService implements OnModuleInit {
   private readonly logger = new Logger(UpdateCheckService.name);
+  private cachedResult: UpdateCheckResponse = { ...EMPTY_RESPONSE };
+  private lastKnownFrontendVersion?: string;
+  private isChecking = false;
 
   constructor(
     @InjectRepository(SystemSetting)
@@ -41,15 +51,31 @@ export class UpdateCheckService {
     private readonly connectionAuditRepository: Repository<ConnectionAudit>,
   ) {}
 
-  /**
-   * 检查更新
-   * 收集信息 → 调用更新检查 API → 返回结果
-   * @param frontendVersion 前端版本号，由前端在请求时携带
-   */
+  async onModuleInit() {
+    await this.fetchUpdate();
+  }
+
+  @Interval(UPDATE_CHECK_INTERVAL_MS)
+  async handleScheduledUpdateCheck() {
+    await this.fetchUpdate();
+  }
+
   async checkUpdate(frontendVersion?: string): Promise<UpdateCheckResponse> {
-    const payload = await this.buildRequestPayload(frontendVersion);
+    if (frontendVersion) {
+      this.lastKnownFrontendVersion = frontendVersion;
+    }
+    return this.cachedResult;
+  }
+
+  private async fetchUpdate(): Promise<void> {
+    if (this.isChecking) return;
+    this.isChecking = true;
 
     try {
+      const payload = await this.buildRequestPayload(
+        this.lastKnownFrontendVersion,
+      );
+
       const response = await fetch(UPDATE_API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -61,21 +87,17 @@ export class UpdateCheckService {
         this.logger.warn(
           `Update check API returned ${response.status}: ${response.statusText}`,
         );
-        return {
-          backend: { has_update: false },
-          frontend: { has_update: false },
-        };
+        return;
       }
 
       const data = (await response.json()) as UpdateCheckResponse;
-      return data;
+      this.cachedResult = data;
+      this.logger.log('Update check completed successfully');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Update check failed: ${message}`);
-      return {
-        backend: { has_update: false },
-        frontend: { has_update: false },
-      };
+    } finally {
+      this.isChecking = false;
     }
   }
 

--- a/src/modules/update-check/update-check.service.ts
+++ b/src/modules/update-check/update-check.service.ts
@@ -52,6 +52,7 @@ export class UpdateCheckService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
+    await this.loadPersistedFrontendVersion();
     await this.fetchUpdate();
   }
 
@@ -61,10 +62,24 @@ export class UpdateCheckService implements OnModuleInit {
   }
 
   async checkUpdate(frontendVersion?: string): Promise<UpdateCheckResponse> {
-    if (frontendVersion) {
+    if (frontendVersion && frontendVersion !== this.lastKnownFrontendVersion) {
       this.lastKnownFrontendVersion = frontendVersion;
+      await this.setSetting(
+        'update_check',
+        'frontend_version',
+        frontendVersion,
+      );
     }
     return this.cachedResult;
+  }
+
+  private async loadPersistedFrontendVersion(): Promise<void> {
+    const setting = await this.settingRepository.findOne({
+      where: { key: 'frontend_version', category: 'update_check' },
+    });
+    if (setting) {
+      this.lastKnownFrontendVersion = setting.value;
+    }
   }
 
   private async fetchUpdate(): Promise<void> {


### PR DESCRIPTION
## Summary

- Replace on-demand update check with a scheduled hourly background check using `@Interval` decorator
- Cache the update check result in the service; frontend requests now return cached data instantly
- Change endpoint from `POST /api/update-check` to `GET /api/update-check` (frontend_version as query param)
- Remove `CheckUpdateDto` and `Throttle`/`HttpCode` decorators no longer needed
- Add `OnModuleInit` to trigger initial check on startup, preventing empty cache on first request