### PR TITLE
fix: resolve dual throttler guard causing 429 on heartbeat endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { DeviceThrottlerGuard } from './common/guards/device-throttler.guard';
 import { HeartbeatModule } from './modules/heartbeat/heartbeat.module';
 import { AddressBookModule } from './modules/address-book/address-book.module';
 import { AuditModule } from './modules/audit/audit.module';
@@ -132,7 +133,7 @@ import { UserGroup } from './modules/user-group/entities/user-group.entity';
   providers: [
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: DeviceThrottlerGuard,
     },
     {
       provide: APP_GUARD,

--- a/src/modules/heartbeat/heartbeat.controller.ts
+++ b/src/modules/heartbeat/heartbeat.controller.ts
@@ -1,9 +1,8 @@
-import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { HeartbeatService } from './heartbeat.service';
 import { HeartbeatDto } from './dto/heartbeat.dto';
 import { Public } from '../auth/decorators/public.decorator';
-import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard';
 
 /**
  * 心跳控制器
@@ -13,7 +12,6 @@ import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard
  * - POST /api/heartbeat - 接收设备心跳
  */
 @Controller('heartbeat')
-@UseGuards(DeviceThrottlerGuard)
 export class HeartbeatController {
   constructor(private readonly HeartbeatService: HeartbeatService) {}
 

--- a/src/modules/sysinfo/sysinfo.controller.ts
+++ b/src/modules/sysinfo/sysinfo.controller.ts
@@ -1,9 +1,8 @@
-import { Controller, Post, Body, UseGuards, Header } from '@nestjs/common';
+import { Controller, Post, Body, Header } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { SysinfoService } from './sysinfo.service';
 import { SysinfoDto } from './dto/sysinfo.dto';
 import { Public } from '../auth/decorators/public.decorator';
-import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard';
 
 /**
  * 系统信息控制器
@@ -13,7 +12,6 @@ import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard
  * - POST /api/sysinfo - 提交系统信息
  */
 @Controller()
-@UseGuards(DeviceThrottlerGuard)
 export class SysinfoController {
   constructor(private readonly sysinfoService: SysinfoService) {}
 


### PR DESCRIPTION
## Summary

- Fix frequent 429 errors on `/heartbeat` endpoint caused by dual throttler guard execution
- The global `ThrottlerGuard` (IP-based, 100/min) and controller-level `DeviceThrottlerGuard` (device-based, 10/min) both executed independently on heartbeat/sysinfo endpoints
- When multiple devices share the same IP (NAT/proxy), the global IP-based limit was exceeded even though per-device limits were not violated

## Root Cause

In `app.module.ts`, `ThrottlerGuard` was registered as a global guard using IP-based tracking. Meanwhile, `HeartbeatController` and `SysinfoController` additionally applied `DeviceThrottlerGuard` via `@UseGuards()`. Since NestJS executes both global and controller-level guards, the global IP-based throttler counted all device requests under the same IP key, easily exceeding the 100/min limit with multiple devices behind NAT.

## Changes

- Replace global `ThrottlerGuard` with `DeviceThrottlerGuard` in `app.module.ts` — it uses device ID as tracker when available and falls back to IP address, maintaining backward compatibility
- Remove redundant `@UseGuards(DeviceThrottlerGuard)` from `heartbeat.controller.ts` and `sysinfo.controller.ts`

## Test Plan

- [ ] Verify single device heartbeat works without 429 (4 req/min < 10 req/min limit)
- [ ] Verify multiple devices behind same IP no longer trigger 429 from IP-based global limit
- [ ] Verify non-device endpoints still have IP-based rate limiting via DeviceThrottlerGuard fallback
- [ ] Verify sysinfo endpoint rate limiting still works correctly