### PR TITLE
feat(settings): expose audit log retention days via settings/audit API

### DIFF
--- a/src/modules/settings/audit-settings.controller.ts
+++ b/src/modules/settings/audit-settings.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminGuard } from '../../common/guards/admin.guard';
+import { UpdateAuditSettingsDto } from './dto/audit-settings.dto';
+import { AuditSettingsService } from './services/audit-settings.service';
+
+@Controller('settings/audit')
+export class AuditSettingsController {
+  constructor(
+    private readonly auditSettingsService: AuditSettingsService,
+  ) {}
+
+  @Get()
+  @UseGuards(AdminGuard)
+  getSettings() {
+    return this.auditSettingsService.getRetentionDays().then((retentionDays) => ({
+      retentionDays,
+    }));
+  }
+
+  @Put()
+  @UseGuards(AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async updateSettings(@Body() dto: UpdateAuditSettingsDto) {
+    await this.auditSettingsService.setRetentionDays(dto.retentionDays);
+    return { retentionDays: dto.retentionDays };
+  }
+}

--- a/src/modules/settings/audit-settings.service.spec.ts
+++ b/src/modules/settings/audit-settings.service.spec.ts
@@ -1,0 +1,156 @@
+import 'reflect-metadata';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { DataSource, Repository } from 'typeorm';
+import { AdminGuard } from '../../common/guards/admin.guard';
+import { UpdateAuditSettingsDto } from './dto/audit-settings.dto';
+import { SystemSetting } from './entities/system-setting.entity';
+import { AuditSettingsController } from './audit-settings.controller';
+import { AuditSettingsService } from './services/audit-settings.service';
+
+describe('AuditSettingsService', () => {
+  let dataSource: DataSource;
+  let repository: Repository<SystemSetting>;
+  let service: AuditSettingsService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      dropSchema: true,
+      synchronize: true,
+      logging: false,
+      entities: [SystemSetting],
+    });
+    await dataSource.initialize();
+    repository = dataSource.getRepository(SystemSetting);
+    service = new AuditSettingsService(repository);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('returns 0 by default', async () => {
+    await expect(service.getRetentionDays()).resolves.toBe(0);
+  });
+
+  it('persists retention days and reads them back', async () => {
+    await service.setRetentionDays(30);
+    await expect(service.getRetentionDays()).resolves.toBe(30);
+
+    const setting = await repository.findOne({
+      where: { key: 'audit.retentionDays' },
+    });
+    expect(setting).not.toBeNull();
+    expect(setting!.value).toBe('30');
+    expect(setting!.category).toBe('audit');
+  });
+
+  it('overwrites the existing value on subsequent sets', async () => {
+    await service.setRetentionDays(7);
+    await service.setRetentionDays(90);
+    await expect(service.getRetentionDays()).resolves.toBe(90);
+    await expect(repository.count()).resolves.toBe(1);
+  });
+
+  it('falls back to default for malformed stored values', async () => {
+    await repository.save([
+      repository.create({
+        key: 'audit.retentionDays',
+        value: 'not-a-number',
+        category: 'audit',
+      }),
+    ]);
+    await expect(service.getRetentionDays()).resolves.toBe(0);
+  });
+
+  it('allows 0 to disable cleanup', async () => {
+    await service.setRetentionDays(0);
+    await expect(service.getRetentionDays()).resolves.toBe(0);
+  });
+});
+
+describe('audit settings HTTP contract', () => {
+  let dataSource: DataSource;
+  let repository: Repository<SystemSetting>;
+  let service: AuditSettingsService;
+  let controller: AuditSettingsController;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      dropSchema: true,
+      synchronize: true,
+      logging: false,
+      entities: [SystemSetting],
+    });
+    await dataSource.initialize();
+    repository = dataSource.getRepository(SystemSetting);
+    service = new AuditSettingsService(repository);
+    controller = new AuditSettingsController(service);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('GET returns the current retention days', async () => {
+    await service.setRetentionDays(14);
+    await expect(controller.getSettings()).resolves.toEqual({
+      retentionDays: 14,
+    });
+  });
+
+  it('PUT updates the retention days', async () => {
+    await controller.updateSettings({ retentionDays: 60 });
+    await expect(service.getRetentionDays()).resolves.toBe(60);
+  });
+
+  it('validates retentionDays must be a non-negative integer', async () => {
+    const valid = plainToInstance(UpdateAuditSettingsDto, {
+      retentionDays: 30,
+    });
+    await expect(validate(valid)).resolves.toHaveLength(0);
+
+    const validZero = plainToInstance(UpdateAuditSettingsDto, {
+      retentionDays: 0,
+    });
+    await expect(validate(validZero)).resolves.toHaveLength(0);
+
+    const invalidNegative = plainToInstance(UpdateAuditSettingsDto, {
+      retentionDays: -1,
+    });
+    await expect(validate(invalidNegative)).resolves.not.toHaveLength(0);
+
+    const invalidFloat = plainToInstance(UpdateAuditSettingsDto, {
+      retentionDays: 3.5,
+    });
+    await expect(validate(invalidFloat)).resolves.not.toHaveLength(0);
+
+    const invalidString = plainToInstance(UpdateAuditSettingsDto, {
+      retentionDays: '30',
+    });
+    await expect(validate(invalidString)).resolves.not.toHaveLength(0);
+  });
+
+  it('restricts reads and updates to administrators', () => {
+    const readHandler = Object.getOwnPropertyDescriptor(
+      AuditSettingsController.prototype,
+      'getSettings',
+    )?.value as (...args: unknown[]) => unknown;
+    const updateHandler = Object.getOwnPropertyDescriptor(
+      AuditSettingsController.prototype,
+      'updateSettings',
+    )?.value as (...args: unknown[]) => unknown;
+
+    expect(Reflect.getMetadata(GUARDS_METADATA, readHandler)).toContain(
+      AdminGuard,
+    );
+    expect(Reflect.getMetadata(GUARDS_METADATA, updateHandler)).toContain(
+      AdminGuard,
+    );
+  });
+});

