### PR TITLE
fix(avatar): bust browser cache with timestamp query parameter

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -638,7 +638,7 @@ export class UserService {
   }
 
   private removeAvatarFile(avatarPath: string) {
-    const filename = path.basename(avatarPath);
+    const filename = path.basename(avatarPath.split('?')[0]);
     const fullPath = path.join(AVATAR_DIR, filename);
     if (fs.existsSync(fullPath)) {
       fs.unlinkSync(fullPath);
@@ -686,7 +686,7 @@ export class UserService {
     this.ensureAvatarDir();
 
     const filename = `${userGuid}.webp`;
-    const relativePath = `/api/avatars/${filename}`;
+    const relativePath = `/api/avatars/${filename}?v=${Date.now()}`;
     const fullPath = path.join(AVATAR_DIR, filename);
 
     await sharp(file.buffer)


### PR DESCRIPTION
## Summary

- Fix stale browser cache showing old avatar after upload by appending a timestamp query parameter to the avatar URL

## Problem

The avatar filename is always `<userGuid>.webp` and never changes between uploads. With `Cache-Control: public, max-age=86400`, the browser cached the image for 24 hours and served the stale version instead of fetching the updated file.

## Solution

Append `?v=${Date.now()}` to the avatar URL stored in the database on each upload. Since the URL changes every time the avatar is updated, the browser treats it as a new resource and fetches the fresh image. Unchanged avatars continue to be served from cache with zero server requests.

| Scenario | Behavior |
|----------|----------|
| Avatar unchanged | Browser cache hit (no request) |
| Avatar updated | New URL → cache miss → fresh fetch |

Also update `removeAvatarFile` to strip the query string before extracting the filename, so file deletion works correctly with the new URL format.

## Changes

- `src/modules/user/user.service.ts` — add `?v=${Date.now()}` to avatar URL; strip query string in `removeAvatarFile`