### PR TITLE
refactor(settings): consolidate env vars into general settings API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,22 +4,25 @@ PORT=3000
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-change-in-production
 
-# Default Admin Account (will be created on first run)
-ADMIN_USERNAME=databk
-ADMIN_EMAIL=databk@github.com
-ADMIN_PASSWORD=databk
-
 # Database Configuration (SQLite by default)
-# For PostgreSQL or MySQL, modify the TypeORM config in app.module.ts
+# Path to the SQLite database file
+DB_PATH=rustdesk-console.db
 
-# OIDC Configuration
-# The base URL for OIDC callback, defaults to http://localhost:3000
-# OIDC_REDIRECT_URI=http://localhost:3000
+# Nexus build artifact storage path (optional, uses default if empty)
+# NEXUS_STORAGE_PATH=
 
-# Console URL (for invitation links)
-# CONSOLE_URL=http://localhost:3000
+# Application version (injected at build time, optional override)
+# APP_VERSION=
 
-# Web Frontend URLs (comma-separated)
-# Allowed URLs for OIDC web login callbackUrl parameter
-# Example: WEB_FRONTEND_URLS=http://localhost:5173,https://admin.example.com
-WEB_FRONTEND_URLS=http://localhost:5173
+# ---------------------------------------------------------------------------
+# The following are managed via the settings/general API (stored in the
+# database, editable from the frontend settings page), no longer env vars:
+#   site.frontendUrl   - replaces CONSOLE_URL / WEB_FRONTEND_URLS / WEBAUTHN_RP_ORIGINS
+#   site.backendUrl    - replaces OIDC_REDIRECT_URI (falls back to frontendUrl)
+#   webauthn.enabled   - defaults to true, auto-disabled if frontendUrl is unset
+#   webauthn.rpName    - WebAuthn relying party display name
+#   watermarkEnabled   - console watermark toggle
+# ---------------------------------------------------------------------------
+
+# Default admin account (databk / databk) is created on first run.
+# Change the password immediately after first login.

--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,12 @@
 # Server Configuration
-PORT=3000
+# PORT=3000
 
 # JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-change-in-production
+# JWT_SECRET=rustdesk-api-secret-key-change-in-production
 
 # Database Configuration (SQLite by default)
 # Path to the SQLite database file
-DB_PATH=rustdesk-console.db
+# DB_PATH=rustdesk-console.db
 
 # Nexus build artifact storage path (optional, uses default if empty)
-# NEXUS_STORAGE_PATH=
-
-# Application version (injected at build time, optional override)
-# APP_VERSION=
-
-# ---------------------------------------------------------------------------
-# The following are managed via the settings/general API (stored in the
-# database, editable from the frontend settings page), no longer env vars:
-#   site.frontendUrl   - replaces CONSOLE_URL / WEB_FRONTEND_URLS / WEBAUTHN_RP_ORIGINS
-#   site.backendUrl    - replaces OIDC_REDIRECT_URI (falls back to frontendUrl)
-#   webauthn.enabled   - defaults to true, auto-disabled if frontendUrl is unset
-#   webauthn.rpName    - WebAuthn relying party display name
-#   watermarkEnabled   - console watermark toggle
-# ---------------------------------------------------------------------------
-
-# Default admin account (databk / databk) is created on first run.
-# Change the password immediately after first login.
+# NEXUS_STORAGE_PATH=./data/nexus-builds

--- a/src/database/database-init.service.ts
+++ b/src/database/database-init.service.ts
@@ -50,16 +50,13 @@ export class DatabaseInitService implements OnModuleInit {
       return;
     }
 
-    const adminUsername = process.env.ADMIN_USERNAME || 'databk';
-    const adminEmail = process.env.ADMIN_EMAIL || 'databk@github.com';
-    const adminPassword = process.env.ADMIN_PASSWORD || 'databk';
+    const adminUsername = 'databk';
+    const adminEmail = 'databk@github.com';
+    const adminPassword = 'databk';
 
