### PR TITLE
refactor(nexus): remove NEXUS_STORAGE_PATH env var override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,5 @@
 # Both the SQLite database and Nexus build artifacts are stored here.
 # DATA_DIR=./data
 
-# Override individual paths (optional, takes precedence over DATA_DIR)
+# Override database path (optional, takes precedence over DATA_DIR)
 # DB_PATH=rustdesk-console.db
-# NEXUS_STORAGE_PATH=./data/nexus-builds

--- a/src/common/utils/data-dir.util.ts
+++ b/src/common/utils/data-dir.util.ts
@@ -26,12 +26,8 @@ export function getDbPath(): string {
 
 /**
  * Get the Nexus build artifact storage directory.
- * Uses NEXUS_STORAGE_PATH env var if set (backward compatibility),
- * otherwise derives it from DATA_DIR.
+ * Always derived from DATA_DIR.
  */
 export function getNexusStoragePath(): string {
-  if (process.env.NEXUS_STORAGE_PATH) {
-    return process.env.NEXUS_STORAGE_PATH;
-  }
   return path.join(getDataDir(), NEXUS_BUILD_SUBDIR);
 }


### PR DESCRIPTION
## Summary

- Remove the `NEXUS_STORAGE_PATH` environment variable override now that `DATA_DIR` unifies all storage paths
- Nexus build artifact directory is always derived from `DATA_DIR`

## Rationale

PR #276 introduced `DATA_DIR` to unify database and build artifact storage. `NEXUS_STORAGE_PATH` was kept as a backward-compatible override, but it is now redundant — `DATA_DIR` fully controls the storage location. Removing it simplifies configuration and avoids two ways to set the same path.

## Changes

- `src/common/utils/data-dir.util.ts` — remove `NEXUS_STORAGE_PATH` check from `getNexusStoragePath()`
- `.env.example` — remove the `NEXUS_STORAGE_PATH` line