### PR TITLE
feat(settings): make JWT token expiry configurable via settings/general API

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -27,7 +27,7 @@ import { EmailModule } from '../email/email.module';
 import { LdapModule } from '../ldap/ldap.module';
 import { UserGroupModule } from '../user-group/user-group.module';
 import { SettingsModule } from '../settings/settings.module';
-import { JWT_DEFAULT_SECRET } from './auth.constants';
+import { JWT_DEFAULT_SECRET, TOKEN_EXPIRY_DAYS } from './auth.constants';
 
 /**
  * 认证模块
@@ -65,7 +65,7 @@ import { JWT_DEFAULT_SECRET } from './auth.constants';
     JwtModule.register({
       secret: process.env.JWT_SECRET || JWT_DEFAULT_SECRET,
       signOptions: {
-        expiresIn: '30d',
+        expiresIn: `${TOKEN_EXPIRY_DAYS}d`,
       },
     }),
   ],

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -7,7 +7,8 @@ import { User } from '../../user/entities/user.entity';
 import { UserToken } from '../../user/entities/user-token.entity';
 import { JwtPayload } from '../../../common/services/token.service';
 import { DeviceInfoDto } from '../dto/auth.dto';
-import { TOKEN_EXPIRY_DAYS } from '../auth.constants';
+
+import { GeneralSettingsService } from '../../settings/services/general-settings.service';
 
 export interface SessionInfo {
   jti: string;
@@ -36,6 +37,7 @@ export class AuthTokenService {
     @InjectRepository(UserToken)
     private tokenRepository: Repository<UserToken>,
     private jwtService: JwtService,
+    private readonly generalSettingsService: GeneralSettingsService,
   ) {}
 
   /**
@@ -65,10 +67,14 @@ export class AuthTokenService {
       jti,
     };
 
-    const token = this.jwtService.sign(payload);
+    const expiryDays = await this.generalSettingsService.getJwtExpiryDays();
+
+    const token = this.jwtService.sign(payload, {
+      expiresIn: `${expiryDays}d`,
+    });
 
     const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + TOKEN_EXPIRY_DAYS);
+    expiresAt.setDate(expiresAt.getDate() + expiryDays);
 
     const userToken = this.tokenRepository.create({
       guid: jti,

--- a/src/modules/settings/dto/general-settings.dto.ts
+++ b/src/modules/settings/dto/general-settings.dto.ts
@@ -1,9 +1,11 @@
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
+  IsInt,
   IsOptional,
   IsString,
   Matches,
+  Min,
   ValidateNested,
 } from 'class-validator';
 
@@ -31,6 +33,7 @@ export class WebAuthnSettingsDto {
 export class GeneralSettingsDto {
   watermarkEnabled: boolean;
   defaultLanguage: string;
+  jwtExpiryDays: number;
   site: SiteSettingsDto;
   webauthn: WebAuthnSettingsDto;
 }
@@ -51,6 +54,11 @@ export class UpdateGeneralSettingsDto {
       'defaultLanguage must be a BCP 47 region tag like en-US, pt-BR, zh-CN',
   })
   defaultLanguage?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  jwtExpiryDays?: number;
 
   @IsOptional()
   @ValidateNested()

--- a/src/modules/settings/general-settings.service.spec.ts
+++ b/src/modules/settings/general-settings.service.spec.ts
@@ -14,6 +14,7 @@ import { GeneralSettingsService } from './services/general-settings.service';
 const DEFAULT_SETTINGS = {
   watermarkEnabled: true,
   defaultLanguage: 'en-US',
+  jwtExpiryDays: 30,
   site: { frontendUrl: '', backendUrl: '' },
   webauthn: { enabled: true, rpName: 'RustDesk Console' },
 };
@@ -69,7 +70,38 @@ describe('GeneralSettingsService', () => {
       ...DEFAULT_SETTINGS,
       watermarkEnabled: false,
     });
-    await expect(repository.count()).resolves.toBe(6);
+    await expect(repository.count()).resolves.toBe(7);
+  });
+
+  it('persists jwtExpiryDays and reads it back', async () => {
+    await service.updateSettings({
+      watermarkEnabled: true,
+      jwtExpiryDays: 7,
+    });
+    await expect(service.getSettings()).resolves.toMatchObject({
+      jwtExpiryDays: 7,
+    });
+    await expect(service.getJwtExpiryDays()).resolves.toBe(7);
+  });
+
+  it('falls back to default jwtExpiryDays for invalid values', async () => {
+    await repository.save([
+      repository.create({
+        key: 'general.jwtExpiryDays',
+        value: 'not-a-number',
+        category: 'general',
+      }),
+    ]);
+    await expect(service.getJwtExpiryDays()).resolves.toBe(30);
+
+    await repository.save([
+      repository.create({
+        key: 'general.jwtExpiryDays',
+        value: '0',
+        category: 'general',
+      }),
+    ]);
+    await expect(service.getJwtExpiryDays()).resolves.toBe(30);
   });
 
   it('persists defaultLanguage and validates the format', async () => {
@@ -167,6 +199,32 @@ describe('general settings HTTP contract', () => {
       webauthn: { enabled: 'yes' },
     });
     await expect(validate(invalidWebauthn)).resolves.not.toHaveLength(0);
+  });
+
+  it('validates jwtExpiryDays must be a positive integer', async () => {
+    const valid = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      jwtExpiryDays: 14,
+    });
+    await expect(validate(valid)).resolves.toHaveLength(0);
+
+    const invalidFloat = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      jwtExpiryDays: 3.5,
+    });
+    await expect(validate(invalidFloat)).resolves.not.toHaveLength(0);
+
+    const invalidZero = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      jwtExpiryDays: 0,
+    });
+    await expect(validate(invalidZero)).resolves.not.toHaveLength(0);
+
+    const invalidString = plainToInstance(UpdateGeneralSettingsDto, {
+      watermarkEnabled: true,
+      jwtExpiryDays: '30',
+    });
+    await expect(validate(invalidString)).resolves.not.toHaveLength(0);
   });
 
   it('restricts general reads and updates to administrators', () => {

--- a/src/modules/settings/services/general-settings.service.ts
+++ b/src/modules/settings/services/general-settings.service.ts
@@ -11,6 +11,7 @@ import { SystemSetting } from '../entities/system-setting.entity';
 const CATEGORY = 'general';
 const WATERMARK_ENABLED_KEY = 'general.watermarkEnabled';
 const DEFAULT_LANGUAGE_KEY = 'general.defaultLanguage';
+const JWT_EXPIRY_DAYS_KEY = 'general.jwtExpiryDays';
 const SITE_FRONTEND_URL_KEY = 'general.siteFrontendUrl';
 const SITE_BACKEND_URL_KEY = 'general.siteBackendUrl';
 const WEBAUTHN_ENABLED_KEY = 'general.webauthnEnabled';
@@ -20,11 +21,13 @@ const DEFAULT_FRONTEND_URL = '';
 const DEFAULT_BACKEND_URL = '';
 const DEFAULT_RP_NAME = 'RustDesk Console';
 const DEFAULT_LANGUAGE = 'en-US';
+const DEFAULT_JWT_EXPIRY_DAYS = 30;
 const FALLBACK_URL = 'http://localhost:3000';
 
 const ALL_KEYS = [
   WATERMARK_ENABLED_KEY,
   DEFAULT_LANGUAGE_KEY,
+  JWT_EXPIRY_DAYS_KEY,
   SITE_FRONTEND_URL_KEY,
   SITE_BACKEND_URL_KEY,
   WEBAUTHN_ENABLED_KEY,
@@ -47,6 +50,7 @@ export class GeneralSettingsService {
         values.get(WATERMARK_ENABLED_KEY),
       ),
       defaultLanguage: values.get(DEFAULT_LANGUAGE_KEY) ?? DEFAULT_LANGUAGE,
+      jwtExpiryDays: this.readJwtExpiryDays(values.get(JWT_EXPIRY_DAYS_KEY)),
       site: {
         frontendUrl: values.get(SITE_FRONTEND_URL_KEY) ?? DEFAULT_FRONTEND_URL,
         backendUrl: values.get(SITE_BACKEND_URL_KEY) ?? DEFAULT_BACKEND_URL,
@@ -117,6 +121,15 @@ export class GeneralSettingsService {
     };
   }
 
+  /**
+   * 获取 JWT Token 有效期天数（供 AuthTokenService 消费）
+   * 默认 30 天，可通过 settings/general 接口修改
+   */
+  async getJwtExpiryDays(): Promise<number> {
+    const values = await this.readValues([JWT_EXPIRY_DAYS_KEY]);
+    return this.readJwtExpiryDays(values.get(JWT_EXPIRY_DAYS_KEY));
+  }
+
   async updateSettings(
     dto: UpdateGeneralSettingsDto,
   ): Promise<GeneralSettingsDto> {
@@ -124,6 +137,7 @@ export class GeneralSettingsService {
     const merged: GeneralSettingsDto = {
       watermarkEnabled: dto.watermarkEnabled,
       defaultLanguage: dto.defaultLanguage ?? current.defaultLanguage,
+      jwtExpiryDays: dto.jwtExpiryDays ?? current.jwtExpiryDays,
       site: {
         frontendUrl: dto.site?.frontendUrl ?? current.site.frontendUrl,
         backendUrl: dto.site?.backendUrl ?? current.site.backendUrl,
@@ -137,6 +151,7 @@ export class GeneralSettingsService {
     const values = new Map<string, string>([
       [WATERMARK_ENABLED_KEY, String(merged.watermarkEnabled)],
       [DEFAULT_LANGUAGE_KEY, merged.defaultLanguage ?? DEFAULT_LANGUAGE],
+      [JWT_EXPIRY_DAYS_KEY, String(merged.jwtExpiryDays)],
       [SITE_FRONTEND_URL_KEY, merged.site.frontendUrl ?? ''],
       [SITE_BACKEND_URL_KEY, merged.site.backendUrl ?? ''],
       [WEBAUTHN_ENABLED_KEY, String(merged.webauthn.enabled)],
@@ -179,5 +194,11 @@ export class GeneralSettingsService {
   private readWebAuthnEnabled(value: string | undefined): boolean {
     if (value === 'false') return false;
     return true;
+  }
+
+  private readJwtExpiryDays(value: string | undefined): number {
+    const parsed = parseInt(value ?? '', 10);
+    if (Number.isNaN(parsed) || parsed < 1) return DEFAULT_JWT_EXPIRY_DAYS;
+    return parsed;
   }
 }


### PR DESCRIPTION
## Summary

- Make the JWT token expiration period configurable through the `PUT /settings/general` API endpoint, replacing the previously hardcoded 30-day expiry
- Add `jwtExpiryDays` field to the general settings DTO with `@IsInt` and `@Min(1)` validation
- `AuthTokenService` now reads the configured expiry at token signing time and passes it dynamically to `JwtService.sign()`

## Changes

| File | Change |
|------|--------|
| `dto/general-settings.dto.ts` | Add `jwtExpiryDays` to `GeneralSettingsDto` and `UpdateGeneralSettingsDto` with validation |
| `services/general-settings.service.ts` | Add `JWT_EXPIRY_DAYS_KEY`, `getJwtExpiryDays()`, and `readJwtExpiryDays()` |
| `auth/services/auth-token.service.ts` | Inject `GeneralSettingsService`, use dynamic `expiresIn` in `sign()` and `expiresAt` |
| `auth/auth.module.ts` | Use `TOKEN_EXPIRY_DAYS` constant instead of hardcoded `'30d'` as module-level fallback |
| `general-settings.service.spec.ts` | Add tests for persistence, invalid value fallback, and DTO validation |

## Usage

```http
PUT /api/settings/general
{
  "watermarkEnabled": true,
  "jwtExpiryDays": 7
}
```

The default remains 30 days if unset or invalid.

Closes #291