### PR TITLE
fix(user): specify varchar type for Invitation.note to support sqlite

### DIFF
--- a/src/modules/user/entities/invitation.entity.ts
+++ b/src/modules/user/entities/invitation.entity.ts
@@ -52,7 +52,7 @@ export class Invitation {
   /**
    * 备注
    */
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   note: string | null;
 
   /**


### PR DESCRIPTION
## Summary
- Fix `DataTypeNotSupportedError: Data type "Object" in "Invitation.note" is not supported by "sqlite" database` that prevented the app from connecting to the database on startup.
- The `note` field on the `Invitation` entity had no explicit column type, so TypeORM inferred `Object`, which the sqlite driver does not support.
- Explicitly set the column type to `varchar` to match the `string | null` TypeScript type.

## Root Cause
`src/modules/user/entities/invitation.entity.ts:55` declared:
```ts
@Column({ nullable: true })
note: string | null;
```
Without an explicit `type`, TypeORM fell back to an unsupported type for sqlite.

## Verification
- `npx tsc --noEmit` passes.