### PR TITLE
fix(avatar): prevent stale browser cache from showing old avatar

### DIFF
--- a/src/modules/user/avatar.controller.ts
+++ b/src/modules/user/avatar.controller.ts
@@ -29,7 +29,7 @@ export class AvatarController {
     }
 
     res.setHeader('Content-Type', 'image/webp');
-    res.setHeader('Cache-Control', 'public, max-age=86400');
+    res.setHeader('Cache-Control', 'no-cache');
     const stream = fs.createReadStream(filePath);
     stream.pipe(res);
   }


### PR DESCRIPTION
## Summary

- Fix stale browser cache causing old avatar to display after upload or delete-then-reupload

## Problem

The avatar endpoint set `Cache-Control: public, max-age=86400` (24 hours). Since the filename is always `<userGuid>.webp` and never changes between uploads, the browser served the cached old image instead of requesting the updated file from the server.

This affected both:
- Uploading a new avatar to replace an existing one
- Deleting the avatar and uploading a new one

In both cases the server-side file was correctly updated, but the browser displayed the stale cached version.

## Solution

Change `Cache-Control` from `public, max-age=86400` to `no-cache`, so the browser always revalidates with the server before using a cached response.