--- a/src/modules/settings/dto/audit-settings.dto.ts
+++ b/src/modules/settings/dto/audit-settings.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, Min } from 'class-validator';
+
+export class AuditSettingsDto {
+  retentionDays: number;
+}
+
+export class UpdateAuditSettingsDto {
+  @IsInt()
+  @Min(0)
+  retentionDays: number;
+}

--- a/src/modules/settings/settings.module.ts
+++ b/src/modules/settings/settings.module.ts
@@ -6,6 +6,7 @@ import { SmtpSettingsService } from './services/smtp-settings.service';
 import { AuditSettingsService } from './services/audit-settings.service';
 import { GeneralSettingsController } from './general-settings.controller';
 import { FrontendSettingsController } from './frontend-settings.controller';
+import { AuditSettingsController } from './audit-settings.controller';
 import { GeneralSettingsService } from './services/general-settings.service';
 
 /**
@@ -24,6 +25,7 @@ import { GeneralSettingsService } from './services/general-settings.service';
     SettingsController,
     GeneralSettingsController,
     FrontendSettingsController,
+    AuditSettingsController,
   ],
   providers: [
     SmtpSettingsService,


### PR DESCRIPTION
## Summary

- Expose the audit log retention days configuration through a new `GET/PUT /api/settings/audit` API endpoint, restricted to administrators
- Previously the retention days could only be changed by direct database manipulation — the `setRetentionDays()` method existed but had no caller

## Changes

| File | Change |
|------|--------|
| `dto/audit-settings.dto.ts` | New DTO with `retentionDays` field validated via `@IsInt()` and `@Min(0)` |
| `audit-settings.controller.ts` | New controller with `GET /settings/audit` and `PUT /settings/audit`, guarded by `AdminGuard` |
| `settings.module.ts` | Register `AuditSettingsController` |
| `audit-settings.service.spec.ts` | Tests for service persistence, fallback on malformed values, controller contract, and DTO validation |

## Usage

```http
GET /api/settings/audit
```
```json
{ "retentionDays": 0 }
```

```http
PUT /api/settings/audit
{ "retentionDays": 30 }
```

A value of `0` disables auto-cleanup (default). The daily cron job in `AuditCleanupService` reads this setting and deletes audit records older than the configured number of days.