### PR TITLE
refactor(config): remove DB_PATH env var override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,3 @@
 # Data Directory (unified storage for database and build artifacts)
 # Both the SQLite database and Nexus build artifacts are stored here.
 # DATA_DIR=./data
-
-# Override database path (optional, takes precedence over DATA_DIR)
-# DB_PATH=rustdesk-console.db

--- a/src/common/utils/data-dir.util.ts
+++ b/src/common/utils/data-dir.util.ts
@@ -14,19 +14,13 @@ export function getDataDir(): string {
 
 /**
  * Get the SQLite database file path.
- * Uses DB_PATH env var if set (backward compatibility),
- * otherwise derives it from DATA_DIR.
  */
 export function getDbPath(): string {
-  if (process.env.DB_PATH) {
-    return process.env.DB_PATH;
-  }
   return path.join(getDataDir(), DB_FILENAME);
 }
 
 /**
  * Get the Nexus build artifact storage directory.
- * Always derived from DATA_DIR.
  */
 export function getNexusStoragePath(): string {
   return path.join(getDataDir(), NEXUS_BUILD_SUBDIR);

--- a/src/modules/dashboard/dashboard-system-status.spec.ts
+++ b/src/modules/dashboard/dashboard-system-status.spec.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 import * as si from 'systeminformation';
 import { Repository } from 'typeorm';
 import { Peer } from '../../common/entities/peer.entity';
@@ -56,13 +57,13 @@ const readSystemStatus = (service: DashboardService) =>
   ).getSystemStatus();
 
 describe('DashboardService system status', () => {
-  const originalDbPath = process.env.DB_PATH;
+  const originalDataDir = process.env.DATA_DIR;
 
   afterEach(() => {
-    if (originalDbPath === undefined) {
-      delete process.env.DB_PATH;
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
     } else {
-      process.env.DB_PATH = originalDbPath;
+      process.env.DATA_DIR = originalDataDir;
     }
     currentLoadMock.mockReset();
     memMock.mockReset();
@@ -70,8 +71,8 @@ describe('DashboardService system status', () => {
     uptimeMock.mockReset();
   });
 
-  it('uses available memory, a Windows database path, and OS uptime', async () => {
-    process.env.DB_PATH = 'D:\\data\\rustdesk-console.db';
+  it('uses available memory, the configured data dir, and OS uptime', async () => {
+    process.env.DATA_DIR = '/data';
     currentLoadMock.mockResolvedValue({
       currentLoad: 64.44,
     } as Awaited<ReturnType<typeof si.currentLoad>>);
@@ -92,11 +93,13 @@ describe('DashboardService system status', () => {
       disk: 17.5,
       uptime: 90061,
     });
-    expect(statfsMock).toHaveBeenCalledWith('D:\\data\\rustdesk-console.db');
+    expect(statfsMock).toHaveBeenCalledWith(
+      path.join('/data', 'rustdesk-console.db'),
+    );
   });
 
-  it('queries the Linux database filesystem directly', async () => {
-    process.env.DB_PATH = '/data/rustdesk-console.db';
+  it('queries the database filesystem directly', async () => {
+    process.env.DATA_DIR = '/data';
     currentLoadMock.mockResolvedValue({
       currentLoad: 10,
     } as Awaited<ReturnType<typeof si.currentLoad>>);
@@ -117,7 +120,9 @@ describe('DashboardService system status', () => {
       disk: 20,
       uptime: 3600,
     });
-    expect(statfsMock).toHaveBeenCalledWith('/data/rustdesk-console.db');
+    expect(statfsMock).toHaveBeenCalledWith(
+      path.join('/data', 'rustdesk-console.db'),
+    );
   });
 
   it('keeps successful metrics when one collector fails', async () => {


### PR DESCRIPTION
## Summary

- Remove the `DB_PATH` environment variable override now that `DATA_DIR` is the single unified storage config
- The database path is always derived from `DATA_DIR`

## Rationale

Following PRs #276 and #277, `DATA_DIR` fully controls all storage locations. `DB_PATH` was the last remaining override and is now redundant. Removing it leaves a single, clear configuration variable.

## Changes

- `src/common/utils/data-dir.util.ts` — remove `DB_PATH` check from `getDbPath()`
- `.env.example` — remove the `DB_PATH` line
- `src/modules/dashboard/dashboard-system-status.spec.ts` — update tests to use `DATA_DIR` instead of `DB_PATH`