### PR TITLE
feat(heartbeat): add verbose logging for heartbeat endpoint and rate limiting

### DIFF
--- a/src/common/guards/device-throttler.guard.ts
+++ b/src/common/guards/device-throttler.guard.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { Injectable, Logger } from '@nestjs/common';
+import { ThrottlerGuard, ThrottlerRequest } from '@nestjs/throttler';
 
 /**
  * 设备限流守卫
@@ -9,6 +9,8 @@ import { ThrottlerGuard } from '@nestjs/throttler';
  */
 @Injectable()
 export class DeviceThrottlerGuard extends ThrottlerGuard {
+  private readonly logger = new Logger(DeviceThrottlerGuard.name);
+
   /**
    * 重写 getTracker 方法，从请求体提取设备ID
    *
@@ -21,6 +23,8 @@ export class DeviceThrottlerGuard extends ThrottlerGuard {
    * 返回格式：{设备ID}:{HTTP方法}:{路由路径}
    */
   protected getTracker(req: Record<string, unknown>): Promise<string> {
+    this.logger.debug(`[getTracker] 开始提取tracker, method=${String(req.method)}, url=${String(req.url ?? '')}`);
+
     // 1. 尝试从请求体提取设备ID
     const body = req.body as Record<string, unknown> | undefined;
     const rawDeviceId = body?.id || body?.uuid || body?.deviceId;
@@ -34,9 +38,9 @@ export class DeviceThrottlerGuard extends ThrottlerGuard {
     if (deviceId) {
       // 使用设备ID作为tracker
       const route = req.route as { path?: string } | undefined;
-      return Promise.resolve(
-        `${deviceId}:${String(req.method)}:${route?.path ?? ''}`,
-      );
+      const tracker = `${deviceId}:${String(req.method)}:${route?.path ?? ''}`;
+      this.logger.debug(`[getTracker] 使用设备ID作为tracker: ${tracker}`);
+      return Promise.resolve(tracker);
     }
 
     // 2. 如果没有设备ID，降级使用IP地址（防止恶意请求）
@@ -49,6 +53,44 @@ export class DeviceThrottlerGuard extends ThrottlerGuard {
           ? String(rawIp)
           : 'unknown';
     const route = req.route as { path?: string } | undefined;
-    return Promise.resolve(`${ip}:${String(req.method)}:${route?.path ?? ''}`);
+    const tracker = `${ip}:${String(req.method)}:${route?.path ?? ''}`;
+    this.logger.warn(`[getTracker] 未找到设备ID，降级使用IP作为tracker: ${tracker}`);
+    return Promise.resolve(tracker);
+  }
+
+  protected async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {
+    const { context, limit, ttl } = requestProps;
+    const req = context.switchToHttp().getRequest<Record<string, unknown>>();
+    const body = req.body as Record<string, unknown> | undefined;
+    const deviceId = body?.id || body?.uuid || body?.deviceId || 'unknown';
+    const route = req.route as { path?: string } | undefined;
+    const path = route?.path ?? String(req.url ?? '');
+    const method = String(req.method);
+
+    this.logger.debug(
+      `[handleRequest] 限流检查开始: device=${deviceId}, method=${method}, path=${path}, limit=${limit}, ttl=${ttl}ms`,
+    );
+
+    try {
+      const result = await super.handleRequest(requestProps);
+
+      if (result) {
+        this.logger.log(
+          `[handleRequest] 限流通过: device=${deviceId}, method=${method}, path=${path}, limit=${limit}, ttl=${ttl}ms`,
+        );
+      } else {
+        this.logger.warn(
+          `[handleRequest] 限流拒绝: device=${deviceId}, method=${method}, path=${path}, limit=${limit}, ttl=${ttl}ms`,
+        );
+      }
+
+      return result;
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `[handleRequest] 限流检查异常: device=${deviceId}, method=${method}, path=${path}, error=${msg}`,
+      );
+      throw error;
+    }
   }
 }

--- a/src/modules/heartbeat/heartbeat.controller.ts
+++ b/src/modules/heartbeat/heartbeat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Logger } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { HeartbeatService } from './heartbeat.service';
 import { HeartbeatDto } from './dto/heartbeat.dto';
