### PR TITLE
fix(avatar): use ETag conditional requests for efficient avatar caching

### DIFF
--- a/src/modules/user/avatar.controller.ts
+++ b/src/modules/user/avatar.controller.ts
@@ -1,7 +1,14 @@
-import { Controller, Get, Param, Res, NotFoundException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Req,
+  Res,
+  NotFoundException,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../auth/decorators/public.decorator';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getAvatarDir } from '../../common/utils/data-dir.util';
@@ -13,7 +20,11 @@ const AVATAR_DIR = getAvatarDir();
 export class AvatarController {
   @Throttle({ default: { limit: 60, ttl: 60000 } })
   @Get(':filename')
-  getAvatar(@Param('filename') filename: string, @Res() res: Response) {
+  getAvatar(
+    @Param('filename') filename: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
     if (!filename.match(/^[a-f0-9-]+\.webp$/)) {
       throw new NotFoundException();
     }
@@ -28,8 +39,18 @@ export class AvatarController {
       throw new NotFoundException();
     }
 
+    const stat = fs.statSync(filePath);
+    const etag = `"${stat.size.toString(16)}-${stat.mtime.getTime().toString(16)}"`;
+
+    res.setHeader('ETag', etag);
+    res.setHeader('Cache-Control', 'no-cache');
+
+    if (req.headers['if-none-match'] === etag) {
+      res.status(304).end();
+      return;
+    }
+
     res.setHeader('Content-Type', 'image/webp');
-    res.setHeader('Cache-Control', 'public, max-age=86400');
     const stream = fs.createReadStream(filePath);
     stream.pipe(res);
   }


### PR DESCRIPTION
## Summary

- Replace unconditional 24-hour browser cache with ETag-based conditional requests
- Fixes stale avatar display after upload while avoiding unnecessary full fetches

## Problem

The avatar endpoint used `Cache-Control: public, max-age=86400` (24 hours). Since the filename is always `<userGuid>.webp` and never changes between uploads, the browser served the stale cached image instead of requesting the updated file.

A previous attempt (#280) used `no-cache` without ETag, which forces a full re-fetch on every request — wasteful when the avatar hasn't changed.

## Solution

Use standard HTTP conditional requests with ETag:

1. Server generates an ETag from file size and mtime: `"size-mtime"`
2. `Cache-Control: no-cache` allows browser caching but requires revalidation
3. Browser sends `If-None-Match` with the cached ETag
4. If ETag matches → `304 Not Modified` (no body, minimal overhead)
5. If ETag differs → `200 OK` with the full new image

| Scenario | Before | After |
|----------|--------|-------|
| Avatar unchanged | No request (stale cache) | `304` (tiny response, correct image) |
| Avatar updated | Stale cache served | `200` with new image |

## Changes

- `src/modules/user/avatar.controller.ts` — add ETag generation, `If-None-Match` check, and `304` response