### PR TITLE
fix: use fuzzy search for device group name filter

### DIFF
--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -76,7 +76,9 @@ export class DeviceGroupService {
         .take(pageSize);
 
       if (name) {
-        queryBuilder = queryBuilder.andWhere('dg.name = :name', { name });
+        queryBuilder = queryBuilder.andWhere('dg.name LIKE :name', {
+          name: `%${name}%`,
+        });
       }
 
       const [groups, total] = await queryBuilder.getManyAndCount();
@@ -106,7 +108,9 @@ export class DeviceGroupService {
       .take(pageSize);
 
     if (name) {
-      queryBuilder = queryBuilder.andWhere('dg.name = :name', { name });
+      queryBuilder = queryBuilder.andWhere('dg.name LIKE :name', {
+        name: `%${name}%`,
+      });
     }
 
     const [groups, total] = await queryBuilder.getManyAndCount();


### PR DESCRIPTION
## Summary
- Change device group name filter from exact match (`dg.name = :name`) to fuzzy search (`dg.name LIKE :name`) in `getAccessibleDeviceGroups` method
- Applies to both admin and regular user query branches