@@ -15,6 +15,8 @@ import { DeviceThrottlerGuard } from '../../common/guards/device-throttler.guard
 @Controller('heartbeat')
 @UseGuards(DeviceThrottlerGuard)
 export class HeartbeatController {
+  private readonly logger = new Logger(HeartbeatController.name);
+
   constructor(private readonly HeartbeatService: HeartbeatService) {}
 
   /**
@@ -39,6 +41,36 @@ export class HeartbeatController {
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @Post()
   receiveHeartbeat(@Body() HeartbeatDto: HeartbeatDto) {
-    return this.HeartbeatService.handleHeartbeat(HeartbeatDto);
+    this.logger.log(
+      `[receiveHeartbeat] 收到心跳请求: id=${HeartbeatDto.id}, uuid=${HeartbeatDto.uuid}, ver=${HeartbeatDto.ver}, modified_at=${HeartbeatDto.modified_at}, conns=${JSON.stringify(HeartbeatDto.conns ?? [])}`,
+    );
+
+    const startTime = Date.now();
+
+    try {
+      const result = this.HeartbeatService.handleHeartbeat(HeartbeatDto);
+
+      result.then((res) => {
+        const elapsed = Date.now() - startTime;
+        this.logger.log(
+          `[receiveHeartbeat] 心跳处理完成: uuid=${HeartbeatDto.uuid}, elapsed=${elapsed}ms, code=${res.code}`,
+        );
+      }).catch((err: unknown) => {
+        const elapsed = Date.now() - startTime;
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `[receiveHeartbeat] 心跳处理失败: uuid=${HeartbeatDto.uuid}, elapsed=${elapsed}ms, error=${msg}`,
+        );
+      });
+
+      return result;
+    } catch (error: unknown) {
+      const elapsed = Date.now() - startTime;
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `[receiveHeartbeat] 心跳处理同步异常: uuid=${HeartbeatDto.uuid}, elapsed=${elapsed}ms, error=${msg}`,
+      );
+      throw error;
+    }
   }
 }

--- a/src/modules/heartbeat/heartbeat.service.ts
+++ b/src/modules/heartbeat/heartbeat.service.ts
@@ -21,11 +21,17 @@ export class HeartbeatService {
   ) {}
 
   async handleHeartbeat(data: HeartbeatDto) {
-    this.logger.debug(`收到心跳数据: id=${data.id}, uuid=${data.uuid}`);
+    this.logger.log(
+      `[handleHeartbeat] 开始处理心跳: id=${data.id}, uuid=${data.uuid}, ver=${data.ver}, modified_at=${data.modified_at}, conns=${JSON.stringify(data.conns ?? [])}`,
+    );
 
     const existingPeer = await this.peerRepository.findOne({
       where: { uuid: data.uuid },
     });
+
+    this.logger.debug(
+      `[handleHeartbeat] 设备查询结果: uuid=${data.uuid}, exists=${!!existingPeer}`,
+    );
 
     if (existingPeer) {
       await this.peerRepository.update(
@@ -37,7 +43,9 @@ export class HeartbeatService {
           lastHeartbeat: new Date(),
         },
       );
-      this.logger.debug(`设备 ${data.uuid} 心跳已更新`);
+      this.logger.log(
+        `[handleHeartbeat] 设备心跳已更新: uuid=${data.uuid}, id=${data.id}, ver=${data.ver}`,
+      );
     } else {
       const peer = this.peerRepository.create({
         id: data.id,
@@ -47,24 +55,45 @@ export class HeartbeatService {
         lastHeartbeat: new Date(),
       });
       await this.peerRepository.save(peer);
-      this.logger.log(`新设备 ${data.uuid} 已注册`);
+      this.logger.log(
+        `[handleHeartbeat] 新设备已注册: uuid=${data.uuid}, id=${data.id}, ver=${data.ver}`,
+      );
     }
 
     if (data.conns !== undefined) {
+      this.logger.debug(
+        `[handleHeartbeat] 开始同步活跃连接: uuid=${data.uuid}, conns=${JSON.stringify(data.conns)}`,
+      );
       await this.syncActiveConnections(data.uuid, data.conns);
+      this.logger.debug(
+        `[handleHeartbeat] 开始处理断开连接: uuid=${data.uuid}, currentConns=${JSON.stringify(data.conns)}`,
+      );
       this.disconnectStoreService.removeDisconnected(data.uuid, data.conns);
+      this.logger.debug(
+        `[handleHeartbeat] 断开连接处理完成: uuid=${data.uuid}`,
+      );
+    } else {
+      this.logger.debug(
+        `[handleHeartbeat] 心跳未携带conns字段，跳过连接同步: uuid=${data.uuid}`,
+      );
     }
 
     const disconnect = this.disconnectStoreService.getPendingDisconnects(
       data.uuid,
+    );
+    this.logger.debug(
+      `[handleHeartbeat] 待断开连接查询: uuid=${data.uuid}, pendingDisconnects=${JSON.stringify(disconnect)}`,
     );
 
     const strategyResult = await this.resolveStrategy(
       data.uuid,
       data.modified_at,
     );
+    this.logger.debug(
+      `[handleHeartbeat] 策略解析结果: uuid=${data.uuid}, hasStrategy=${!!strategyResult}${strategyResult ? `, modified_at=${strategyResult.modified_at}` : ''}`,
+    );
 
-    return {
+    const result = {
       code: 200,
       message: '心跳接收成功',
       ...(disconnect.length > 0 ? { disconnect } : {}),
@@ -79,6 +108,12 @@ export class HeartbeatService {
         device_id: data.id,
       },
     };
+
+    this.logger.log(
+      `[handleHeartbeat] 心跳处理完成: uuid=${data.uuid}, code=${result.code}, hasDisconnect=${disconnect.length > 0}, hasStrategy=${!!strategyResult}`,
+    );
+
+    return result;
   }
 
   async getActiveConnectionIds(deviceUuid: string): Promise<number[]> {
@@ -97,26 +132,43 @@ export class HeartbeatService {
     modified_at: number;
   } | null> {
     try {
+      this.logger.debug(
+        `[resolveStrategy] 开始解析策略: uuid=${deviceUuid}, clientModifiedAt=${clientModifiedAt}`,
+      );
+
       const strategy =
         await this.strategyService.findStrategyForDevice(deviceUuid);
       if (!strategy) {
+        this.logger.debug(
+          `[resolveStrategy] 设备无关联策略: uuid=${deviceUuid}`,
+        );
         return null;
       }
+
+      this.logger.debug(
+        `[resolveStrategy] 找到策略: uuid=${deviceUuid}, strategyUpdatedAt=${strategy.updatedAt.getTime()}, clientModifiedAt=${clientModifiedAt}, needsUpdate=${strategy.updatedAt.getTime() > clientModifiedAt}`,
+      );
 
       if (strategy.updatedAt.getTime() > clientModifiedAt) {
         const configOptions: Record<string, string> = JSON.parse(
           strategy.configOptions || '{}',
         ) as Record<string, string>;
+        this.logger.log(
+          `[resolveStrategy] 策略需更新: uuid=${deviceUuid}, configKeys=${Object.keys(configOptions).join(',')}`,
+        );
         return {
           config_options: configOptions,
           modified_at: strategy.updatedAt.getTime(),
         };
       }
 
+      this.logger.debug(
+        `[resolveStrategy] 策略无需更新: uuid=${deviceUuid}, 客户端已是最新`,
+      );
       return null;
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.logger.warn(`设备 ${deviceUuid} 策略解析失败: ${msg}`);
+      this.logger.warn(`[resolveStrategy] 策略解析失败: uuid=${deviceUuid}, error=${msg}`);
       return null;
     }
   }
@@ -125,6 +177,18 @@ export class HeartbeatService {
     deviceUuid: string,
     conns: number[],
   ): Promise<void> {
+    this.logger.debug(
+      `[syncActiveConnections] 开始同步: uuid=${deviceUuid}, newConns=${JSON.stringify(conns)}`,
+    );
+
+    const existingConns = await this.activeConnectionRepository.find({
+      where: { deviceUuid },
+      select: ['connId'],
+    });
+    this.logger.debug(
+      `[syncActiveConnections] 当前数据库连接: uuid=${deviceUuid}, existingCount=${existingConns.length}, existingConnIds=${JSON.stringify(existingConns.map((c) => c.connId))}`,
+    );
+
     await this.activeConnectionRepository.delete({ deviceUuid });
 
     if (conns.length > 0) {
@@ -135,8 +199,13 @@ export class HeartbeatService {
         }),
       );
       await this.activeConnectionRepository.save(entities);
+      this.logger.log(
+        `[syncActiveConnections] 连接已同步: uuid=${deviceUuid}, count=${conns.length}, connIds=${JSON.stringify(conns)}`,
+      );
+    } else {
+      this.logger.log(
+        `[syncActiveConnections] 清空所有连接: uuid=${deviceUuid}, previousCount=${existingConns.length}`,
+      );
     }
-
-    this.logger.debug(`设备 ${deviceUuid} 活跃连接已同步: ${conns.length} 个`);
   }
 }

--- a/src/modules/heartbeat/services/disconnect-store.service.ts
+++ b/src/modules/heartbeat/services/disconnect-store.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 /**
  * 断开连接内存存储服务
@@ -6,6 +6,8 @@ import { Injectable } from '@nestjs/common';
  */
 @Injectable()
 export class DisconnectStoreService {
+  private readonly logger = new Logger(DisconnectStoreService.name);
+
   /**
    * key: 设备UUID, value: 需要断开的连接ID集合
    */
@@ -17,16 +19,32 @@ export class DisconnectStoreService {
    * @param connIds 需要断开的连接ID列表
    */
   addPendingDisconnects(deviceUuid: string, connIds: number[]): void {
-    if (connIds.length === 0) return;
+    if (connIds.length === 0) {
+      this.logger.debug(
+        `[addPendingDisconnects] 空列表，跳过: uuid=${deviceUuid}`,
+      );
+      return;
+    }
 
     const existing = this.store.get(deviceUuid);
     if (existing) {
+      const before = existing.size;
       for (const connId of connIds) {
         existing.add(connId);
       }
+      this.logger.log(
+        `[addPendingDisconnects] 追加断开连接: uuid=${deviceUuid}, added=${connIds.length}, before=${before}, after=${existing.size}, connIds=${JSON.stringify(connIds)}`,
+      );
     } else {
       this.store.set(deviceUuid, new Set(connIds));
+      this.logger.log(
+        `[addPendingDisconnects] 新增断开连接: uuid=${deviceUuid}, connIds=${JSON.stringify(connIds)}`,
+      );
     }
+
+    this.logger.debug(
+      `[addPendingDisconnects] 当前store状态: totalDevices=${this.store.size}`,
+    );
   }
 
   /**
@@ -37,7 +55,11 @@ export class DisconnectStoreService {
    */
   getPendingDisconnects(deviceUuid: string): number[] {
     const pending = this.store.get(deviceUuid);
-    return pending ? Array.from(pending) : [];
+    const result = pending ? Array.from(pending) : [];
+    this.logger.debug(
+      `[getPendingDisconnects] 查询待断开连接: uuid=${deviceUuid}, count=${result.length}${result.length > 0 ? `, connIds=${JSON.stringify(result)}` : ''}`,
+    );
+    return result;
   }
 
   /**
@@ -48,19 +70,34 @@ export class DisconnectStoreService {
    */
   removeDisconnected(deviceUuid: string, currentConns: number[]): void {
     const pending = this.store.get(deviceUuid);
-    if (!pending || pending.size === 0) return;
+    if (!pending || pending.size === 0) {
+      this.logger.debug(
+        `[removeDisconnected] 无待断开连接: uuid=${deviceUuid}`,
+      );
+      return;
+    }
 
+    const beforeSize = pending.size;
     const currentSet = new Set(currentConns);
+    const removed: number[] = [];
     for (const connId of pending) {
       // 客户端不再上报该连接，说明已断开
       if (!currentSet.has(connId)) {
+        removed.push(connId);
         pending.delete(connId);
       }
     }
 
+    this.logger.log(
+      `[removeDisconnected] 清理已断开连接: uuid=${deviceUuid}, removed=${removed.length}${removed.length > 0 ? `, removedConnIds=${JSON.stringify(removed)}` : ''}, before=${beforeSize}, after=${pending.size}, currentConns=${JSON.stringify(currentConns)}`,
+    );
+
     // 如果待断开列表为空，清理 Map 条目
     if (pending.size === 0) {
       this.store.delete(deviceUuid);
+      this.logger.debug(
+        `[removeDisconnected] 待断开列表已清空，移除设备条目: uuid=${deviceUuid}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add detailed logging to `DeviceThrottlerGuard` including `getTracker` (device ID extraction, IP fallback) and `handleRequest` (rate limit check start/pass/reject/error)
- Add request entry/completion/error logging with elapsed time to `HeartbeatController.receiveHeartbeat`
- Enhance `HeartbeatService.handleHeartbeat` with verbose logs for device lookup, update/create, connection sync, disconnect handling, and strategy resolution
- Add structured logging to `DisconnectStoreService` for add/get/remove operations with before/after state tracking

## Changes

| File | Changes |
|------|---------|
| `src/common/guards/device-throttler.guard.ts` | Added `Logger`, `handleRequest` override with rate limit pass/reject/error logging, enhanced `getTracker` with tracker resolution logging |
| `src/modules/heartbeat/heartbeat.controller.ts` | Added `Logger`, request entry/exit/error logging with elapsed time measurement |
| `src/modules/heartbeat/heartbeat.service.ts` | Enhanced all methods with structured `[methodName]` prefix logs, added device existence check, connection sync detail, strategy resolution detail logging |
| `src/modules/heartbeat/services/disconnect-store.service.ts` | Added `Logger`, structured logging for all store operations with state tracking |