### PR TITLE
fix(auth): add has_password and has_totp to user info response

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -85,6 +85,13 @@ import { JWT_DEFAULT_SECRET } from './auth.constants';
     AuthLoginHelper,
     JwtStrategy,
   ],
-  exports: [AuthService, AuthTokenService, AuthDeviceService, JwtModule],
+  exports: [
+    AuthService,
+    AuthTokenService,
+    AuthDeviceService,
+    AuthResponseHelper,
+    AuthUserHelper,
+    JwtModule,
+  ],
 })
 export class AuthModule {}

--- a/src/modules/auth/services/auth-email.service.ts
+++ b/src/modules/auth/services/auth-email.service.ts
@@ -121,7 +121,10 @@ export class AuthEmailService {
       throw new UnauthorizedException({ error: '验证码错误' });
     }
 
-    const user = await this.authUserHelper.findByUsernameOrEmail(username);
+    const user = await this.authUserHelper.findByUsernameOrEmail(username, {
+      withPassword: true,
+      withTfaSecret: true,
+    });
 
     if (!user || user.guid !== session.userGuid) {
       throw new UnauthorizedException({ error: '用户信息不匹配' });

--- a/src/modules/auth/services/auth-passkey.service.ts
+++ b/src/modules/auth/services/auth-passkey.service.ts
@@ -279,8 +279,9 @@ export class AuthPasskeyService {
       throw new UnauthorizedException({ error: '凭证与用户不匹配' });
     }
 
-    const user = await this.userRepository.findOne({
-      where: { guid: credential.userGuid },
+    const user = await this.authUserHelper.findByGuid(credential.userGuid, {
+      withPassword: true,
+      withTfaSecret: true,
     });
 
     if (!user) {

--- a/src/modules/auth/services/auth-response.helper.ts
+++ b/src/modules/auth/services/auth-response.helper.ts
@@ -22,7 +22,11 @@ export class AuthResponseHelper {
       email: user.email || undefined,
       note: user.note || undefined,
       status: user.status,
-      info: user.getUserInfo(),
+      info: {
+        ...user.getUserInfo(),
+        has_password: !!user.password,
+        has_totp: !!user.tfaSecret,
+      },
       is_admin: user.isAdmin,
       third_auth_type: user.thirdAuthType || undefined,
       ...(user.avatar ? { avatar: user.avatar } : {}),

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -233,6 +233,7 @@ export class AuthTfaService {
     }
 
     const user = await this.authUserHelper.findByGuid(session.userGuid, {
+      withPassword: true,
       withTfaSecret: true,
     });
 

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -180,7 +180,16 @@ export class AuthService {
 
     const ldapUser = await this.tryLdapAuthentication(username, password);
     if (ldapUser) {
-      return this.buildLoginResponse(ldapUser, id, uuid, deviceInfo);
+      const user = await this.authUserHelper.findByGuid(ldapUser.guid, {
+        withPassword: true,
+        withTfaSecret: true,
+      });
+      return this.buildLoginResponse(
+        user ?? ldapUser,
+        id,
+        uuid,
+        deviceInfo,
+      );
     }
 
     return this.localLogin(username, password, id, uuid, deviceInfo);
@@ -363,7 +372,10 @@ export class AuthService {
     userGuid: string,
     _currentUserDto?: CurrentUserDto,
   ): Promise<Record<string, unknown>> {
-    const user = await this.authUserHelper.findByGuid(userGuid);
+    const user = await this.authUserHelper.findByGuid(userGuid, {
+      withPassword: true,
+      withTfaSecret: true,
+    });
 
     if (!user) {
       throw new UnauthorizedException('用户不存在');

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -21,6 +21,8 @@ import { OidcAuthRequestDto } from '../dto/oidc.dto';
 import { LoginResponse } from '../../../common/interfaces';
 import { AuthTokenService } from '../../auth/services/auth-token.service';
 import { AuthDeviceService } from '../../auth/services/auth-device.service';
+import { AuthResponseHelper } from '../../auth/services/auth-response.helper';
+import { AuthUserHelper } from '../../auth/services/auth-user.helper';
 import { UserGroupService } from '../../user-group/user-group.service';
 import { GeneralSettingsService } from '../../settings/services/general-settings.service';
 
@@ -121,6 +123,8 @@ export class OidcService {
     private userRepository: Repository<User>,
     private authTokenService: AuthTokenService,
     private deviceService: AuthDeviceService,
+    private readonly authResponseHelper: AuthResponseHelper,
+    private readonly authUserHelper: AuthUserHelper,
     private readonly generalSettingsService: GeneralSettingsService,
     private readonly userGroupService: UserGroupService,
   ) {}
@@ -623,8 +627,9 @@ export class OidcService {
       throw new UnauthorizedException({ error: 'No authed oidc is found' });
     }
 
-    const user = await this.userRepository.findOne({
-      where: { guid: authState.userGuid },
+    const user = await this.authUserHelper.findByGuid(authState.userGuid, {
+      withPassword: true,
+      withTfaSecret: true,
     });
 
     if (!user) {
@@ -637,15 +642,7 @@ export class OidcService {
     return {
       access_token: authState.accessToken,
       type: 'access_token',
-      user: {
-        name: user.username,
-        email: user.email || undefined,
-        note: user.note || undefined,
-        status: user.status,
-        info: user.getUserInfo(),
-        is_admin: user.isAdmin,
-        third_auth_type: user.thirdAuthType || undefined,
-      },
+      user: this.authResponseHelper.buildUserPayload(user),
     };
   }
 

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -379,6 +379,8 @@ describe('User group integration', () => {
       undefined as never,
       undefined as never,
       undefined as never,
+      undefined as never,
+      undefined as never,
       userGroupService,
     );
 

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -31,6 +31,8 @@ export enum UserStatus {
 export interface UserInfo {
   email_verification?: boolean;
   email_alarm_notification?: boolean;
+  has_password?: boolean;
+  has_totp?: boolean;
   other?: Record<string, any>;
 }
 


### PR DESCRIPTION
## Summary

- Add `has_password` (bool) and `has_totp` (bool) inside the `info` object of the user response
- The frontend already supports these fields; the backend was not providing them

## Changes

### Core
- `src/modules/user/entities/user.entity.ts` — add `has_password` and `has_totp` to `UserInfo` interface
- `src/modules/auth/services/auth-response.helper.ts` — include `has_password` and `has_totp` in the `info` object of `buildUserPayload`

### Query fixes
Since `password` and `tfaSecret` are `select: false` columns, all query call sites that lead to `buildUserPayload` must explicitly load these fields:

- `auth.service.ts` — `getCurrentUser`: add `withPassword` + `withTfaSecret`; LDAP login: re-query user with both fields
- `auth-tfa.service.ts` — `handleTfaLogin`: add `withPassword`
- `auth-email.service.ts` — `handleEmailCodeLogin`: add `withPassword` + `withTfaSecret`
- `auth-passkey.service.ts` — passkey verify: switch to `authUserHelper.findByGuid` with both fields
- `oidc.service.ts` — use `buildUserPayload` for consistent response; inject `AuthResponseHelper` and `AuthUserHelper`
- `auth.module.ts` — export `AuthResponseHelper` and `AuthUserHelper`