### PR TITLE
fix(auth): store has_password and has_totp flags in user info

### DIFF
--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -127,6 +127,7 @@ export class AuthTfaService {
 
     delete other.tfa_pending_secret;
     userInfo.other = other;
+    userInfo.has_totp = true;
     user.setUserInfo(userInfo);
 
     await this.userRepository.save(user);
@@ -163,6 +164,11 @@ export class AuthTfaService {
     }
 
     user.tfaSecret = '';
+
+    const userInfo = user.getUserInfo();
+    userInfo.has_totp = false;
+    user.setUserInfo(userInfo);
+
     await this.userRepository.save(user);
 
     return { message: '2FA已禁用' };

--- a/src/modules/auth/services/auth-tfa.service.ts
+++ b/src/modules/auth/services/auth-tfa.service.ts
@@ -165,7 +165,7 @@ export class AuthTfaService {
 
     user.tfaSecret = '';
 
-    const userInfo = user.getUserInfo();
+
     userInfo.has_totp = false;
     user.setUserInfo(userInfo);
 

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -96,6 +96,10 @@ export class AuthService {
       userGroupGuid,
     });
 
+    const userInfo = user.getUserInfo();
+    userInfo.has_password = true;
+    user.setUserInfo(userInfo);
+
     await this.userRepository.save(user);
 
     this.logger.log(`新用户注册成功: ${username}`);

--- a/src/modules/ldap/ldap.service.ts
+++ b/src/modules/ldap/ldap.service.ts
@@ -406,6 +406,10 @@ export class LdapService {
         user.oidcSubject = ldapSubject;
         user.userGroupGuid = userGroupGuid;
 
+        const userInfo = user.getUserInfo();
+        userInfo.has_password = false;
+        user.setUserInfo(userInfo);
+
         await this.userRepository.save(user);
         this.logger.log(`LDAP 用户已创建: ${finalUsername}`);
         return user;

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -815,6 +815,10 @@ export class OidcService {
         user.oidcSubject = oidcSubject;
         user.userGroupGuid = userGroupGuid;
 
+        const userInfo = user.getUserInfo();
+        userInfo.has_password = false;
+        user.setUserInfo(userInfo);
+
         await this.userRepository.save(user);
         this.logger.log(
           `OIDC user created: ${finalUsername} via ${providerName}`,

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -31,6 +31,8 @@ export enum UserStatus {
 export interface UserInfo {
   email_verification?: boolean;
   email_alarm_notification?: boolean;
+  has_password?: boolean;
+  has_totp?: boolean;
   other?: Record<string, any>;
 }
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -197,6 +197,10 @@ export class UserService {
     user.isAdmin = false;
     user.userGroupGuid = userGroupGuid;
 
+    const userInfo = user.getUserInfo();
+    userInfo.has_password = true;
+    user.setUserInfo(userInfo);
+
     await this.userRepository.save(user);
 
     return { message: '用户创建成功' };
@@ -233,6 +237,10 @@ export class UserService {
     user.status = UserStatus.UNVERIFIED;
     user.isAdmin = false;
     user.userGroupGuid = userGroupGuid;
+
+    const userInfo = user.getUserInfo();
+    userInfo.has_password = false;
+    user.setUserInfo(userInfo);
 
     await this.userRepository.save(user);
 
@@ -346,6 +354,10 @@ export class UserService {
     // 设置密码并激活用户
     user.password = await bcrypt.hash(dto.password, 10);
     user.status = UserStatus.ACTIVE;
+
+    const userInfo = user.getUserInfo();
+    userInfo.has_password = true;
+    user.setUserInfo(userInfo);
 
     await this.userRepository.save(user);
 
@@ -504,6 +516,11 @@ export class UserService {
     }
 
     user.password = await bcrypt.hash(dto.new_password, 10);
+
+    const userInfo = user.getUserInfo();
+    userInfo.has_password = true;
+    user.setUserInfo(userInfo);
+
     await this.userRepository.save(user);
 
     return { message: '密码修改成功' };


### PR DESCRIPTION
## Summary

- Store `has_password` and `has_totp` as boolean flags inside the user `info` JSON when the password or TOTP is set
- The frontend already expects these fields; the backend was not providing them

## Approach

Instead of computing `has_password`/`has_totp` at query time (which would require loading `select:false` columns like `password` and `tfaSecret` on every request), store them as flags in the `info` JSON at the point of change. They are then returned naturally via `getUserInfo()` with no extra queries.

## Changes

- `user.entity.ts` — add `has_password` and `has_totp` to `UserInfo` interface
- `auth.service.ts` — set `has_password = true` on registration
- `user.service.ts` — set `has_password` on createUser, inviteUser, acceptInvitation, changePassword
- `oidc.service.ts` — set `has_password = false` on OIDC user creation
- `ldap.service.ts` — set `has_password = false` on LDAP user creation
- `auth-tfa.service.ts` — set `has_totp = true` on TFA bind, `has_totp = false` on TFA disable