-    // 检查是否使用默认密码
-    if (!process.env.ADMIN_PASSWORD) {
-      this.logger.warn(
-        'WARNING: Using default admin password "databk". Please set ADMIN_PASSWORD environment variable in production!',
-      );
-    }
+    this.logger.warn(
+      'WARNING: Using default admin password "databk". Please change it immediately after first login!',
+    );
 
     const admin = this.userRepository.create({
       guid: uuidv4(),

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -23,10 +23,10 @@ import { UserToken } from '../user/entities/user-token.entity';
 import { Peer } from '../../common/entities';
 import { LoginSession } from './entities/login-session.entity';
 import { PasskeyCredential } from './entities/passkey-credential.entity';
-import { SystemSetting } from '../settings/entities/system-setting.entity';
 import { EmailModule } from '../email/email.module';
 import { LdapModule } from '../ldap/ldap.module';
 import { UserGroupModule } from '../user-group/user-group.module';
+import { SettingsModule } from '../settings/settings.module';
 import { JWT_DEFAULT_SECRET } from './auth.constants';
 
 /**
@@ -56,11 +56,11 @@ import { JWT_DEFAULT_SECRET } from './auth.constants';
       Peer,
       LoginSession,
       PasskeyCredential,
-      SystemSetting,
     ]),
     EmailModule,
     LdapModule,
     UserGroupModule,
+    SettingsModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       secret: process.env.JWT_SECRET || JWT_DEFAULT_SECRET,

--- a/src/modules/auth/services/webauthn-config.service.ts
+++ b/src/modules/auth/services/webauthn-config.service.ts
@@ -1,12 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { SystemSetting } from '../../settings/entities/system-setting.entity';
-
-const RP_ID_KEY = 'webauthn.rpId';
-const RP_NAME_KEY = 'webauthn.rpName';
-const RP_ORIGINS_KEY = 'webauthn.rpOrigins';
-const ENABLED_KEY = 'webauthn.enabled';
+import { GeneralSettingsService } from '../../settings/services/general-settings.service';
 
 export interface WebAuthnConfig {
   rpId: string;
@@ -17,9 +10,10 @@ export interface WebAuthnConfig {
 
 /**
  * WebAuthn 配置服务
- * 从 system_settings 表读取 RP 配置，支持环境变量回退
+ * 从 general settings 读取站点地址与 WebAuthn 开关，推导 RP 配置
  *
- * 管理员配置接口由后续单独实现，当前通过环境变量或直接写入数据库配置
+ * - rpId / rpOrigins 从 site.frontendUrl 自动推导
+ * - enabled 默认 true，但 site.frontendUrl 未配置时自动降级为 false 并告警
  */
 @Injectable()
 export class WebAuthnConfigService {
@@ -29,13 +23,11 @@ export class WebAuthnConfigService {
   private readonly CACHE_TTL_MS = 60_000;
 
   constructor(
-    @InjectRepository(SystemSetting)
-    private readonly settingRepository: Repository<SystemSetting>,
+    private readonly generalSettingsService: GeneralSettingsService,
   ) {}
 
   /**
    * 获取 WebAuthn RP 配置
-   * 优先从数据库读取，未配置时回退到环境变量
    */
   async getConfig(): Promise<WebAuthnConfig> {
     if (
@@ -45,34 +37,26 @@ export class WebAuthnConfigService {
       return this.cachedConfig;
     }
 
-    const settings = await this.settingRepository.find({
-      where: {
-        key: [RP_ID_KEY, RP_NAME_KEY, RP_ORIGINS_KEY, ENABLED_KEY] as never,
-      },
-    });
-    const values = new Map(settings.map((s) => [s.key, s.value]));
+    const site = await this.generalSettingsService.getSiteSettings();
+    const webauthn = await this.generalSettingsService.getWebAuthnSettings();
 
-    const rpId =
-      values.get(RP_ID_KEY) || process.env.WEBAUTHN_RP_ID || 'localhost';
+    const frontendUrl = site.frontendUrl;
+    const { rpId, rpOrigins } = this.deriveRpFromFrontendUrl(frontendUrl);
 
-    const rpName =
-      values.get(RP_NAME_KEY) ||
-      process.env.WEBAUTHN_RP_NAME ||
-      'RustDesk Console';
+    let enabled = webauthn.enabled;
+    if (enabled && !frontendUrl) {
+      this.logger.warn(
+        'WebAuthn is enabled but site.frontendUrl is not configured. Disabling WebAuthn until the frontend URL is set in general settings.',
+      );
+      enabled = false;
+    }
 
-    const rpOriginsStr =
-      values.get(RP_ORIGINS_KEY) ||
-      process.env.WEBAUTHN_RP_ORIGINS ||
-      'http://localhost:3000';
-    const rpOrigins = rpOriginsStr.startsWith('[')
-      ? (JSON.parse(rpOriginsStr) as string[])
-      : rpOriginsStr.split(',').map((s) => s.trim());
-
-    const enabledStr =
-      values.get(ENABLED_KEY) || process.env.WEBAUTHN_ENABLED || 'false';
-    const enabled = enabledStr === 'true';
-
-    this.cachedConfig = { rpId, rpName, rpOrigins, enabled };
+    this.cachedConfig = {
+      rpId,
+      rpName: webauthn.rpName,
+      rpOrigins,
+      enabled,
+    };
     this.lastCacheTime = Date.now();
 
     return this.cachedConfig;
@@ -93,5 +77,24 @@ export class WebAuthnConfigService {
   invalidateCache(): void {
     this.cachedConfig = null;
     this.lastCacheTime = 0;
+  }
+
+  private deriveRpFromFrontendUrl(frontendUrl: string): {
+    rpId: string;
+    rpOrigins: string[];
+  } {
+    if (!frontendUrl) {
+      return { rpId: 'localhost', rpOrigins: ['http://localhost:3000'] };
+    }
+
+    try {
+      const url = new URL(frontendUrl);
+      return { rpId: url.hostname, rpOrigins: [url.origin] };
+    } catch {
+      this.logger.warn(
+        `Failed to parse site.frontendUrl "${frontendUrl}" as URL, falling back to localhost for WebAuthn RP.`,
+      );
+      return { rpId: 'localhost', rpOrigins: ['http://localhost:3000'] };
+    }
   }
 }

--- a/src/modules/nexus/nexus.service.ts
+++ b/src/modules/nexus/nexus.service.ts
@@ -547,7 +547,7 @@ export class NexusService implements OnModuleInit {
     path: string,
     options: RequestInit = {},
   ): Promise<Response> {
-    const url = `${this.configService.get<string>('NEXUS_BASE_URL', NEXUS_BASE_URL)}${path}`;
+    const url = `${NEXUS_BASE_URL}${path}`;
     return fetch(url, options);
   }
 }

--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -9,7 +9,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ConfigService } from '@nestjs/config';
+
 import type { Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -17,6 +17,7 @@ import { OidcService } from '../services/oidc.service';
 import { OidcAuthRequestDto } from '../dto/oidc.dto';
 import { Public } from '../../auth/decorators/public.decorator';
 import { resolveAssetPath } from '../../../common/utils/runtime-paths';
+import { GeneralSettingsService } from '../../settings/services/general-settings.service';
 
 /**
  * HTML特殊字符转义，防止XSS攻击
@@ -48,7 +49,7 @@ export class OidcController {
 
   constructor(
     private readonly oidcService: OidcService,
-    private readonly configService: ConfigService,
+    private readonly generalSettingsService: GeneralSettingsService,
   ) {
     this.successHtml = fs.readFileSync(
       resolveAssetPath(
@@ -126,12 +127,10 @@ export class OidcController {
   @Get('oidc/callback')
   async handleCallback(@Req() req: Request, @Res() res: Response) {
     try {
-      // 使用配置的OIDC_REDIRECT_URI构建回调URL，避免依赖可被伪造的Host头
-      const baseUrl = this.configService.get<string>(
-        'OIDC_REDIRECT_URI',
-        'http://localhost:3000',
-      );
-      const callbackUrl = `${baseUrl}${req.originalUrl}`;
+      // 使用配置的后端地址构建回调URL，避免依赖可被伪造的Host头
+      const { effectiveBackendUrl } =
+        await this.generalSettingsService.getSiteSettings();
+      const callbackUrl = `${effectiveBackendUrl}${req.originalUrl}`;
 
       const result = await this.oidcService.handleCallback(callbackUrl);
 

--- a/src/modules/oidc/controllers/oidc.controller.ts
+++ b/src/modules/oidc/controllers/oidc.controller.ts
@@ -9,7 +9,6 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-
 import type { Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/modules/oidc/oidc.module.ts
+++ b/src/modules/oidc/oidc.module.ts
@@ -10,12 +10,14 @@ import { OidcAuthState } from './entities/oidc-auth-state.entity';
 import { User } from '../user/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
 import { UserGroupModule } from '../user-group/user-group.module';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([OidcProvider, OidcAuthState, User]),
     AuthModule,
     UserGroupModule,
+    SettingsModule,
   ],
   controllers: [OidcController, OidcAdminController],
   providers: [OidcService, OidcAdminService, OidcAuthStateCleanupService],

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -4,7 +4,7 @@ import {
   BadRequestException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
@@ -23,6 +23,7 @@ import { LoginResponse } from '../../../common/interfaces';
 import { AuthTokenService } from '../../auth/services/auth-token.service';
 import { AuthDeviceService } from '../../auth/services/auth-device.service';
 import { UserGroupService } from '../../user-group/user-group.service';
+import { GeneralSettingsService } from '../../settings/services/general-settings.service';
 
 /**
  * OIDC配置接口
@@ -121,44 +122,34 @@ export class OidcService {
     private userRepository: Repository<User>,
     private authTokenService: AuthTokenService,
     private deviceService: AuthDeviceService,
-    private configService: ConfigService,
+    private readonly generalSettingsService: GeneralSettingsService,
     private readonly userGroupService: UserGroupService,
   ) {}
 
   /**
-   * 验证前端回调URL是否在白名单中
-   * 通过环境变量 WEB_FRONTEND_URLS 配置白名单（逗号分隔）
+   * 验证前端回调URL是否在允许的站点地址范围内
+   * 通过 general settings 的 site.frontendUrl 配置允许的前端地址
    *
    * @param callbackUrl 前端回调URL
-   * @returns 是否在白名单中
+   * @returns 是否允许
    */
-  private isCallbackUrlAllowed(callbackUrl: string): boolean {
-    const allowedUrls = this.configService
-      .get<string>('WEB_FRONTEND_URLS', '')
-      .split(',')
-      .map((url) => url.trim())
-      .filter((url) => url.length > 0);
+  private async isCallbackUrlAllowed(callbackUrl: string): Promise<boolean> {
+    const { frontendUrl } = await this.generalSettingsService.getSiteSettings();
 
-    if (allowedUrls.length === 0) {
+    if (!frontendUrl) {
       this.logger.warn(
-        'WEB_FRONTEND_URLS environment variable is not configured or empty',
+        'site.frontendUrl is not configured, OIDC callback URL validation rejected all callbacks',
       );
       return false;
     }
 
     try {
       const callbackUrlObj = new URL(callbackUrl);
-      return allowedUrls.some((allowedUrl) => {
-        try {
-          const allowedUrlObj = new URL(allowedUrl);
-          return (
-            callbackUrlObj.origin === allowedUrlObj.origin &&
-            callbackUrlObj.pathname.startsWith(allowedUrlObj.pathname)
-          );
-        } catch {
-          return false;
-        }
-      });
+      const allowedUrlObj = new URL(frontendUrl);
+      return (
+        callbackUrlObj.origin === allowedUrlObj.origin &&
+        callbackUrlObj.pathname.startsWith(allowedUrlObj.pathname)
+      );
     } catch {
       return false;
     }
@@ -213,9 +204,9 @@ export class OidcService {
     // 验证并保存前端回调URL
     let frontendRedirectUrl: string | null = null;
     if (callbackUrl) {
-      if (!this.isCallbackUrlAllowed(callbackUrl)) {
+      if (!(await this.isCallbackUrlAllowed(callbackUrl))) {
         throw new BadRequestException(
-          'callbackUrl 不在允许的白名单中，请检查 WEB_FRONTEND_URLS 环境变量配置',
+          'callbackUrl 不在允许的站点地址范围内，请检查 general settings 中的 site.frontendUrl 配置',
         );
       }
       frontendRedirectUrl = callbackUrl;
@@ -240,7 +231,9 @@ export class OidcService {
     );
 
     // 构建回调URL
-    const redirectUri = `${this.configService.get<string>('OIDC_REDIRECT_URI', 'http://localhost:3000')}/api/oidc/callback`;
+    const { effectiveBackendUrl } =
+      await this.generalSettingsService.getSiteSettings();
+    const redirectUri = `${effectiveBackendUrl}/api/oidc/callback`;
 
     // 保存授权状态
     const authState = this.authStateRepository.create({

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -4,7 +4,6 @@ import {
   BadRequestException,
   UnauthorizedException,
 } from '@nestjs/common';
-
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/modules/settings/dto/general-settings.dto.ts
+++ b/src/modules/settings/dto/general-settings.dto.ts
@@ -1,10 +1,47 @@
-import { IsBoolean } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+export class SiteSettingsDto {
+  @IsOptional()
+  @IsString()
+  frontendUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  backendUrl?: string;
+}
+
+export class WebAuthnSettingsDto {
+  @IsBoolean()
+  enabled: boolean;
+
+  @IsOptional()
+  @IsString()
+  rpName?: string;
+}
 
 export class GeneralSettingsDto {
   watermarkEnabled: boolean;
+  site: SiteSettingsDto;
+  webauthn: WebAuthnSettingsDto;
 }
 
 export class UpdateGeneralSettingsDto {
   @IsBoolean()
   watermarkEnabled: boolean;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SiteSettingsDto)
+  site?: SiteSettingsDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WebAuthnSettingsDto)
+  webauthn?: WebAuthnSettingsDto;
 }

--- a/src/modules/settings/general-settings.service.spec.ts
+++ b/src/modules/settings/general-settings.service.spec.ts
@@ -10,6 +10,12 @@ import { SystemSetting } from './entities/system-setting.entity';
 import { GeneralSettingsController } from './general-settings.controller';
 import { GeneralSettingsService } from './services/general-settings.service';
 
+const DEFAULT_SETTINGS = {
+  watermarkEnabled: true,
+  site: { frontendUrl: '', backendUrl: '' },
+  webauthn: { enabled: true, rpName: 'RustDesk Console' },
+};
+
 describe('GeneralSettingsService', () => {
   let dataSource: DataSource;
   let repository: Repository<SystemSetting>;
@@ -34,9 +40,7 @@ describe('GeneralSettingsService', () => {
   });
 
   it('returns a compatible default for missing or malformed values', async () => {
-    await expect(service.getSettings()).resolves.toEqual({
-      watermarkEnabled: true,
-    });
+    await expect(service.getSettings()).resolves.toEqual(DEFAULT_SETTINGS);
 
     await repository.save([
       repository.create({
@@ -46,9 +50,7 @@ describe('GeneralSettingsService', () => {
       }),
     ]);
 
-    await expect(service.getSettings()).resolves.toEqual({
-      watermarkEnabled: true,
-    });
+    await expect(service.getSettings()).resolves.toEqual(DEFAULT_SETTINGS);
   });
 
   it('stores the watermark setting and returns its effective value', async () => {
@@ -57,13 +59,48 @@ describe('GeneralSettingsService', () => {
         watermarkEnabled: false,
       }),
     ).resolves.toEqual({
+      ...DEFAULT_SETTINGS,
       watermarkEnabled: false,
     });
 
     await expect(service.getSettings()).resolves.toEqual({
+      ...DEFAULT_SETTINGS,
       watermarkEnabled: false,
     });
-    await expect(repository.count()).resolves.toBe(1);
+    await expect(repository.count()).resolves.toBe(5);
+  });
+
+  it('persists site and webauthn settings and reads them back', async () => {
+    await service.updateSettings({
+      watermarkEnabled: true,
+      site: { frontendUrl: 'https://admin.example.com', backendUrl: '' },
+      webauthn: { enabled: false, rpName: 'Custom RP' },
+    });
+
+    const settings = await service.getSettings();
+    expect(settings.site.frontendUrl).toBe('https://admin.example.com');
+    expect(settings.site.backendUrl).toBe('');
+    expect(settings.webauthn.enabled).toBe(false);
+    expect(settings.webauthn.rpName).toBe('Custom RP');
+  });
+
+  it('resolves effective backend url with fallback chain', async () => {
+    await service.updateSettings({
+      watermarkEnabled: true,
+      site: { frontendUrl: 'https://front.example.com', backendUrl: '' },
+    });
+    const site = await service.getSiteSettings();
+    expect(site.effectiveBackendUrl).toBe('https://front.example.com');
+
+    await service.updateSettings({
+      watermarkEnabled: true,
+      site: {
+        frontendUrl: 'https://front.example.com',
+        backendUrl: 'https://back.example.com',
+      },
+    });
+    const site2 = await service.getSiteSettings();
+    expect(site2.effectiveBackendUrl).toBe('https://back.example.com');
   });
 });
 
@@ -78,6 +115,21 @@ describe('general settings HTTP contract', () => {
 
     await expect(validate(valid)).resolves.toHaveLength(0);
     await expect(validate(invalid)).resolves.not.toHaveLength(0);
+  });
+
+  it('validates nested site and webauthn payloads', async () => {
+    const valid = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      site: { frontendUrl: 'https://a.example.com', backendUrl: '' },
+      webauthn: { enabled: true, rpName: 'RP' },
+    });
+    await expect(validate(valid)).resolves.toHaveLength(0);
+
+    const invalidWebauthn = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      webauthn: { enabled: 'yes' },
+    });
+    await expect(validate(invalidWebauthn)).resolves.not.toHaveLength(0);
   });
 
   it('keeps reads public and updates administrator-only', () => {

--- a/src/modules/settings/services/general-settings.service.ts
+++ b/src/modules/settings/services/general-settings.service.ts
@@ -9,6 +9,23 @@ import { SystemSetting } from '../entities/system-setting.entity';
 
 const CATEGORY = 'general';
 const WATERMARK_ENABLED_KEY = 'general.watermarkEnabled';
+const SITE_FRONTEND_URL_KEY = 'general.siteFrontendUrl';
+const SITE_BACKEND_URL_KEY = 'general.siteBackendUrl';
+const WEBAUTHN_ENABLED_KEY = 'general.webauthnEnabled';
+const WEBAUTHN_RP_NAME_KEY = 'general.webauthnRpName';
+
+const DEFAULT_FRONTEND_URL = '';
+const DEFAULT_BACKEND_URL = '';
+const DEFAULT_RP_NAME = 'RustDesk Console';
+const FALLBACK_URL = 'http://localhost:3000';
+
+const ALL_KEYS = [
+  WATERMARK_ENABLED_KEY,
+  SITE_FRONTEND_URL_KEY,
+  SITE_BACKEND_URL_KEY,
+  WEBAUTHN_ENABLED_KEY,
+  WEBAUTHN_RP_NAME_KEY,
+];
 
 @Injectable()
 export class GeneralSettingsService {
@@ -19,36 +36,98 @@ export class GeneralSettingsService {
   ) {}
 
   async getSettings(): Promise<GeneralSettingsDto> {
-    const settings = await this.settingRepository.find({
-      where: { key: In([WATERMARK_ENABLED_KEY]) },
-    });
-    const values = new Map(
-      settings.map((setting) => [setting.key, setting.value]),
-    );
+    const values = await this.readValues(ALL_KEYS);
 
     return {
       watermarkEnabled: this.readWatermarkEnabled(
         values.get(WATERMARK_ENABLED_KEY),
       ),
+      site: {
+        frontendUrl: values.get(SITE_FRONTEND_URL_KEY) ?? DEFAULT_FRONTEND_URL,
+        backendUrl: values.get(SITE_BACKEND_URL_KEY) ?? DEFAULT_BACKEND_URL,
+      },
+      webauthn: {
+        enabled: this.readWebAuthnEnabled(values.get(WEBAUTHN_ENABLED_KEY)),
+        rpName: values.get(WEBAUTHN_RP_NAME_KEY) ?? DEFAULT_RP_NAME,
+      },
+    };
+  }
+
+  /**
+   * 获取站点地址配置（供 OIDC / User / WebAuthn 等模块消费）
+   * - effectiveFrontendUrl: frontendUrl 未配置时回退到 http://localhost:3000
+   * - effectiveBackendUrl: backendUrl 未配置时回退到 frontendUrl，再回退到 http://localhost:3000
+   */
+  async getSiteSettings(): Promise<{
+    frontendUrl: string;
+    backendUrl: string;
+    effectiveFrontendUrl: string;
+    effectiveBackendUrl: string;
+  }> {
+    const values = await this.readValues([
+      SITE_FRONTEND_URL_KEY,
+      SITE_BACKEND_URL_KEY,
+    ]);
+    const frontendUrl =
+      values.get(SITE_FRONTEND_URL_KEY) ?? DEFAULT_FRONTEND_URL;
+    const backendUrl = values.get(SITE_BACKEND_URL_KEY) ?? DEFAULT_BACKEND_URL;
+
+    return {
+      frontendUrl,
+      backendUrl,
+      effectiveFrontendUrl: frontendUrl || FALLBACK_URL,
+      effectiveBackendUrl: backendUrl || frontendUrl || FALLBACK_URL,
+    };
+  }
+
+  /**
+   * 获取 WebAuthn 配置（供 WebAuthnConfigService 消费）
+   * enabled 默认 true，但 frontendUrl 未配置时由调用方决定是否降级
+   */
+  async getWebAuthnSettings(): Promise<{
+    enabled: boolean;
+    rpName: string;
+  }> {
+    const values = await this.readValues([
+      WEBAUTHN_ENABLED_KEY,
+      WEBAUTHN_RP_NAME_KEY,
+    ]);
+    return {
+      enabled: this.readWebAuthnEnabled(values.get(WEBAUTHN_ENABLED_KEY)),
+      rpName: values.get(WEBAUTHN_RP_NAME_KEY) ?? DEFAULT_RP_NAME,
     };
   }
 
   async updateSettings(
     dto: UpdateGeneralSettingsDto,
   ): Promise<GeneralSettingsDto> {
-    const settings = {
+    const current = await this.getSettings();
+    const merged: GeneralSettingsDto = {
       watermarkEnabled: dto.watermarkEnabled,
+      site: {
+        frontendUrl: dto.site?.frontendUrl ?? current.site.frontendUrl,
+        backendUrl: dto.site?.backendUrl ?? current.site.backendUrl,
+      },
+      webauthn: {
+        enabled: dto.webauthn?.enabled ?? current.webauthn.enabled,
+        rpName: dto.webauthn?.rpName ?? current.webauthn.rpName,
+      },
     };
+
+    const values = new Map<string, string>([
+      [WATERMARK_ENABLED_KEY, String(merged.watermarkEnabled)],
+      [SITE_FRONTEND_URL_KEY, merged.site.frontendUrl ?? ''],
+      [SITE_BACKEND_URL_KEY, merged.site.backendUrl ?? ''],
+      [WEBAUTHN_ENABLED_KEY, String(merged.webauthn.enabled)],
+      [WEBAUTHN_RP_NAME_KEY, merged.webauthn.rpName ?? DEFAULT_RP_NAME],
+    ]);
 
     await this.dataSource.transaction(async (manager) => {
       const repository = manager.getRepository(SystemSetting);
       const existing = await repository.find({
-        where: { key: In([WATERMARK_ENABLED_KEY]) },
+        where: { key: In(ALL_KEYS) },
       });
       const existingByKey = new Map(existing.map((item) => [item.key, item]));
-      const values = new Map<string, string>([
-        [WATERMARK_ENABLED_KEY, String(settings.watermarkEnabled)],
-      ]);
 
       const entities = [...values].map(([key, value]) => {
         const setting = existingByKey.get(key) || repository.create({ key });
@@ -61,10 +140,22 @@ export class GeneralSettingsService {
       await repository.save(entities);
     });
 
-    return settings;
+    return merged;
+  }
+
+  private async readValues(keys: string[]): Promise<Map<string, string>> {
+    const settings = await this.settingRepository.find({
+      where: { key: In(keys) },
+    });
+    return new Map(settings.map((setting) => [setting.key, setting.value]));
   }
 
   private readWatermarkEnabled(value: string | undefined): boolean {
+    if (value === 'false') return false;
+    return true;
+  }
+
+  private readWebAuthnEnabled(value: string | undefined): boolean {
     if (value === 'false') return false;
     return true;
   }

--- a/src/modules/settings/settings.module.ts
+++ b/src/modules/settings/settings.module.ts
@@ -25,6 +25,6 @@ import { GeneralSettingsService } from './services/general-settings.service';
     AuditSettingsService,
     GeneralSettingsService,
   ],
-  exports: [SmtpSettingsService, AuditSettingsService],
+  exports: [SmtpSettingsService, AuditSettingsService, GeneralSettingsService],
 })
 export class SettingsModule {}

--- a/src/modules/update-check/update-check.controller.ts
+++ b/src/modules/update-check/update-check.controller.ts
@@ -1,9 +1,4 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { AdminGuard } from '../../common/guards/admin.guard';
 import { UpdateCheckService } from './update-check.service';
 

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -40,7 +40,7 @@ import { Invitation } from '../user/entities/invitation.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
 import { UserService } from '../user/user.service';
 import { EmailService } from '../email/email.service';
-import { ConfigService } from '@nestjs/config';
+import { GeneralSettingsService } from '../settings/services/general-settings.service';
 import { UserGroupMembersDto, UserGroupQueryDto } from './dto/user-group.dto';
 import { UserGroup } from './entities/user-group.entity';
 import { UserGroupController } from './user-group.controller';
@@ -131,7 +131,17 @@ describe('User group integration', () => {
       {
         sendInvitation: () => Promise.resolve(true),
       } as unknown as EmailService,
-      { get: () => 'http://localhost:3000' } as unknown as ConfigService,
+      {
+        getSiteSettings: () =>
+          Promise.resolve({
+            frontendUrl: '',
+            backendUrl: '',
+            effectiveFrontendUrl: 'http://localhost:3000',
+            effectiveBackendUrl: 'http://localhost:3000',
+          }),
+        getWebAuthnSettings: () =>
+          Promise.resolve({ enabled: true, rpName: 'RustDesk Console' }),
+      } as unknown as GeneralSettingsService,
     );
   });
 
@@ -372,36 +382,11 @@ describe('User group integration', () => {
       userGroupService,
     );
 
-    const previousAdminUsername = process.env.ADMIN_USERNAME;
-    const previousAdminEmail = process.env.ADMIN_EMAIL;
-    const previousAdminPassword = process.env.ADMIN_PASSWORD;
-    process.env.ADMIN_USERNAME = 'seed-admin';
-    process.env.ADMIN_EMAIL = 'seed-admin@example.com';
-    process.env.ADMIN_PASSWORD = 'seed-password';
-
-    try {
-      await (
-        databaseInitService as unknown as {
-          createDefaultAdmin(groupGuid: string): Promise<void>;
-        }
-      ).createDefaultAdmin(defaultGroup.guid);
-    } finally {
-      if (previousAdminUsername === undefined) {
-        delete process.env.ADMIN_USERNAME;
-      } else {
-        process.env.ADMIN_USERNAME = previousAdminUsername;
+    await (
+      databaseInitService as unknown as {
+        createDefaultAdmin(groupGuid: string): Promise<void>;
       }
-      if (previousAdminEmail === undefined) {
-        delete process.env.ADMIN_EMAIL;
-      } else {
-        process.env.ADMIN_EMAIL = previousAdminEmail;
-      }
-      if (previousAdminPassword === undefined) {
-        delete process.env.ADMIN_PASSWORD;
-      } else {
-        process.env.ADMIN_PASSWORD = previousAdminPassword;
-      }
-    }
+    ).createDefaultAdmin(defaultGroup.guid);
 
     await authService.register({
       username: 'registered-user',
@@ -455,7 +440,7 @@ describe('User group integration', () => {
 
     const createdUsers = await userRepository.find({
       where: [
-        { username: 'seed-admin' },
+        { username: 'databk' },
         { username: 'registered-user' },
         { username: 'ldap-user' },
         { username: 'oidc-user' },

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -16,6 +16,7 @@ import { UserUserPermission } from '../device-group/entities/user-user-permissio
 import { Strategy } from '../strategy/entities/strategy.entity';
 import { UserGroupModule } from '../user-group/user-group.module';
 import { EmailModule } from '../email/email.module';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { EmailModule } from '../email/email.module';
     AuthModule,
     UserGroupModule,
     EmailModule,
+    SettingsModule,
   ],
   controllers: [UserController, AvatarController, AdminUserController],
   providers: [UserService, AdminUserService],

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -12,7 +12,6 @@ import * as crypto from 'crypto';
 import sharp from 'sharp';
 import * as fs from 'fs';
 import * as path from 'path';
-
 import { User, UserStatus, UserInfo } from './entities/user.entity';
 import { UserToken } from './entities/user-token.entity';
 import { Invitation } from './entities/invitation.entity';

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -12,7 +12,7 @@ import * as crypto from 'crypto';
 import sharp from 'sharp';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ConfigService } from '@nestjs/config';
+
 import { User, UserStatus, UserInfo } from './entities/user.entity';
 import { UserToken } from './entities/user-token.entity';
 import { Invitation } from './entities/invitation.entity';
@@ -31,6 +31,7 @@ import {
 } from './dto/user.dto';
 import { UserGroupService } from '../user-group/user-group.service';
 import { EmailService } from '../email/email.service';
+import { GeneralSettingsService } from '../settings/services/general-settings.service';
 
 const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
 const AVATAR_SIZE = 256;
@@ -57,7 +58,7 @@ export class UserService {
     private userUserPermissionRepository: Repository<UserUserPermission>,
     private readonly userGroupService: UserGroupService,
     private readonly emailService: EmailService,
-    private readonly configService: ConfigService,
+    private readonly generalSettingsService: GeneralSettingsService,
   ) {}
 
   async getAccessibleUsers(
@@ -256,13 +257,9 @@ export class UserService {
     await this.invitationRepository.save(invitation);
 
     // 发送邀请邮件
-    const consoleUrl = this.configService.get<string>(
-      'CONSOLE_URL',
-      this.configService.get<string>(
-        'OIDC_REDIRECT_URI',
-        'http://localhost:3000',
-      ),
-    );
+    const { effectiveFrontendUrl } =
+      await this.generalSettingsService.getSiteSettings();
+    const consoleUrl = effectiveFrontendUrl;
     const inviteUrl = `${consoleUrl}/#/invite?token=${token}`;
     const emailSent = await this.emailService.sendInvitation(
       email,


### PR DESCRIPTION
## Summary

Consolidate scattered environment variables into the `settings/general` API so they are editable from the frontend settings page without redeploying.

## Changes

### Merged into `settings/general` (stored in DB)
- `CONSOLE_URL` + `WEB_FRONTEND_URLS` + `WEBAUTHN_RP_ORIGINS` → `site.frontendUrl`
- `OIDC_REDIRECT_URI` → `site.backendUrl` (falls back to `frontendUrl` when empty, supporting both proxy and split-domain deployments)
- `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGINS` → auto-derived from `site.frontendUrl` (hostname / origin)
- `WEBAUTHN_RP_NAME` + `WEBAUTHN_ENABLED` → `webauthn.rpName` / `webauthn.enabled`

### Removed env vars
- `NEXUS_BASE_URL` — hardcoded constant (not user-configurable)
- `ADMIN_USERNAME` / `ADMIN_EMAIL` / `ADMIN_PASSWORD` — default admin (`databk` / `databk`) created on first run; change password after first login

### Behavior changes
- WebAuthn **defaults to enabled**, but auto-disables with a warning when `site.frontendUrl` is unset, so password login is never broken by incomplete config
- `backendUrl` empty → falls back to `frontendUrl` → falls back to `http://localhost:3000`

### Resulting `settings/general` DTO
```json
{
  "watermarkEnabled": true,
  "site": { "frontendUrl": "https://admin.example.com", "backendUrl": "" },
  "webauthn": { "enabled": true, "rpName": "RustDesk Console" }
}
```

### Retained env vars (cannot move to DB)
`PORT`, `JWT_SECRET`, `DB_PATH`, `NEXUS_STORAGE_PATH`, `APP_VERSION` — all required before DB is available or are build-time values.

## Verification
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ (22/22 passed)