### PR TITLE
fix(avatar): persist user avatars across Docker updates via DATA_DIR

### DIFF
--- a/src/common/utils/data-dir.util.ts
+++ b/src/common/utils/data-dir.util.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 const DEFAULT_DATA_DIR = './data';
 const DB_FILENAME = 'rustdesk-console.db';
 const NEXUS_BUILD_SUBDIR = 'nexus-builds';
+const AVATAR_SUBDIR = 'avatars';
 
 /**
  * Get the unified data directory.
@@ -24,4 +25,11 @@ export function getDbPath(): string {
  */
 export function getNexusStoragePath(): string {
   return path.join(getDataDir(), NEXUS_BUILD_SUBDIR);
+}
+
+/**
+ * Get the avatar storage directory.
+ */
+export function getAvatarDir(): string {
+  return path.join(getDataDir(), AVATAR_SUBDIR);
 }

--- a/src/modules/user/avatar.controller.ts
+++ b/src/modules/user/avatar.controller.ts
@@ -4,8 +4,9 @@ import { Public } from '../auth/decorators/public.decorator';
 import type { Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getAvatarDir } from '../../common/utils/data-dir.util';
 
-const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
+const AVATAR_DIR = getAvatarDir();
 
 @Public()
 @Controller('avatars')

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -31,8 +31,9 @@ import {
 import { UserGroupService } from '../user-group/user-group.service';
 import { EmailService } from '../email/email.service';
 import { GeneralSettingsService } from '../settings/services/general-settings.service';
+import { getAvatarDir } from '../../common/utils/data-dir.util';
 
-const AVATAR_DIR = path.join(process.cwd(), 'uploads', 'avatars');
+const AVATAR_DIR = getAvatarDir();
 const AVATAR_SIZE = 256;
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_FILE_SIZE = 2 * 1024 * 1024;


### PR DESCRIPTION
## Summary

- Fix user avatars being lost after Docker container updates
- Derive the avatar storage directory from `DATA_DIR` instead of `process.cwd()/uploads/avatars`

## Problem

User avatars were stored at `path.join(process.cwd(), 'uploads', 'avatars')`, which resolved to `/app/uploads/avatars/` inside the container (WORKDIR is `/app`). Since `docker-compose.yml` only mounts `./data:/data`, the avatars directory was **not** persisted. On container recreation, all avatar files were lost while database records (`user.avatar` field) survived — leaving users with broken avatar images (404).

This is the same class of bug that affected Nexus build artifacts (fixed in #276).

## Solution

Add `getAvatarDir()` to `data-dir.util.ts` that derives the avatar directory from `DATA_DIR`. In Docker (`DATA_DIR=/data`), avatars are stored at `/data/avatars/`, which is covered by the existing persistent volume mount.

| Resource | Before | After |
|----------|--------|-------|
| User avatars | `/app/uploads/avatars/` (not persisted) | `${DATA_DIR}/avatars/` → `/data/avatars/` (persisted) |

## Changes

- `src/common/utils/data-dir.util.ts` — add `getAvatarDir()`
- `src/modules/user/user.service.ts` — use `getAvatarDir()` instead of hardcoded path
- `src/modules/user/avatar.controller.ts` — use `getAvatarDir()` instead of hardcoded path