### PR TITLE
fix(sea): remove dead code and enrich dist package.json metadata

### DIFF
--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -140,21 +140,17 @@ copyDir(
   path.join(templatesDir, 'oidc'),
 );
 
-// Copy minimal package.json (for version info)
+// --- Step 6: Install native modules ---
+console.log('\n[6/6] Installing native modules (sqlite3, sharp)...');
 const pkgJson = JSON.parse(
   fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'),
 );
-fs.writeFileSync(
-  path.join(distDir, 'package.json'),
-  JSON.stringify({ name: pkgJson.name, version: pkgJson.version }, null, 2) + '\n',
-);
-console.log('  Wrote dist-sea/package.json');
-
-// --- Step 6: Install native modules ---
-console.log('\n[6/6] Installing native modules (sqlite3, sharp)...');
 const nativePkg = {
-  name: 'rustdesk-console-sea',
+  name: pkgJson.name,
   version: pkgJson.version,
+  description: pkgJson.description,
+  author: pkgJson.author,
+  license: pkgJson.license,
   private: true,
   dependencies: {
     sqlite3: pkgJson.dependencies.sqlite3,
@@ -165,6 +161,7 @@ fs.writeFileSync(
   path.join(distDir, 'package.json'),
   JSON.stringify(nativePkg, null, 2) + '\n',
 );
+console.log('  Wrote dist-sea/package.json');
 
 run('npm install --omit=dev', { cwd: distDir });
 


### PR DESCRIPTION
## Summary

- Remove redundant first write of `dist-sea/package.json` that was immediately overwritten by the native module install step (dead code)
- Use original package name (`rustdesk-console`) instead of hardcoded `rustdesk-console-sea`
- Carry over `description`, `author`, `license` from the source `package.json` for distribution identification

## Context

The build script wrote `dist-sea/package.json` twice in succession:

1. Step 5 wrote `{ name, version }` (minimal, for version info)
2. Step 6 overwrote it with `{ name: 'rustdesk-console-sea', version, private, dependencies: { sqlite3, sharp } }`

The first write was dead code — no read happened between the two writes. This PR removes it and enriches the surviving write with metadata (`description`, `author`, `license`) from the original `package.json`, and uses the original package name for consistency.