### PR TITLE
feat(sea): add macOS SEA build support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,6 +158,10 @@ jobs:
             os: ubuntu-24.04-arm
           - target: win-x64
             os: windows-latest
+          - target: macos-x64
+            os: macos-13
+          - target: macos-arm64
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -191,6 +195,12 @@ jobs:
       - name: Create archive (Windows)
         if: runner.os == 'Windows'
         run: Compress-Archive -Path dist-sea/* -DestinationPath rustdesk-console-${{ matrix.target }}.zip
+
+      - name: Create archive (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cd dist-sea
+          tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -159,7 +159,7 @@ jobs:
           - target: win-x64
             os: windows-latest
           - target: macos-x64
-            os: macos-13
+            os: macos-26-intel
           - target: macos-arm64
             os: macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -186,21 +186,15 @@ jobs:
       - name: Build SEA executable
         run: npm run build:sea
 
-      - name: Create archive (Linux)
-        if: runner.os == 'Linux'
+      - name: Create archive (tar.gz)
+        if: runner.os != 'Windows'
         run: |
           cd dist-sea
           tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
-      - name: Create archive (Windows)
+      - name: Create archive (zip)
         if: runner.os == 'Windows'
         run: Compress-Archive -Path dist-sea/* -DestinationPath rustdesk-console-${{ matrix.target }}.zip
-
-      - name: Create archive (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          cd dist-sea
-          tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,21 +131,15 @@ jobs:
       - name: Build SEA executable
         run: npm run build:sea
 
-      - name: Create archive (Linux)
-        if: runner.os == 'Linux'
+      - name: Create archive (tar.gz)
+        if: runner.os != 'Windows'
         run: |
           cd dist-sea
           tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
-      - name: Create archive (Windows)
+      - name: Create archive (zip)
         if: runner.os == 'Windows'
         run: Compress-Archive -Path dist-sea/* -DestinationPath rustdesk-console-${{ matrix.target }}.zip
-
-      - name: Create archive (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          cd dist-sea
-          tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           - target: win-x64
             os: windows-latest
           - target: macos-x64
-            os: macos-13
+            os: macos-26-intel
           - target: macos-arm64
             os: macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,10 @@ jobs:
             os: ubuntu-24.04-arm
           - target: win-x64
             os: windows-latest
+          - target: macos-x64
+            os: macos-13
+          - target: macos-arm64
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -136,6 +140,12 @@ jobs:
       - name: Create archive (Windows)
         if: runner.os == 'Windows'
         run: Compress-Archive -Path dist-sea/* -DestinationPath rustdesk-console-${{ matrix.target }}.zip
+
+      - name: Create archive (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cd dist-sea
+          tar czf ../rustdesk-console-${{ matrix.target }}.tar.gz .
 
       - name: Upload to release
         uses: softprops/action-gh-release@v3

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
 const isWindows = process.platform === 'win32';
+const isMacos = process.platform === 'darwin';
 const exeName = isWindows ? 'rustdesk-console.exe' : 'rustdesk-console';
 
 function run(cmd, opts = {}) {
@@ -101,7 +102,19 @@ if (isWindows) {
   }
 }
 
+// Remove signature on macOS (Node binary is signed, must be removed before injection)
+if (isMacos) {
+  console.log('  Removing signature from executable...');
+  run(`codesign --remove-signature "${exeName}"`);
+}
+
 run(`npx postject "${exeName}" NODE_SEA_BLOB sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`);
+
+// Re-sign ad-hoc on macOS so the modified binary can run
+if (isMacos) {
+  console.log('  Re-signing executable ad-hoc...');
+  run(`codesign --sign - "${exeName}"`);
+}
 
 // --- Step 5: Assemble distribution directory ---
 console.log('\n[5/6] Assembling distribution...');


### PR DESCRIPTION
## Summary

- Add macOS targets (`macos-x64` on `macos-13`, `macos-arm64` on `macos-latest`) to the SEA build matrix in both `nightly.yml` and `release.yml`
- Update `scripts/build-sea.mjs` to handle macOS code signing: remove the signature with `codesign --remove-signature` before blob injection, then re-sign ad-hoc with `codesign --sign -` after injection so the executable can run
- Add a macOS archive step (`.tar.gz`) to both workflows

## Details

The Node.js binary on macOS is code-signed. After `postject` injects the SEA blob, the signature becomes invalid and macOS refuses to run the binary. The fix follows the same pattern already used for Windows: remove the signature before injection, then re-sign ad-hoc after injection.

| Target | Runner | Archive |
|--------|--------|---------|
| `macos-x64` | `macos-13` (Intel) | `.tar.gz` |
| `macos-arm64` | `macos-latest` (Apple Silicon) | `.tar.gz` |