### PR TITLE
feat(rbac): enforce fine-grained console permissions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -48,6 +48,13 @@ import { NexusToken } from './modules/nexus/entities/nexus-token.entity';
 import { NexusBuild } from './modules/nexus/entities/nexus-build.entity';
 import { UserGroupModule } from './modules/user-group/user-group.module';
 import { UserGroup } from './modules/user-group/entities/user-group.entity';
+import { RbacModule } from './modules/rbac/rbac.module';
+import { Role } from './modules/rbac/entities/role.entity';
+import { RolePermission } from './modules/rbac/entities/role-permission.entity';
+import { UserRoleAssignment } from './modules/rbac/entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from './modules/rbac/entities/user-role-assignment-device-group.entity';
+import { ConsoleAudit } from './modules/rbac/entities/console-audit.entity';
+import { RbacGuard } from './modules/rbac/guards/rbac.guard';
 
 /**
  * 应用根模块
@@ -112,6 +119,11 @@ import { UserGroup } from './modules/user-group/entities/user-group.entity';
         NexusToken,
         NexusBuild,
         UserGroup,
+        Role,
+        RolePermission,
+        UserRoleAssignment,
+        UserRoleAssignmentDeviceGroup,
+        ConsoleAudit,
       ],
       synchronize: true,
       logging: false,
@@ -132,6 +144,7 @@ import { UserGroup } from './modules/user-group/entities/user-group.entity';
     UpdateCheckModule,
     NexusModule,
     UserGroupModule,
+    RbacModule,
   ],
   providers: [
     {
@@ -141,6 +154,10 @@ import { UserGroup } from './modules/user-group/entities/user-group.entity';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RbacGuard,
     },
   ],
 })

--- a/src/common/guards/admin.guard.ts
+++ b/src/common/guards/admin.guard.ts
@@ -4,6 +4,8 @@ import {
   ExecutionContext,
   ForbiddenException,
 } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { User, UserStatus } from '../../modules/user/entities/user.entity';
 
 @Injectable()
 /**
@@ -14,20 +16,33 @@ import {
  * 只有管理员才能访问的路由会使用此守卫
  *
  * 验证逻辑：
- * 检查用户信息中的isAdmin字段
+ * 读取数据库中的当前用户状态和 isAdmin 字段，不信任 JWT 内的旧权限状态
  */
 export class AdminGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context
       .switchToHttp()
-      .getRequest<{ user?: { isAdmin?: boolean } }>();
+      .getRequest<{ user?: { id?: string } }>();
     const user = request.user;
 
     if (!user) {
       throw new ForbiddenException('请先登录');
     }
 
-    if (!user.isAdmin) {
+    if (!user.id) {
+      throw new ForbiddenException('授权服务不可用');
+    }
+
+    const currentUser = await this.dataSource.getRepository(User).findOne({
+      where: { guid: user.id },
+      select: ['guid', 'isAdmin', 'status'],
+    });
+    const isAdmin =
+      currentUser?.isAdmin === true && currentUser.status === UserStatus.ACTIVE;
+
+    if (!isAdmin) {
       throw new ForbiddenException('无权限访问，需要管理员权限');
     }
 

--- a/src/common/interfaces/login-response.interface.ts
+++ b/src/common/interfaces/login-response.interface.ts
@@ -19,6 +19,8 @@ export interface LoginResponse {
   passkey_options?: PublicKeyCredentialRequestOptionsJSON;
   /** 用户信息 */
   user?: {
+    /** Stable database identifier */
+    guid: string;
     /** 用户名 */
     name: string;
     /** 显示名称 */

--- a/src/database/database-init.service.spec.ts
+++ b/src/database/database-init.service.spec.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+import { DatabaseInitService } from './database-init.service';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+describe('DatabaseInitService owner startup guard', () => {
+  function createService() {
+    const userRepository = {
+      count: jest.fn(),
+    };
+    const dataSource = {
+      query: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new DatabaseInitService(
+      userRepository as never,
+      undefined as never,
+      undefined as never,
+      {
+        initializeStorage: jest.fn().mockResolvedValue({ guid: 'default' }),
+      } as never,
+      dataSource as never,
+    );
+    const internals = service as unknown as {
+      createDefaultAdmin: jest.Mock;
+      createDefaultOidcProviders: jest.Mock;
+      cleanupExpiredAuthStates: jest.Mock;
+    };
+    const createDefaultAdmin = (internals.createDefaultAdmin = jest.fn());
+    const createDefaultOidcProviders = (internals.createDefaultOidcProviders =
+      jest.fn());
+    const cleanupExpiredAuthStates = (internals.cleanupExpiredAuthStates =
+      jest.fn());
+    return {
+      service,
+      userRepository,
+      dataSource,
+      createDefaultAdmin,
+      createDefaultOidcProviders,
+      cleanupExpiredAuthStates,
+    };
+  }
+
+  it.each([0, 1])('continues startup with %i owner(s)', async (owners) => {
+    const context = createService();
+    context.userRepository.count.mockResolvedValue(owners);
+
+    await context.service.onModuleInit();
+
+    expect(context.createDefaultAdmin).toHaveBeenCalledWith('default');
+    expect(context.dataSource.query).toHaveBeenCalledWith(
+      'CREATE UNIQUE INDEX IF NOT EXISTS UQ_users_single_owner ON users (isAdmin) WHERE isAdmin = 1',
+    );
+    expect(context.createDefaultOidcProviders).toHaveBeenCalledTimes(1);
+    expect(context.cleanupExpiredAuthStates).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects startup when legacy data contains multiple owners', async () => {
+    const context = createService();
+    context.userRepository.count.mockResolvedValue(2);
+
+    await expect(context.service.onModuleInit()).rejects.toThrow(
+      'Database contains 2 system owners',
+    );
+    expect(context.createDefaultAdmin).not.toHaveBeenCalled();
+    expect(context.dataSource.query).not.toHaveBeenCalled();
+    expect(context.createDefaultOidcProviders).not.toHaveBeenCalled();
+    expect(context.cleanupExpiredAuthStates).not.toHaveBeenCalled();
+  });
+});

--- a/src/database/database-init.service.ts
+++ b/src/database/database-init.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, QueryFailedError, Repository } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import { User, UserStatus } from '../modules/user/entities/user.entity';
@@ -27,10 +27,39 @@ export class DatabaseInitService implements OnModuleInit {
     @InjectRepository(OidcAuthState)
     private oidcAuthStateRepository: Repository<OidcAuthState>,
     private readonly userGroupService: UserGroupService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async onModuleInit() {
     const defaultGroup = await this.userGroupService.initializeStorage();
+    const owners = await this.userRepository.count({
+      where: { isAdmin: true },
+    });
+    if (owners > 1) {
+      throw new Error(
+        `Database contains ${owners} system owners; resolve the duplicate isAdmin rows offline before starting the server`,
+      );
+    }
+    // The partial unique index is the database-level owner boundary. Creating
+    // it after the explicit legacy check keeps duplicate historical owners
+    // readable and reports them with the actionable error above.
+    try {
+      await this.dataSource.query(
+        'CREATE UNIQUE INDEX IF NOT EXISTS UQ_users_single_owner ON users (isAdmin) WHERE isAdmin = 1',
+      );
+    } catch (error: unknown) {
+      if (error instanceof QueryFailedError) {
+        const currentOwners = await this.userRepository.count({
+          where: { isAdmin: true },
+        });
+        if (currentOwners > 1) {
+          throw new Error(
+            `Database contains ${currentOwners} system owners; resolve the duplicate isAdmin rows offline before starting the server`,
+          );
+        }
+      }
+      throw error;
+    }
     await this.createDefaultAdmin(defaultGroup.guid);
     await this.createDefaultOidcProviders();
     await this.cleanupExpiredAuthStates();
@@ -69,7 +98,19 @@ export class DatabaseInitService implements OnModuleInit {
       userGroupGuid: defaultGroupGuid,
     });
 
-    await this.userRepository.save(admin);
+    try {
+      await this.userRepository.save(admin);
+    } catch (error: unknown) {
+      // Another process may have won the empty-database race after the
+      // unique index was installed. Treat that loser as an idempotent start.
+      if (error instanceof QueryFailedError) {
+        const owner = await this.userRepository.findOne({
+          where: { isAdmin: true },
+        });
+        if (owner) return;
+      }
+      throw error;
+    }
     this.logger.log(`Default admin user created: ${adminUsername}`);
     this.logger.warn(
       `Please change the default password for user: ${adminUsername}`,

--- a/src/modules/address-book/address-book.controller.ts
+++ b/src/modules/address-book/address-book.controller.ts
@@ -10,7 +10,6 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  UseGuards,
 } from '@nestjs/common';
 import { AddressBookService } from './services';
 import {
@@ -31,7 +30,7 @@ import {
 } from './dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AddressBookRuleService } from './services/address-book-rule.service';
-import { AdminGuard } from '../../common/guards/admin.guard';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
 
 /**
  * 地址簿控制器
@@ -251,6 +250,28 @@ export class AddressBookController {
     );
   }
 
+  @Get('shared/:guid/access')
+  @HttpCode(HttpStatus.OK)
+  getWebSharedAddressBook(
+    @Param('guid') guid: string,
+    @CurrentUser('id') userId: number,
+  ) {
+    return this.addressBookService.getWebSharedAddressBook(
+      guid,
+      String(userId),
+    );
+  }
+
+  @Get('shared/:guid/share-candidates')
+  @RequirePermission('address_books.share')
+  @HttpCode(HttpStatus.OK)
+  getShareCandidates(
+    @Param('guid') guid: string,
+    @CurrentUser('id') userId: number,
+  ) {
+    return this.ruleService.getShareCandidates(guid, String(userId));
+  }
+
   /**
    * 添加共享地址簿
    * 创建一个新的共享地址簿
@@ -260,7 +281,7 @@ export class AddressBookController {
    * @returns 操作结果
    */
   @Post('shared/add')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.share')
   @HttpCode(HttpStatus.OK)
   async addSharedAddressBook(
     @Body() dto: CreateAddressBookProfileDto,
@@ -288,7 +309,7 @@ export class AddressBookController {
    * @returns 操作结果
    */
   @Put('shared/update/profile')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.edit')
   @HttpCode(HttpStatus.OK)
   async updateSharedAddressBook(
     @Body() dto: UpdateAddressBookProfileDto,
@@ -318,7 +339,7 @@ export class AddressBookController {
    * @returns 操作结果
    */
   @Delete('shared')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.edit')
   @HttpCode(HttpStatus.OK)
   async deleteSharedAddressBooks(
     @Body() guids: string[],
@@ -573,6 +594,7 @@ export class AddressBookController {
    * @returns 规则列表（分页）
    */
   @Get('rules')
+  @RequirePermission('address_books.view')
   @HttpCode(HttpStatus.OK)
   async getRules(
     @Query() query: RuleQueryDto,
@@ -590,7 +612,7 @@ export class AddressBookController {
    * @returns 新创建的规则 GUID
    */
   @Post('rule')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.share')
   @HttpCode(HttpStatus.OK)
   async addRule(@Body() dto: CreateRuleDto, @CurrentUser('id') userId: number) {
     return this.ruleService.createRule(dto, String(userId));
@@ -605,7 +627,7 @@ export class AddressBookController {
    * @returns 更新成功消息
    */
   @Patch('rule')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.share')
   @HttpCode(HttpStatus.OK)
   async updateRule(
     @Body() dto: UpdateRuleDto,
@@ -623,7 +645,7 @@ export class AddressBookController {
    * @returns 删除成功消息
    */
   @Delete('rules')
-  @UseGuards(AdminGuard)
+  @RequirePermission('address_books.share')
   @HttpCode(HttpStatus.OK)
   async deleteRules(
     @Body() ruleGuids: string[],

--- a/src/modules/address-book/address-book.module.ts
+++ b/src/modules/address-book/address-book.module.ts
@@ -19,6 +19,7 @@ import {
 import { Sysinfo, Peer } from '../../common/entities';
 import { User } from '../user/entities/user.entity';
 import { UserGroupModule } from '../user-group/user-group.module';
+import { UserGroup } from '../user-group/entities/user-group.entity';
 
 /**
  * 地址簿模块
@@ -49,6 +50,7 @@ import { UserGroupModule } from '../user-group/user-group.module';
       Sysinfo,
       Peer,
       User,
+      UserGroup,
     ]),
     UserGroupModule,
   ],

--- a/src/modules/address-book/services/address-book-legacy.service.spec.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.spec.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+import { Repository } from 'typeorm';
+import { AddressBookLegacyService } from './address-book-legacy.service';
+import {
+  AddressBook,
+  AddressBookPeer,
+  AddressBookPeerTag,
+  AddressBookTag,
+} from '../entities';
+import { Sysinfo, Peer } from '../../../common/entities';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+type MockRepository = {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  delete: jest.Mock;
+};
+
+const repository = (): MockRepository => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  delete: jest.fn().mockResolvedValue({ affected: 0 }),
+});
+
+describe('AddressBookLegacyService', () => {
+  it("does not delete peer tags belonging to another user's address book", async () => {
+    const addressBookRepository = repository();
+    const addressBookPeerRepository = repository();
+    const addressBookTagRepository = repository();
+    const addressBookPeerTagRepository = repository();
+    const sysinfoRepository = repository();
+    const peerRepository = repository();
+
+    addressBookRepository.findOne.mockResolvedValue({
+      guid: 'book-a',
+      owner: 'user-a',
+      isPersonal: true,
+    });
+    addressBookPeerRepository.find.mockResolvedValue([{ guid: 'entry-a' }]);
+
+    const service = new AddressBookLegacyService(
+      addressBookRepository as unknown as Repository<AddressBook>,
+      addressBookPeerRepository as unknown as Repository<AddressBookPeer>,
+      addressBookTagRepository as unknown as Repository<AddressBookTag>,
+      addressBookPeerTagRepository as unknown as Repository<AddressBookPeerTag>,
+      sysinfoRepository as unknown as Repository<Sysinfo>,
+      peerRepository as unknown as Repository<Peer>,
+    );
+
+    await service.updateLegacyAddressBook(
+      'user-a',
+      JSON.stringify({ tags: [], peers: [] }),
+    );
+
+    expect(addressBookPeerTagRepository.delete).toHaveBeenCalledTimes(1);
+    const criteria = addressBookPeerTagRepository.delete.mock.calls[0][0] as {
+      peerGuid: { value: string[] };
+    };
+    expect(criteria.peerGuid.value).toEqual(['entry-a']);
+    expect(addressBookPeerTagRepository.delete).not.toHaveBeenCalledWith({});
+    expect(addressBookTagRepository.delete).toHaveBeenCalledWith({
+      addressBookGuid: 'book-a',
+    });
+    expect(addressBookPeerRepository.delete).toHaveBeenCalledWith({
+      addressBookGuid: 'book-a',
+    });
+  });
+});

--- a/src/modules/address-book/services/address-book-legacy.service.spec.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { AddressBookLegacyService } from './address-book-legacy.service';
 import {
   AddressBook,
@@ -43,6 +43,21 @@ describe('AddressBookLegacyService', () => {
     });
     addressBookPeerRepository.find.mockResolvedValue([{ guid: 'entry-a' }]);
 
+    const dataSource = {
+      transaction: async (cb: (manager: unknown) => Promise<unknown>) => {
+        const manager = {
+          getRepository: (target: unknown) => {
+            if (target === AddressBookPeer) return addressBookPeerRepository;
+            if (target === AddressBookPeerTag)
+              return addressBookPeerTagRepository;
+            if (target === AddressBookTag) return addressBookTagRepository;
+            throw new Error(`unexpected repository: ${String(target)}`);
+          },
+        };
+        return cb(manager);
+      },
+    };
+
     const service = new AddressBookLegacyService(
       addressBookRepository as unknown as Repository<AddressBook>,
       addressBookPeerRepository as unknown as Repository<AddressBookPeer>,
@@ -50,6 +65,7 @@ describe('AddressBookLegacyService', () => {
       addressBookPeerTagRepository as unknown as Repository<AddressBookPeerTag>,
       sysinfoRepository as unknown as Repository<Sysinfo>,
       peerRepository as unknown as Repository<Peer>,
+      dataSource as unknown as DataSource,
     );
 
     await service.updateLegacyAddressBook(

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -213,8 +213,17 @@ export class AddressBookLegacyService {
       }
     }
 
-    // 删除所有现有标签和设备
-    await this.addressBookPeerTagRepository.delete({});
+    // Remove only this address book's peer-tag links. The legacy endpoint is
+    // user-scoped; an empty delete criteria would erase every user's tags.
+    const existingPeers = await this.addressBookPeerRepository.find({
+      where: { addressBookGuid },
+      select: ['guid'],
+    });
+    if (existingPeers.length > 0) {
+      await this.addressBookPeerTagRepository.delete({
+        peerGuid: In(existingPeers.map((peer) => peer.guid)),
+      });
+    }
     await this.addressBookTagRepository.delete({ addressBookGuid });
     await this.addressBookPeerRepository.delete({ addressBookGuid });
 

--- a/src/modules/address-book/services/address-book-legacy.service.ts
+++ b/src/modules/address-book/services/address-book-legacy.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, DataSource } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import {
   AddressBook,
@@ -36,6 +36,7 @@ export class AddressBookLegacyService {
     private sysinfoRepository: Repository<Sysinfo>,
     @InjectRepository(Peer)
     private peerRepository: Repository<Peer>,
+    private readonly dataSource: DataSource,
   ) {}
 
   /**
@@ -215,72 +216,81 @@ export class AddressBookLegacyService {
 
     // Remove only this address book's peer-tag links. The legacy endpoint is
     // user-scoped; an empty delete criteria would erase every user's tags.
-    const existingPeers = await this.addressBookPeerRepository.find({
-      where: { addressBookGuid },
-      select: ['guid'],
-    });
-    if (existingPeers.length > 0) {
-      await this.addressBookPeerTagRepository.delete({
-        peerGuid: In(existingPeers.map((peer) => peer.guid)),
+    // Run the full replacement inside one transaction so a later write failure
+    // rolls back the deletes instead of leaving the address book partially
+    // deleted.
+    await this.dataSource.transaction(async (manager) => {
+      const peerRepository = manager.getRepository(AddressBookPeer);
+      const peerTagRepository = manager.getRepository(AddressBookPeerTag);
+      const tagRepository = manager.getRepository(AddressBookTag);
+
+      const existingPeers = await peerRepository.find({
+        where: { addressBookGuid },
+        select: ['guid'],
       });
-    }
-    await this.addressBookTagRepository.delete({ addressBookGuid });
-    await this.addressBookPeerRepository.delete({ addressBookGuid });
-
-    // 创建新标签
-    const tagNameToGuid: Record<string, string> = {};
-    const dangerousProperties = ['__proto__', 'constructor', 'prototype'];
-
-    if (parsedData.tags && parsedData.tags.length > 0) {
-      for (const tagName of parsedData.tags) {
-        if (dangerousProperties.includes(tagName)) {
-          continue;
-        }
-
-        const tagGuid = uuidv4();
-        const tag = this.addressBookTagRepository.create({
-          guid: tagGuid,
-          addressBookGuid,
-          name: tagName,
-          color: tagColors[tagName] || 0,
+      if (existingPeers.length > 0) {
+        await peerTagRepository.delete({
+          peerGuid: In(existingPeers.map((peer) => peer.guid)),
         });
-        await this.addressBookTagRepository.save(tag);
-        tagNameToGuid[tagName] = tagGuid;
       }
-    }
+      await tagRepository.delete({ addressBookGuid });
+      await peerRepository.delete({ addressBookGuid });
 
-    // 创建新设备
-    if (parsedData.peers && parsedData.peers.length > 0) {
-      for (const peerData of parsedData.peers) {
-        // 通过 findOrCreatePeer 查找或创建 peer 记录，获取 uuid 作为 deviceId
-        // 与新版 API 保持一致：deviceId 始终引用 peers.uuid
-        const peerRecord = await this.findOrCreatePeer(peerData.id);
+      // 创建新标签
+      const tagNameToGuid: Record<string, string> = {};
+      const dangerousProperties = ['__proto__', 'constructor', 'prototype'];
 
-        const peerGuid = uuidv4();
-        const peer = this.addressBookPeerRepository.create({
-          guid: peerGuid,
-          addressBookGuid,
-          deviceId: peerRecord.uuid,
-          hash: peerData.hash || '',
-          alias: peerData.alias || '',
-        });
-        await this.addressBookPeerRepository.save(peer);
+      if (parsedData.tags && parsedData.tags.length > 0) {
+        for (const tagName of parsedData.tags) {
+          if (dangerousProperties.includes(tagName)) {
+            continue;
+          }
 
-        // 处理标签关联
-        if (peerData.tags && peerData.tags.length > 0) {
-          for (const tagName of peerData.tags) {
-            const tagGuid = tagNameToGuid[tagName];
-            if (tagGuid) {
-              const peerTag = this.addressBookPeerTagRepository.create({
-                peerGuid,
-                tagGuid,
-              });
-              await this.addressBookPeerTagRepository.save(peerTag);
+          const tagGuid = uuidv4();
+          const tag = tagRepository.create({
+            guid: tagGuid,
+            addressBookGuid,
+            name: tagName,
+            color: tagColors[tagName] || 0,
+          });
+          await tagRepository.save(tag);
+          tagNameToGuid[tagName] = tagGuid;
+        }
+      }
+
+      // 创建新设备
+      if (parsedData.peers && parsedData.peers.length > 0) {
+        for (const peerData of parsedData.peers) {
+          // 通过 findOrCreatePeer 查找或创建 peer 记录，获取 uuid 作为 deviceId
+          // 与新版 API 保持一致：deviceId 始终引用 peers.uuid
+          const peerRecord = await this.findOrCreatePeer(peerData.id);
+
+          const peerGuid = uuidv4();
+          const peer = peerRepository.create({
+            guid: peerGuid,
+            addressBookGuid,
+            deviceId: peerRecord.uuid,
+            hash: peerData.hash || '',
+            alias: peerData.alias || '',
+          });
+          await peerRepository.save(peer);
+
+          // 处理标签关联
+          if (peerData.tags && peerData.tags.length > 0) {
+            for (const tagName of peerData.tags) {
+              const tagGuid = tagNameToGuid[tagName];
+              if (tagGuid) {
+                const peerTag = peerTagRepository.create({
+                  peerGuid,
+                  tagGuid,
+                });
+                await peerTagRepository.save(peerTag);
+              }
             }
           }
         }
       }
-    }
+    });
 
     return 'null';
   }

--- a/src/modules/address-book/services/address-book-rule.service.spec.ts
+++ b/src/modules/address-book/services/address-book-rule.service.spec.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata';
+import { ForbiddenException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { AddressBookController } from '../address-book.controller';
+import { AddressBook, AddressBookRule, ShareRule } from '../entities';
+import { User } from '../../user/entities/user.entity';
+import { UserGroup } from '../../user-group/entities/user-group.entity';
+import { REQUIRE_PERMISSION_KEY } from '../../rbac/decorators/require-permission.decorator';
+import { AddressBookPermissionService } from './address-book-permission.service';
+import { AddressBookRuleService } from './address-book-rule.service';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+describe('Address-book share candidates', () => {
+  const ruleRepository = { count: jest.fn(), find: jest.fn() };
+  const userRepository = { find: jest.fn() };
+  const userGroupRepository = { find: jest.fn() };
+  const permissionService = { checkAddressBookAccess: jest.fn() };
+  const service = new AddressBookRuleService(
+    ruleRepository as unknown as Repository<AddressBookRule>,
+    {} as Repository<AddressBook>,
+    userRepository as unknown as Repository<User>,
+    userGroupRepository as unknown as Repository<UserGroup>,
+    permissionService as unknown as AddressBookPermissionService,
+    {} as never,
+    {} as never,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    permissionService.checkAddressBookAccess.mockResolvedValue({});
+  });
+
+  it('returns names only for principals already assigned to a rule', async () => {
+    ruleRepository.count.mockResolvedValue(2);
+    ruleRepository.find.mockResolvedValue([
+      {
+        guid: 'rule-user',
+        addressBookGuid: 'book-1',
+        targetUserId: 'user-1',
+        targetGroupId: null,
+        rule: 1,
+        ruleType: 'user',
+      },
+      {
+        guid: 'rule-group',
+        addressBookGuid: 'book-1',
+        targetUserId: null,
+        targetGroupId: 'group-1',
+        rule: 2,
+        ruleType: 'group',
+      },
+    ]);
+    userRepository.find.mockResolvedValue([
+      { guid: 'user-1', username: 'alice', displayName: 'Alice' },
+    ]);
+    userGroupRepository.find.mockResolvedValue([
+      { guid: 'group-1', name: 'Operators' },
+    ]);
+
+    const result = await service.getRules({ ab: 'book-1' }, 'actor');
+
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        user: 'user-1',
+        target: { name: 'alice', display_name: 'Alice' },
+      }),
+      expect.objectContaining({
+        group: 'group-1',
+        target: { name: 'Operators' },
+      }),
+    ]);
+  });
+
+  it('guards the address-book-owned endpoint with address_books.share', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        AddressBookController.prototype.getShareCandidates,
+      ),
+    ).toEqual(['address_books.share']);
+  });
+
+  it('checks full-control ACL and returns only selector fields', async () => {
+    userRepository.find.mockResolvedValue([
+      {
+        guid: 'user-1',
+        username: 'alice',
+        displayName: 'Alice',
+        email: 'secret@example.com',
+        status: 1,
+      },
+    ]);
+    userGroupRepository.find.mockResolvedValue([
+      { guid: 'group-1', name: 'Operators', note: 'not exposed' },
+    ]);
+
+    const result = await service.getShareCandidates('book-1', 'actor');
+
+    expect(permissionService.checkAddressBookAccess).toHaveBeenCalledWith(
+      'book-1',
+      'actor',
+      ShareRule.FULL_CONTROL,
+    );
+    expect(result).toEqual({
+      users: [{ guid: 'user-1', name: 'alice', display_name: 'Alice' }],
+      groups: [{ guid: 'group-1', name: 'Operators' }],
+    });
+    expect(JSON.stringify(result)).not.toContain('secret@example.com');
+    expect(JSON.stringify(result)).not.toContain('not exposed');
+  });
+
+  it('does not load candidates after an object-ACL denial', async () => {
+    permissionService.checkAddressBookAccess.mockRejectedValue(
+      new ForbiddenException('需要完全控制权限'),
+    );
+
+    await expect(
+      service.getShareCandidates('book-1', 'actor'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(userRepository.find).not.toHaveBeenCalled();
+    expect(userGroupRepository.find).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/address-book/services/address-book-rule.service.ts
+++ b/src/modules/address-book/services/address-book-rule.service.ts
@@ -19,13 +19,14 @@ import {
 } from '../dto';
 import { AddressBookPermissionService } from './address-book-permission.service';
 import { UserGroupService } from '../../user-group/user-group.service';
+import { UserGroup } from '../../user-group/entities/user-group.entity';
 
 interface SharedAddressBookRow {
   guid: string;
   name: string | null;
   owner: string;
   note: string | null;
-  info: string | null;
+  info?: string | null;
   rule: string | number;
 }
 
@@ -68,6 +69,9 @@ export class AddressBookRuleService {
     @InjectRepository(User)
     private userRepository: Repository<User>,
 
+    @InjectRepository(UserGroup)
+    private userGroupRepository: Repository<UserGroup>,
+
     private readonly permissionService: AddressBookPermissionService,
     private readonly userGroupService: UserGroupService,
     private readonly dataSource: DataSource,
@@ -102,8 +106,54 @@ export class AddressBookRuleService {
       order: { createdAt: 'ASC' },
     });
 
+    const userIds = [
+      ...new Set(
+        rules
+          .map((rule) => rule.targetUserId)
+          .filter((guid): guid is string => Boolean(guid)),
+      ),
+    ];
+    const groupIds = [
+      ...new Set(
+        rules
+          .map((rule) => rule.targetGroupId)
+          .filter((guid): guid is string => Boolean(guid)),
+      ),
+    ];
+    const usersPromise: Promise<User[]> = userIds.length
+      ? this.userRepository.find({
+          where: { guid: In(userIds) },
+          select: ['guid', 'username', 'displayName'],
+        })
+      : Promise.resolve([]);
+    const groupsPromise: Promise<UserGroup[]> = groupIds.length
+      ? this.userGroupRepository.find({
+          where: { guid: In(groupIds) },
+          select: ['guid', 'name'],
+        })
+      : Promise.resolve([]);
+    const [users, groups] = await Promise.all([usersPromise, groupsPromise]);
+    const userTargets = new Map<string, { name: string; display_name: string }>(
+      users.map((user) => [
+        user.guid,
+        {
+          name: user.username,
+          display_name: user.displayName || user.username,
+        },
+      ]),
+    );
+    const groupTargets = new Map<string, { name: string }>(
+      groups.map((group) => [group.guid, { name: group.name }] as const),
+    );
+
     return {
-      data: rules.map((rule) => this.toResponseFormat(rule)),
+      data: rules.map((rule) => ({
+        ...this.toResponseFormat(rule),
+        target:
+          (rule.targetUserId && userTargets.get(rule.targetUserId)) ||
+          (rule.targetGroupId && groupTargets.get(rule.targetGroupId)) ||
+          undefined,
+      })),
       total,
     };
   }
@@ -234,33 +284,50 @@ export class AddressBookRuleService {
     if (!ruleGuids || ruleGuids.length === 0) {
       throw new BadRequestException('至少需要一个规则 GUID');
     }
-
-    // 获取所有规则的信息（用于权限检查和获取 addressBookGuid 字段）
-    const rules = await this.ruleRepository.find({
-      where: ruleGuids.map((g) => ({ guid: g })),
-      relations: ['addressBook'],
-    });
-
-    if (rules.length === 0) {
-      throw new NotFoundException('未找到任何规则');
+    const uniqueGuids = [...new Set(ruleGuids)];
+    const invalidGuid = uniqueGuids.find((guid) => !isUUID(guid, '4'));
+    if (invalidGuid) {
+      throw new BadRequestException(`规则 GUID 格式无效: ${invalidGuid}`);
     }
 
-    // 检查每个规则所属的地址簿权限，确保用户对所有地址簿都有权限
-    for (const rule of rules) {
-      await this.permissionService.checkAddressBookAccess(
-        rule.addressBookGuid,
-        userId,
-        ShareRule.FULL_CONTROL,
-      );
-    }
-
-    // 由于 AddressBookRule 有多个主键，需要使用完整的主键对象删除
-    for (const rule of rules) {
-      await this.ruleRepository.delete({
-        guid: rule.guid,
-        addressBookGuid: rule.addressBookGuid,
+    await this.dataSource.transaction(async (manager) => {
+      const ruleRepository = manager.getRepository(AddressBookRule);
+      const rules = await ruleRepository.find({
+        where: uniqueGuids.map((guid) => ({ guid })),
+        relations: ['addressBook'],
       });
-    }
+      const rulesByGuid = new Map<string, AddressBookRule[]>();
+      for (const rule of rules) {
+        const matches = rulesByGuid.get(rule.guid) || [];
+        matches.push(rule);
+        rulesByGuid.set(rule.guid, matches);
+      }
+      if (uniqueGuids.some((guid) => !rulesByGuid.has(guid))) {
+        throw new NotFoundException('未找到任何规则');
+      }
+
+      const orderedRules = uniqueGuids.flatMap(
+        (guid) => rulesByGuid.get(guid) || [],
+      );
+      for (const rule of orderedRules) {
+        await this.permissionService.checkAddressBookAccess(
+          rule.addressBookGuid,
+          userId,
+          ShareRule.FULL_CONTROL,
+        );
+      }
+
+      // AddressBookRule has a compound primary key; delete each complete key.
+      for (const rule of orderedRules) {
+        const result = await ruleRepository.delete({
+          guid: rule.guid,
+          addressBookGuid: rule.addressBookGuid,
+        });
+        if (result.affected !== 1) {
+          throw new NotFoundException('未找到任何规则');
+        }
+      }
+    });
 
     return { message: '删除成功' };
   }
@@ -281,6 +348,51 @@ export class AddressBookRuleService {
 
   async getWebSharedAddressBooks(userId: string, query: PaginationDto) {
     return this.getAccessibleAddressBooks(userId, query, true);
+  }
+
+  async getWebSharedAddressBook(guid: string, userId: string) {
+    const result = await this.getAccessibleAddressBooks(
+      userId,
+      { current: 1, pageSize: 1 },
+      true,
+      guid,
+    );
+    const addressBook = result.data[0];
+    if (!addressBook) {
+      throw new NotFoundException('共享地址簿不存在');
+    }
+    return addressBook;
+  }
+
+  async getShareCandidates(guid: string, userId: string) {
+    await this.permissionService.checkAddressBookAccess(
+      guid,
+      userId,
+      ShareRule.FULL_CONTROL,
+    );
+
+    const [users, groups] = await Promise.all([
+      this.userRepository.find({
+        select: ['guid', 'username', 'displayName'],
+        order: { username: 'ASC' },
+      }),
+      this.userGroupRepository.find({
+        select: ['guid', 'name'],
+        order: { name: 'ASC' },
+      }),
+    ]);
+
+    return {
+      users: users.map((user) => ({
+        guid: user.guid,
+        name: user.username,
+        display_name: user.displayName || user.username,
+      })),
+      groups: groups.map((group) => ({
+        guid: group.guid,
+        name: group.name,
+      })),
+    };
   }
 
   async getCustomAddressBooks(userId: string, query: PaginationDto) {
@@ -402,6 +514,7 @@ export class AddressBookRuleService {
     userId: string,
     query: PaginationDto,
     sharedOnly: boolean,
+    guid?: string,
   ) {
     const { current = 1, pageSize = 100, name } = query;
     const skip = (current - 1) * pageSize;
@@ -448,6 +561,10 @@ export class AddressBookRuleService {
       );
     }
 
+    if (guid) {
+      queryBuilder.andWhere('addressBook.guid = :guid', { guid });
+    }
+
     const trimmedName = name?.trim();
     if (trimmedName) {
       queryBuilder.andWhere('addressBook.name LIKE :name', {
@@ -460,12 +577,11 @@ export class AddressBookRuleService {
       .select('COUNT(DISTINCT addressBook.guid)', 'total')
       .getRawOne<{ total: string | number }>();
 
-    const rows = await queryBuilder
+    const rowsQuery = queryBuilder
       .select('addressBook.guid', 'guid')
       .addSelect('addressBook.name', 'name')
       .addSelect('addressBook.owner', 'owner')
       .addSelect('addressBook.note', 'note')
-      .addSelect('addressBook.info', 'info')
       .addSelect(
         'MAX(CASE WHEN addressBook.owner = :userId THEN :fullControl ELSE rule.rule END)',
         'rule',
@@ -474,8 +590,15 @@ export class AddressBookRuleService {
       .groupBy('addressBook.guid')
       .addGroupBy('addressBook.name')
       .addGroupBy('addressBook.owner')
-      .addGroupBy('addressBook.note')
-      .addGroupBy('addressBook.info')
+      .addGroupBy('addressBook.note');
+
+    if (!sharedOnly) {
+      rowsQuery
+        .addSelect('addressBook.info', 'info')
+        .addGroupBy('addressBook.info');
+    }
+
+    const rows = await rowsQuery
       .orderBy('addressBook.name', 'ASC')
       .addOrderBy('addressBook.guid', 'ASC')
       .offset(skip)
@@ -504,7 +627,13 @@ export class AddressBookRuleService {
       owner: userMap.get(row.owner) || row.owner,
       note: row.note || '',
       rule: Number(row.rule),
-      info: row.info ? (JSON.parse(row.info) as Record<string, unknown>) : {},
+      ...(!sharedOnly
+        ? {
+            info: row.info
+              ? (JSON.parse(row.info) as Record<string, unknown>)
+              : {},
+          }
+        : {}),
       ...(sharedOnly ? { is_owner: row.owner === userId } : {}),
     }));
 

--- a/src/modules/address-book/services/address-book.service.ts
+++ b/src/modules/address-book/services/address-book.service.ts
@@ -309,6 +309,10 @@ export class AddressBookService {
     return this.ruleService.getWebSharedAddressBooks(userId, query);
   }
 
+  async getWebSharedAddressBook(guid: string, userId: string) {
+    return this.ruleService.getWebSharedAddressBook(guid, userId);
+  }
+
   /**
    * 添加共享地址簿
    * 委托给 RuleService 处理

--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Post,
   Body,
-  UseGuards,
   Get,
   Query,
   Patch,
@@ -13,12 +12,18 @@ import { Throttle } from '@nestjs/throttler';
 import { AuditService } from './audit.service';
 import {
   ConnectionAuditDto,
+  ActiveConnectionQueryDto,
+  ConnectionAuditQueryDto,
   UpdateConnectionAuditDto,
 } from './dto/connection-audit.dto';
 import { FileAuditDto } from './dto/file-audit.dto';
 import { AlarmAuditDto } from './dto/alarm-audit.dto';
 import { Public } from '../auth/decorators/public.decorator';
-import { AdminGuard } from '../../common/guards/admin.guard';
+import {
+  RequirePermission,
+  RequireSuperAdmin,
+} from '../rbac/decorators/require-permission.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
 /**
  * 审计控制器
@@ -135,6 +140,15 @@ export class AuditsController {
 
   // ============ 审计查询接口（管理端调用，需要认证）============
 
+  @RequirePermission('devices.disconnect')
+  @Get('conn/active')
+  queryActiveConnections(
+    @Query() query: ActiveConnectionQueryDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.auditService.queryActiveConnections(userId, query);
+  }
+
   /**
    * 查询连接审计
    * 查询远程桌面连接的审计记录
@@ -146,7 +160,7 @@ export class AuditsController {
    * - 支持按连接类型过滤（type，-1表示未建立连接）
    *
    * 安全措施：
-   * - 使用AdminGuard进行认证
+   * - 需要 audit.view 权限
    * - 只有管理员可以查询审计记录
    *
    * @param deviceId 被控端设备ID（模糊匹配）
@@ -157,24 +171,13 @@ export class AuditsController {
    * @param current 当前页码
    * @returns 连接审计列表
    */
-  @UseGuards(AdminGuard)
+  @RequirePermission('audit.view')
   @Get('conn')
   async queryConnectionAudits(
-    @Query('deviceId') deviceId?: string,
-    @Query('type') type?: number,
-    @Query('startTime') startTime?: string,
-    @Query('endTime') endTime?: string,
-    @Query('pageSize') pageSize?: number,
-    @Query('current') current?: number,
+    @CurrentUser('id') userId: string,
+    @Query() query: ConnectionAuditQueryDto,
   ) {
-    return await this.auditService.queryConnectionAudits({
-      deviceId,
-      type,
-      startTime,
-      endTime,
-      pageSize,
-      current,
-    });
+    return await this.auditService.queryConnectionAudits(query, userId);
   }
 
   /**
@@ -184,7 +187,7 @@ export class AuditsController {
    * @param id 连接审计记录主键
    * @param dto 更新数据
    */
-  @UseGuards(AdminGuard)
+  @RequireSuperAdmin()
   @Patch('conn/:id')
   async updateConnectionAudit(
     @Param('id', ParseIntPipe) id: number,
@@ -209,7 +212,7 @@ export class AuditsController {
    * - 支持按文件传输类型过滤（type: 0-发送, 1-接收）
    *
    * 安全措施：
-   * - 使用AdminGuard进行认证
+   * - 需要 audit.view 权限
    * - 只有管理员可以查询审计记录
    *
    * @param deviceId 被控端设备ID（模糊匹配）
@@ -220,7 +223,7 @@ export class AuditsController {
    * @param current 当前页码
    * @returns 文件审计列表
    */
-  @UseGuards(AdminGuard)
+  @RequirePermission('audit.view')
   @Get('file')
   async queryFileAudits(
     @Query('deviceId') deviceId?: string,
@@ -251,7 +254,7 @@ export class AuditsController {
    * - 支持按告警类型过滤（type: 0-IP白名单, 1-超30次尝试, 2-1分钟6次尝试, 6-IPv6前缀超限, 7-终端OS登录backoff, 8-终端OS登录并发超限）
    *
    * 安全措施：
-   * - 使用AdminGuard进行认证
+   * - 需要 audit.view 权限
    * - 只有管理员可以查询审计记录
    *
    * @param deviceId 被控端设备ID（模糊匹配）
@@ -262,7 +265,7 @@ export class AuditsController {
    * @param current 当前页码
    * @returns 告警审计列表
    */
-  @UseGuards(AdminGuard)
+  @RequirePermission('audit.view')
   @Get('alarm')
   async queryAlarmAudits(
     @Query('deviceId') deviceId?: string,
@@ -292,7 +295,7 @@ export class AuditsController {
    * - 支持按创建时间过滤
    *
    * 安全措施：
-   * - 使用AdminGuard进行认证
+   * - 需要 audit.view 权限
    * - 只有管理员可以查询审计记录
    *
    * @param operator 操作人（模糊匹配）
@@ -301,7 +304,7 @@ export class AuditsController {
    * @param created_at 创建时间（UTC时间字符串）
    * @returns 控制台审计列表
    */
-  @UseGuards(AdminGuard)
+  @RequirePermission('audit.view')
   @Get('console')
   queryConsoleAudits(
     @Query('operator') operator?: string,

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -7,6 +7,9 @@ import { ConnectionAudit } from './entities/connection-audit.entity';
 import { FileAudit } from './entities/file-audit.entity';
 import { AlarmAudit } from './entities/alarm-audit.entity';
 import { SettingsModule } from '../settings/settings.module';
+import { RbacModule } from '../rbac/rbac.module';
+import { ActiveConnection } from '../heartbeat/entities/active-connection.entity';
+import { Peer } from '../../common/entities/peer.entity';
 
 /**
  * 审计模块
@@ -25,8 +28,15 @@ import { SettingsModule } from '../settings/settings.module';
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ConnectionAudit, FileAudit, AlarmAudit]),
+    TypeOrmModule.forFeature([
+      ConnectionAudit,
+      FileAudit,
+      AlarmAudit,
+      ActiveConnection,
+      Peer,
+    ]),
     SettingsModule,
+    RbacModule,
   ],
   controllers: [AuditController, AuditsController],
   providers: [AuditService, AuditCleanupService],

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,0 +1,315 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { Repository } from 'typeorm';
+import { Peer } from '../../common/entities/peer.entity';
+import { REQUIRE_PERMISSION_KEY } from '../rbac/decorators/require-permission.decorator';
+import { RbacAuditService } from '../rbac/services/rbac-audit.service';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
+import { ConsoleAudit } from '../rbac/entities/console-audit.entity';
+import { User } from '../user/entities/user.entity';
+import { ActiveConnection } from '../heartbeat/entities/active-connection.entity';
+import { AuditsController } from './audit.controller';
+import { AuditService } from './audit.service';
+import { ActiveConnectionQueryDto } from './dto/connection-audit.dto';
+import { AlarmAudit } from './entities/alarm-audit.entity';
+import { ConnectionAudit } from './entities/connection-audit.entity';
+import { FileAudit } from './entities/file-audit.entity';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+describe('Disconnect connection reads', () => {
+  const connectionAuditRepository = {
+    createQueryBuilder: jest.fn(),
+  };
+  const activeConnectionRepository = {
+    createQueryBuilder: jest.fn(),
+    find: jest.fn(),
+  };
+  const peerRepository = { find: jest.fn() };
+  const authorizationService = {
+    requirePermission: jest.fn(),
+    getPermissionScope: jest.fn(),
+  };
+  const service = new AuditService(
+    connectionAuditRepository as unknown as Repository<ConnectionAudit>,
+    {} as Repository<FileAudit>,
+    {} as Repository<AlarmAudit>,
+    activeConnectionRepository as unknown as Repository<ActiveConnection>,
+    peerRepository as unknown as Repository<Peer>,
+    {} as RbacAuditService,
+    authorizationService as unknown as RbacAuthorizationService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizationService.requirePermission.mockResolvedValue({
+      global: true,
+      deviceGroupGuids: new Set<string>(),
+    });
+    authorizationService.getPermissionScope.mockResolvedValue({
+      global: true,
+      deviceGroupGuids: new Set<string>(),
+    });
+  });
+
+  it('guards the active list independently of audit.view', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        AuditsController.prototype.queryActiveConnections,
+      ),
+    ).toEqual(['devices.disconnect']);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        AuditsController.prototype.queryConnectionAudits,
+      ),
+    ).toEqual(['audit.view']);
+  });
+
+  it('returns only active in-scope disconnect selector fields', async () => {
+    const builder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(1),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          deviceUuid: 'device-1',
+          deviceId: '123456789',
+          connId: '42',
+          peerName: 'not exposed',
+        },
+      ]),
+    };
+    activeConnectionRepository.createQueryBuilder.mockReturnValue(builder);
+    authorizationService.requirePermission.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    });
+
+    const result = await service.queryActiveConnections('actor', {
+      current: 2,
+      pageSize: 10,
+      deviceId: '123',
+    });
+
+    expect(result).toEqual({
+      data: [
+        {
+          deviceId: '123456789',
+          deviceUuid: 'device-1',
+          connId: 42,
+          can_disconnect: true,
+        },
+      ],
+      total: 1,
+    });
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      'peer.deviceGroupGuid IN (:...deviceGroupGuids)',
+      { deviceGroupGuids: ['group-1'] },
+    );
+    expect(builder.offset).toHaveBeenCalledWith(10);
+    expect(JSON.stringify(result)).not.toContain('not exposed');
+  });
+
+  it('returns no active connections when the device scope is empty', async () => {
+    const builder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(0),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+    activeConnectionRepository.createQueryBuilder.mockReturnValue(builder);
+    authorizationService.requirePermission.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set<string>(),
+    });
+
+    await expect(
+      service.queryActiveConnections('actor', { current: 1, pageSize: 20 }),
+    ).resolves.toEqual({ data: [], total: 0 });
+    expect(builder.andWhere).toHaveBeenCalledWith('1 = 0');
+  });
+
+  it('marks full-audit rows from current active connections and device scope', async () => {
+    const auditRows = [
+      {
+        deviceUuid: 'device-1',
+        connId: '42',
+        closedAt: null,
+        createdAt: new Date(),
+      },
+      {
+        deviceUuid: 'device-2',
+        connId: '43',
+        closedAt: null,
+        createdAt: new Date(),
+      },
+    ] as unknown as ConnectionAudit[];
+    const builder = {
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([auditRows, 2]),
+    };
+    connectionAuditRepository.createQueryBuilder.mockReturnValue(builder);
+    authorizationService.getPermissionScope.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    });
+    peerRepository.find.mockResolvedValue([{ uuid: 'device-1' }]);
+    activeConnectionRepository.find.mockResolvedValue([
+      { deviceUuid: 'device-1', connId: 42 },
+    ]);
+
+    const result = await service.queryConnectionAudits({}, 'actor');
+
+    expect(result.data.map((row) => row.can_disconnect)).toEqual([true, false]);
+    expect(peerRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: ['uuid'],
+      }),
+    );
+  });
+
+  it('validates active-list pagination and rejects unknown fields', async () => {
+    const dto = plainToInstance(ActiveConnectionQueryDto, {
+      current: 0,
+      pageSize: 101,
+      secret: true,
+    });
+    expect(
+      await validate(dto, { whitelist: true, forbidNonWhitelisted: true }),
+    ).not.toHaveLength(0);
+  });
+});
+
+describe('Console audit query contract', () => {
+  const repository = { createQueryBuilder: jest.fn() };
+  const builder = {
+    leftJoin: jest.fn(),
+    addSelect: jest.fn(),
+    andWhere: jest.fn(),
+    orderBy: jest.fn(),
+    skip: jest.fn(),
+    take: jest.fn(),
+    getCount: jest.fn(),
+    getRawAndEntities: jest.fn(),
+  };
+  const service = new RbacAuditService(
+    repository as unknown as Repository<ConsoleAudit>,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const method of [
+      'leftJoin',
+      'addSelect',
+      'andWhere',
+      'orderBy',
+      'skip',
+      'take',
+    ]) {
+      builder[method as keyof typeof builder].mockReturnValue(builder);
+    }
+    repository.createQueryBuilder.mockReturnValue(builder);
+  });
+
+  it('joins usernames, filters by username, and returns stable actor fields', async () => {
+    const first = {
+      guid: 'audit-1',
+      actorUserGuid: 'user-1',
+      targetType: 'role',
+      targetGuid: 'role-1',
+      action: 'role.update',
+      result: 'allowed',
+      reason: null,
+      beforeState: null,
+      afterState: null,
+      requestId: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    } as unknown as ConsoleAudit;
+    const second = { ...first, guid: 'audit-2', actorUserGuid: 'deleted-user' };
+    builder.getCount.mockResolvedValue(2);
+    builder.getRawAndEntities.mockResolvedValue({
+      entities: [first, second],
+      raw: [
+        { audit_guid: 'audit-1', actor_user_name: 'alice' },
+        { audit_guid: 'audit-2', actor_user_name: null },
+      ],
+    });
+
+    await expect(
+      service.query({ operator: 'ali', current: 2, pageSize: 10 }),
+    ).resolves.toMatchObject({
+      total: 2,
+      data: [
+        {
+          guid: 'audit-1',
+          actor_user_guid: 'user-1',
+          actor_user_name: 'alice',
+        },
+        {
+          guid: 'audit-2',
+          actor_user_guid: 'deleted-user',
+          actor_user_name: null,
+        },
+      ],
+    });
+    expect(builder.leftJoin).toHaveBeenCalledWith(
+      User,
+      'actor',
+      'actor.guid = audit.actorUserGuid',
+    );
+    expect(builder.addSelect).toHaveBeenCalledWith(
+      'actor.username',
+      'actor_user_name',
+    );
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      'actor.username LIKE :operator',
+      { operator: '%ali%' },
+    );
+    expect(builder.skip).toHaveBeenCalledWith(10);
+    expect(builder.take).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('Console audit controller contract', () => {
+  it('forwards the operator filter to the service', async () => {
+    const queryConsoleAudits = jest
+      .fn()
+      .mockResolvedValue({ data: [], total: 0 });
+    const controller = new AuditsController({
+      queryConsoleAudits,
+    } as unknown as AuditService);
+
+    await expect(
+      controller.queryConsoleAudits('alice', 10, 2, '2026-01-01'),
+    ).resolves.toEqual({ data: [], total: 0 });
+    expect(queryConsoleAudits).toHaveBeenCalledWith({
+      operator: 'alice',
+      pageSize: 10,
+      current: 2,
+      created_at: '2026-01-01',
+    });
+  });
+});

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindOptionsWhere } from 'typeorm';
+import { Repository, FindOptionsWhere, In } from 'typeorm';
 import { ConnectionAudit, ConnType } from './entities/connection-audit.entity';
 import { FileAudit } from './entities/file-audit.entity';
 import { AlarmAudit } from './entities/alarm-audit.entity';
@@ -8,6 +8,11 @@ import { ConnectionAuditDto } from './dto/connection-audit.dto';
 import { UpdateConnectionAuditDto } from './dto/connection-audit.dto';
 import { FileAuditDto } from './dto/file-audit.dto';
 import { AlarmAuditDto } from './dto/alarm-audit.dto';
+import { RbacAuditService } from '../rbac/services/rbac-audit.service';
+import { ActiveConnection } from '../heartbeat/entities/active-connection.entity';
+import { Peer } from '../../common/entities/peer.entity';
+import { ActiveConnectionQueryDto } from './dto/connection-audit.dto';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 @Injectable()
 /**
@@ -32,6 +37,12 @@ export class AuditService {
     private readonly fileAuditRepository: Repository<FileAudit>,
     @InjectRepository(AlarmAudit)
     private readonly alarmAuditRepository: Repository<AlarmAudit>,
+    @InjectRepository(ActiveConnection)
+    private readonly activeConnectionRepository: Repository<ActiveConnection>,
+    @InjectRepository(Peer)
+    private readonly peerRepository: Repository<Peer>,
+    private readonly rbacAuditService: RbacAuditService,
+    private readonly rbacAuthorizationService: RbacAuthorizationService,
   ) {}
 
   /**
@@ -277,14 +288,17 @@ export class AuditService {
    * @param filters 过滤条件
    * @returns 连接审计列表
    */
-  async queryConnectionAudits(filters: {
-    deviceId?: string;
-    type?: number;
-    startTime?: string;
-    endTime?: string;
-    pageSize?: number;
-    current?: number;
-  }) {
+  async queryConnectionAudits(
+    filters: {
+      deviceId?: string;
+      type?: number;
+      startTime?: string;
+      endTime?: string;
+      pageSize?: number;
+      current?: number;
+    },
+    actorGuid: string,
+  ) {
     const {
       deviceId,
       type,
@@ -340,10 +354,120 @@ export class AuditService {
 
     const [data, total] = await queryBuilder.getManyAndCount();
 
-    return {
+    const disconnectable = await this.getDisconnectableConnectionKeys(
+      actorGuid,
       data,
+    );
+
+    return {
+      data: data.map((connection) => ({
+        ...connection,
+        can_disconnect:
+          connection.connId !== null &&
+          connection.closedAt === null &&
+          disconnectable.has(
+            this.connectionKey(connection.deviceUuid, connection.connId),
+          ),
+      })),
       total,
     };
+  }
+
+  async queryActiveConnections(
+    actorGuid: string,
+    query: ActiveConnectionQueryDto,
+  ) {
+    const { current = 1, pageSize = 20, deviceId } = query;
+    const scope = await this.rbacAuthorizationService.requirePermission(
+      actorGuid,
+      'devices.disconnect',
+    );
+    const queryBuilder = this.activeConnectionRepository
+      .createQueryBuilder('activeConnection')
+      .innerJoin(Peer, 'peer', 'peer.uuid = activeConnection.deviceUuid');
+
+    if (!scope.global) {
+      if (scope.deviceGroupGuids.size) {
+        queryBuilder.andWhere(
+          'peer.deviceGroupGuid IN (:...deviceGroupGuids)',
+          { deviceGroupGuids: [...scope.deviceGroupGuids] },
+        );
+      } else {
+        queryBuilder.andWhere('1 = 0');
+      }
+    }
+    const trimmedDeviceId = deviceId?.trim();
+    if (trimmedDeviceId) {
+      queryBuilder.andWhere('peer.id LIKE :deviceId', {
+        deviceId: `%${trimmedDeviceId}%`,
+      });
+    }
+
+    const total = await queryBuilder.getCount();
+    const rows = await queryBuilder
+      .select('activeConnection.deviceUuid', 'deviceUuid')
+      .addSelect('activeConnection.connId', 'connId')
+      .addSelect('peer.id', 'deviceId')
+      .orderBy('peer.id', 'ASC')
+      .addOrderBy('activeConnection.connId', 'ASC')
+      .offset((current - 1) * pageSize)
+      .limit(pageSize)
+      .getRawMany<{
+        deviceId: string;
+        deviceUuid: string;
+        connId: string | number;
+      }>();
+
+    return {
+      data: rows.map((row) => ({
+        deviceId: row.deviceId,
+        deviceUuid: row.deviceUuid,
+        connId: Number(row.connId),
+        can_disconnect: true as const,
+      })),
+      total,
+    };
+  }
+
+  private async getDisconnectableConnectionKeys(
+    actorGuid: string,
+    connections: ConnectionAudit[],
+  ): Promise<Set<string>> {
+    const deviceUuids = [
+      ...new Set(connections.map(({ deviceUuid }) => deviceUuid)),
+    ];
+    if (deviceUuids.length === 0) return new Set();
+
+    const scope = await this.rbacAuthorizationService.getPermissionScope(
+      actorGuid,
+      'devices.disconnect',
+    );
+    if (!scope.global && scope.deviceGroupGuids.size === 0) return new Set();
+
+    const peers = await this.peerRepository.find({
+      where: {
+        uuid: In(deviceUuids),
+        ...(scope.global
+          ? {}
+          : { deviceGroupGuid: In([...scope.deviceGroupGuids]) }),
+      },
+      select: ['uuid'],
+    });
+    if (peers.length === 0) return new Set();
+
+    const activeConnections = await this.activeConnectionRepository.find({
+      where: { deviceUuid: In(peers.map(({ uuid }) => uuid)) },
+      select: ['deviceUuid', 'connId'],
+    });
+    return new Set(
+      activeConnections.map(({ deviceUuid, connId }) =>
+        this.connectionKey(deviceUuid, connId),
+      ),
+    );
+  }
+
+  private connectionKey(deviceUuid: string, connId: string | number): string {
+    return `${deviceUuid}:${String(connId)}`;
   }
 
   /**
@@ -491,16 +615,12 @@ export class AuditService {
    * @param filters 过滤条件
    * @returns 控制台审计列表
    */
-  queryConsoleAudits(_filters: {
+  queryConsoleAudits(filters: {
     operator?: string;
     pageSize?: number;
     current?: number;
     created_at?: string;
   }) {
-    // 控制台审计暂时没有实体，返回空列表
-    return {
-      data: [],
-      total: 0,
-    };
+    return this.rbacAuditService.query(filters);
   }
 }

--- a/src/modules/audit/dto/connection-audit.dto.ts
+++ b/src/modules/audit/dto/connection-audit.dto.ts
@@ -7,7 +7,9 @@ import {
   Max,
   IsNumber,
   MaxLength,
+  IsDateString,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 
 /**
  * ConnectionAuditDto
@@ -62,4 +64,59 @@ export class UpdateConnectionAuditDto {
   @IsString()
   @MaxLength(256)
   note: string;
+}
+
+export class ActiveConnectionQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100000)
+  current?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number = 20;
+
+  @IsOptional()
+  @IsString()
+  deviceId?: string;
+}
+
+export class ConnectionAuditQueryDto {
+  @IsOptional()
+  @IsString()
+  deviceId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(-1)
+  @Max(4)
+  type?: number;
+
+  @IsOptional()
+  @IsDateString()
+  startTime?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endTime?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  pageSize?: number = 10;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100000)
+  current?: number = 1;
 }

--- a/src/modules/auth/services/auth-response.helper.ts
+++ b/src/modules/auth/services/auth-response.helper.ts
@@ -17,6 +17,7 @@ export class AuthResponseHelper {
    */
   buildUserPayload(user: User): UserPayload {
     return {
+      guid: user.guid,
       name: user.username,
       display_name: user.displayName || undefined,
       email: user.email || undefined,

--- a/src/modules/auth/services/auth-token.service.ts
+++ b/src/modules/auth/services/auth-token.service.ts
@@ -104,8 +104,24 @@ export class AuthTokenService {
     try {
       const payload = this.jwtService.verify<JwtPayload>(token);
 
+      // JWT types are compile-time only. Reject malformed signed payloads
+      // before they reach a TypeORM where clause, where undefined values may
+      // otherwise be ignored.
+      if (
+        typeof payload.sub !== 'string' ||
+        payload.sub.length === 0 ||
+        typeof payload.jti !== 'string' ||
+        payload.jti.length === 0
+      ) {
+        return null;
+      }
+
       const tokenRecord = await this.tokenRepository.findOne({
-        where: { jti: payload.jti, isRevoked: false },
+        where: {
+          userGuid: payload.sub,
+          jti: payload.jti,
+          isRevoked: false,
+        },
       });
 
       if (!tokenRecord) {

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -415,6 +415,18 @@ export class AuthService {
    * @returns 令牌负载，验证失败返回null
    */
   async validateToken(token: string): Promise<JwtPayload | null> {
-    return this.tokenService.validateToken(token);
+    const payload = await this.tokenService.validateToken(token);
+    if (!payload) return null;
+
+    // A valid signature and token row do not prove that the account is still
+    // active. Check the current user row so legacy/client routes cannot keep
+    // working after an administrator disables or deletes the account.
+    const user = await this.userRepository.findOne({
+      where: { guid: payload.sub },
+      select: ['guid', 'status', 'isAdmin'],
+    });
+    return user?.status === UserStatus.ACTIVE
+      ? { ...payload, isAdmin: user.isAdmin }
+      : null;
   }
 }

--- a/src/modules/auth/services/login-session.service.ts
+++ b/src/modules/auth/services/login-session.service.ts
@@ -117,7 +117,7 @@ export class LoginSessionService {
    */
   async markSessionUsed(session: LoginSession): Promise<void> {
     const result = await this.loginSessionRepository.update(
-      { guid: session.guid, used: false },
+      { guid: session.guid, used: false, expiresAt: MoreThan(new Date()) },
       { used: true },
     );
     if (result.affected !== 1) {

--- a/src/modules/auth/services/login-session.service.ts
+++ b/src/modules/auth/services/login-session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
@@ -116,8 +116,14 @@ export class LoginSessionService {
    * 标记会话为已使用，防止重放攻击
    */
   async markSessionUsed(session: LoginSession): Promise<void> {
+    const result = await this.loginSessionRepository.update(
+      { guid: session.guid, used: false },
+      { used: true },
+    );
+    if (result.affected !== 1) {
+      throw new UnauthorizedException('登录会话已使用或已撤销');
+    }
     session.used = true;
-    await this.loginSessionRepository.save(session);
   }
 
   /**
@@ -129,5 +135,9 @@ export class LoginSessionService {
       userGuid,
       used: false,
     });
+  }
+
+  async revokeUserSessions(userGuid: string): Promise<void> {
+    await this.deleteUserUnusedSessions(userGuid);
   }
 }

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -86,7 +86,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
    */
   async validate(
     req: Request,
-    payload: JwtPayload,
+    _payload: JwtPayload,
   ): Promise<Record<string, unknown>> {
     const token = extractToken(req);
 
@@ -101,7 +101,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Token 已失效或被撤销');
     }
 
-    const { sub, username, email, isAdmin, jti } = payload;
+    const { sub, username, email, isAdmin, jti } = validPayload;
 
     // 保持原有字段名 id，实际值是用户的 guid
     return {

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { DashboardService } from './dashboard.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RequireSuperAdmin } from '../rbac/decorators/require-permission.decorator';
 import {
   DashboardOverviewDto,
   DashboardStatisticsDto,
@@ -14,6 +15,7 @@ import {
  */
 @Controller('dashboard')
 @UseGuards(JwtAuthGuard)
+@RequireSuperAdmin()
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 

--- a/src/modules/device-group/device-group.controller.ts
+++ b/src/modules/device-group/device-group.controller.ts
@@ -10,7 +10,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
 import { DeviceGroupService } from './device-group.service';
@@ -28,6 +27,8 @@ import { DisconnectStoreService } from '../heartbeat/services/disconnect-store.s
 import { HeartbeatService } from '../heartbeat/heartbeat.service';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AdminGuard } from '../../common/guards/admin.guard';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 /**
  * 设备组控制器
@@ -45,6 +46,7 @@ export class DeviceGroupController {
     private readonly peerService: PeerService,
     private readonly disconnectStoreService: DisconnectStoreService,
     private readonly heartbeatService: HeartbeatService,
+    private readonly rbacAuthorizationService: RbacAuthorizationService,
   ) {}
 
   // ============ 客户端 API 接口 ============
@@ -67,13 +69,14 @@ export class DeviceGroupController {
   @Get('device-group/accessible')
   async getAccessibleDeviceGroups(
     @CurrentUser('id') userId: string,
-    @CurrentUser('isAdmin') isAdmin: boolean,
     @Query() query: DeviceGroupQueryDto,
   ) {
+    const currentUser =
+      await this.rbacAuthorizationService.getCurrentUser(userId);
     return this.deviceGroupService.getAccessibleDeviceGroups(
       userId,
       query,
-      isAdmin,
+      currentUser.isAdmin,
     );
   }
 
@@ -100,34 +103,49 @@ export class DeviceGroupController {
   @Get('peers')
   async getAccessiblePeers(
     @CurrentUser('id') userId: string,
-    @CurrentUser('isAdmin') isAdmin: boolean,
     @Query() query: PeerQueryDto,
   ) {
-    return this.peerService.getAccessiblePeers(userId, query, isAdmin);
+    const currentUser =
+      await this.rbacAuthorizationService.getCurrentUser(userId);
+    return this.peerService.getAccessiblePeers(
+      userId,
+      query,
+      currentUser.isAdmin,
+    );
   }
 
   // ============ 管理员 API 接口 ============
 
-  /**
-   * 获取设备组列表
-   * 管理员可以查看所有设备组
-   *
-   * @param userId 当前用户ID（从JWT令牌中提取）
-   * @param isAdmin 是否为管理员（从JWT令牌中提取）
-   * @param query 查询参数（分页、名称过滤）
-   * @returns 设备组列表（分页）
-   */
+  /** 获取完整设备组管理列表。 */
   @Get('device-groups')
   @UseGuards(AdminGuard)
   async getDeviceGroups(
     @CurrentUser('id') userId: string,
-    @CurrentUser('isAdmin') isAdmin: boolean,
     @Query() query: DeviceGroupQueryDto,
   ) {
     return this.deviceGroupService.getAccessibleDeviceGroups(
       userId,
       query,
-      isAdmin,
+      true,
+    );
+  }
+
+  /** 获取当前策略分配范围内的设备组候选项。 */
+  @Get('device-groups/strategy-targets')
+  @RequirePermission('strategies.assign')
+  async getStrategyTargetDeviceGroups(
+    @CurrentUser('id') userId: string,
+    @Query() query: DeviceGroupQueryDto,
+  ) {
+    const scope = await this.rbacAuthorizationService.getPermissionScope(
+      userId,
+      'strategies.assign',
+    );
+    return this.deviceGroupService.getAccessibleDeviceGroups(
+      userId,
+      query,
+      scope.global,
+      scope,
     );
   }
 
@@ -143,11 +161,13 @@ export class DeviceGroupController {
   @HttpCode(HttpStatus.OK)
   async createDeviceGroup(
     @Body() body: { name: string; note?: string; allowed_incomings?: any[] },
+    @CurrentUser('id') userId: string,
   ) {
     return this.deviceGroupService.createDeviceGroup(
       body.name,
       body.note,
       body.allowed_incomings,
+      userId,
     );
   }
 
@@ -170,12 +190,14 @@ export class DeviceGroupController {
       note?: string;
       allowed_incomings?: any[];
     },
+    @CurrentUser('id') userId: string,
   ) {
     return this.deviceGroupService.updateDeviceGroup(
       guid,
       body.name,
       body.note,
       body.allowed_incomings,
+      userId,
     );
   }
 
@@ -189,8 +211,11 @@ export class DeviceGroupController {
   @Delete('device-groups/:guid')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
-  async deleteDeviceGroup(@Param('guid') guid: string) {
-    await this.deviceGroupService.deleteDeviceGroup(guid);
+  async deleteDeviceGroup(
+    @Param('guid') guid: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    await this.deviceGroupService.deleteDeviceGroup(guid, userId);
     return { message: '设备组删除成功' };
   }
 
@@ -205,8 +230,12 @@ export class DeviceGroupController {
   @Post('device-groups/:guid')
   @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
-  async addDevicesToGroup(@Param('guid') guid: string, @Body() body: string[]) {
-    return this.deviceGroupService.addDevicesToGroup(guid, body);
+  async addDevicesToGroup(
+    @Param('guid') guid: string,
+    @Body() body: string[],
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.deviceGroupService.addDevicesToGroup(guid, body, userId);
   }
 
   /**
@@ -223,8 +252,9 @@ export class DeviceGroupController {
   async removeDevicesFromGroup(
     @Param('guid') guid: string,
     @Body() body: string[],
+    @CurrentUser('id') userId: string,
   ) {
-    return this.deviceGroupService.removeDevicesFromGroup(guid, body);
+    return this.deviceGroupService.removeDevicesFromGroup(guid, body, userId);
   }
 
   /**
@@ -232,17 +262,25 @@ export class DeviceGroupController {
    * 管理员可以查看所有设备
    *
    * @param userId 当前用户ID（从JWT令牌中提取）
-   * @param isAdmin 是否为管理员（从JWT令牌中提取）
    * @param query 查询参数（分页、过滤）
    * @returns 设备列表（分页）
    */
   @Get('devices')
+  @RequirePermission('devices.view')
   async getDevices(
     @CurrentUser('id') userId: string,
-    @CurrentUser('isAdmin') isAdmin: boolean,
     @Query() query: DeviceQueryDto,
   ) {
-    return this.deviceGroupService.getDevices(userId, query, isAdmin);
+    const scope = await this.rbacAuthorizationService.getPermissionScope(
+      userId,
+      'devices.view',
+    );
+    return this.deviceGroupService.getDevices(
+      userId,
+      query,
+      scope.global,
+      scope,
+    );
   }
 
   /**
@@ -253,13 +291,15 @@ export class DeviceGroupController {
    * @returns 操作结果
    */
   @Patch('devices/status')
-  @UseGuards(AdminGuard)
+  @RequirePermission('devices.status')
   async updateDeviceStatus(
+    @CurrentUser('id') userId: string,
     @Body() dto: UpdateDeviceStatusDto,
   ): Promise<{ success: boolean; data: DeviceOperationResult }> {
     const result = await this.deviceGroupService.updateDeviceStatus(
       dto.guids,
       dto.status,
+      userId,
     );
     return {
       success: result.failedCount === 0,
@@ -279,12 +319,13 @@ export class DeviceGroupController {
    * @returns 更新结果
    */
   @Patch('devices/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('devices.edit')
   async updateDevice(
     @Param('guid') guid: string,
     @Body() dto: UpdateDeviceDto,
+    @CurrentUser('id') userId: string,
   ) {
-    await this.deviceGroupService.updateDevice(guid, dto);
+    await this.deviceGroupService.updateDevice(guid, dto, userId);
     return { message: '设备更新成功' };
   }
 
@@ -296,10 +337,13 @@ export class DeviceGroupController {
    * @returns 删除结果
    */
   @Delete('devices/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('devices.delete')
   @HttpCode(HttpStatus.OK)
-  async deleteDevice(@Param('guid') guid: string) {
-    await this.deviceGroupService.deleteDevice(guid);
+  async deleteDevice(
+    @Param('guid') guid: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    await this.deviceGroupService.deleteDevice(guid, userId);
     return { message: '设备已删除' };
   }
 
@@ -313,16 +357,21 @@ export class DeviceGroupController {
    * @returns 操作结果
    */
   @Post('devices/:uuid/disconnect')
-  @UseGuards(AdminGuard)
+  @RequirePermission('devices.disconnect')
   @HttpCode(HttpStatus.OK)
   async disconnectDevice(
     @Param('uuid') uuid: string,
     @Body() dto: DisconnectDto,
+    @CurrentUser('id') userId: string,
   ) {
-    const peer = await this.peerService.findByUuid(uuid);
-    if (!peer) {
-      throw new NotFoundException('设备不存在');
-    }
+    // Check the current device-group scope before inspecting connections or
+    // enqueueing a disconnect command. A scoped operator must not be able to
+    // act on an out-of-scope device by supplying its UUID directly.
+    await this.rbacAuthorizationService.assertDeviceAccess(
+      userId,
+      'devices.disconnect',
+      uuid,
+    );
 
     // 验证请求断开的连接ID是否为该设备的活跃连接
     const activeConnIds =
@@ -335,6 +384,13 @@ export class DeviceGroupController {
       );
     }
 
+    // The device may have been moved while the active connections were read.
+    // Recheck immediately before the synchronous enqueue operation.
+    await this.rbacAuthorizationService.assertDeviceAccess(
+      userId,
+      'devices.disconnect',
+      uuid,
+    );
     this.disconnectStoreService.addPendingDisconnects(uuid, dto.connIds);
     return {
       message: '断开指令已提交，将在设备下次心跳时下发',

--- a/src/modules/device-group/device-group.module.ts
+++ b/src/modules/device-group/device-group.module.ts
@@ -11,6 +11,8 @@ import { User } from '../user/entities/user.entity';
 import { Strategy } from '../strategy/entities/strategy.entity';
 import { AuthModule } from '../auth/auth.module';
 import { HeartbeatModule } from '../heartbeat/heartbeat.module';
+import { RbacModule } from '../rbac/rbac.module';
+import { AdminGuard } from '../../common/guards/admin.guard';
 
 /**
  * 设备组模块
@@ -42,9 +44,10 @@ import { HeartbeatModule } from '../heartbeat/heartbeat.module';
     ]),
     AuthModule,
     HeartbeatModule,
+    RbacModule,
   ],
   controllers: [DeviceGroupController],
-  providers: [DeviceGroupService, PeerService],
+  providers: [DeviceGroupService, PeerService, AdminGuard],
   exports: [DeviceGroupService, PeerService],
 })
 export class DeviceGroupModule {}

--- a/src/modules/device-group/device-group.service.ts
+++ b/src/modules/device-group/device-group.service.ts
@@ -1,14 +1,16 @@
 import {
+  BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
-  BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { DataSource, Repository, In } from 'typeorm';
 import * as uuid from 'uuid';
 import { DeviceGroup } from './entities/device-group.entity';
 import { User, UserStatus } from '../user/entities/user.entity';
 import { Peer, PeerStatus } from '../../common/entities/peer.entity';
+import { Sysinfo } from '../../common/entities/sysinfo.entity';
 import { Strategy } from '../strategy/entities/strategy.entity';
 import { DeviceGroupUserPermission } from './entities/device-group-user-permission.entity';
 import {
@@ -17,6 +19,9 @@ import {
   DeviceOperationFailure,
 } from './dto/device-status.dto';
 import { UpdateDeviceDto } from './dto/update-device.dto';
+import type { PermissionScope } from '../rbac/services/rbac-authorization.service';
+import { UserRoleAssignmentDeviceGroup } from '../rbac/entities/user-role-assignment-device-group.entity';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 @Injectable()
 /**
@@ -40,10 +45,14 @@ export class DeviceGroupService {
     private userRepository: Repository<User>,
     @InjectRepository(Peer)
     private peerRepository: Repository<Peer>,
+    @InjectRepository(Sysinfo)
+    private sysinfoRepository: Repository<Sysinfo>,
     @InjectRepository(DeviceGroupUserPermission)
     private deviceGroupUserPermissionRepository: Repository<DeviceGroupUserPermission>,
     @InjectRepository(Strategy)
     private strategyRepository: Repository<Strategy>,
+    private readonly dataSource: DataSource,
+    private readonly rbacAuthorizationService: RbacAuthorizationService,
   ) {}
 
   /**
@@ -59,6 +68,7 @@ export class DeviceGroupService {
     userGuid: string,
     query: { current: number; pageSize: number; name?: string },
     isAdmin: boolean = false,
+    rbacScope?: PermissionScope,
   ): Promise<{
     data: { guid: string; name: string; note?: string }[];
     total: number;
@@ -67,13 +77,24 @@ export class DeviceGroupService {
     const skip = (current - 1) * pageSize;
 
     // 管理员可以看到所有设备组
-    if (isAdmin) {
+    if (isAdmin || rbacScope) {
       let queryBuilder = this.deviceGroupRepository
         .createQueryBuilder('dg')
         .select(['dg.guid', 'dg.name', 'dg.note'])
         .orderBy('dg.name', 'ASC')
         .skip(skip)
         .take(pageSize);
+
+      if (rbacScope && !rbacScope.global) {
+        if (rbacScope.deviceGroupGuids.size === 0) {
+          queryBuilder = queryBuilder.andWhere('1 = 0');
+        } else {
+          queryBuilder = queryBuilder.andWhere(
+            'dg.guid IN (:...rbacDeviceGroups)',
+            { rbacDeviceGroups: [...rbacScope.deviceGroupGuids] },
+          );
+        }
+      }
 
       if (name) {
         queryBuilder = queryBuilder.andWhere('dg.name LIKE :name', {
@@ -261,9 +282,11 @@ export class DeviceGroupService {
    */
   async createDeviceGroup(
     name: string,
-    note?: string,
-    _allowedIncomings?: unknown[],
+    note: string | undefined,
+    _allowedIncomings: unknown[] | undefined,
+    actorGuid: string,
   ) {
+    await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
     // 检查设备组名称是否已存在
     const existingGroup = await this.deviceGroupRepository.findOne({
       where: { name },
@@ -292,10 +315,12 @@ export class DeviceGroupService {
    */
   async updateDeviceGroup(
     guid: string,
-    name?: string,
-    note?: string,
-    _allowedIncomings?: unknown[],
+    name: string | undefined,
+    note: string | undefined,
+    _allowedIncomings: unknown[] | undefined,
+    actorGuid: string,
   ) {
+    await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
     const deviceGroup = await this.deviceGroupRepository.findOne({
       where: { guid },
     });
@@ -327,15 +352,28 @@ export class DeviceGroupService {
    * 删除设备组
    * @param guid 设备组GUID
    */
-  async deleteDeviceGroup(guid: string) {
-    const deviceGroup = await this.deviceGroupRepository.findOne({
-      where: { guid },
-    });
-    if (!deviceGroup) {
-      throw new NotFoundException('设备组不存在');
-    }
+  async deleteDeviceGroup(guid: string, actorGuid: string) {
+    await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
+    await this.dataSource.transaction(async (manager) => {
+      const deviceGroupRepository = manager.getRepository(DeviceGroup);
+      const deviceGroup = await deviceGroupRepository.findOne({
+        where: { guid },
+      });
+      if (!deviceGroup) {
+        throw new NotFoundException('设备组不存在');
+      }
 
-    await this.deviceGroupRepository.remove(deviceGroup);
+      const scopedAssignments = await manager
+        .getRepository(UserRoleAssignmentDeviceGroup)
+        .count({ where: { deviceGroupGuid: guid } });
+      if (scopedAssignments > 0) {
+        throw new BadRequestException(
+          '设备组仍被角色授权引用，不能删除，请先移除相关授权',
+        );
+      }
+
+      await deviceGroupRepository.remove(deviceGroup);
+    });
   }
 
   /**
@@ -343,7 +381,12 @@ export class DeviceGroupService {
    * @param guid 设备组GUID
    * @param deviceIds 设备ID列表
    */
-  async addDevicesToGroup(guid: string, deviceIds: string[]) {
+  async addDevicesToGroup(
+    guid: string,
+    deviceIds: string[],
+    actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
     const deviceGroup = await this.deviceGroupRepository.findOne({
       where: { guid },
     });
@@ -376,7 +419,12 @@ export class DeviceGroupService {
    * @param guid 设备组GUID
    * @param deviceIds 设备ID列表
    */
-  async removeDevicesFromGroup(guid: string, deviceIds: string[]) {
+  async removeDevicesFromGroup(
+    guid: string,
+    deviceIds: string[],
+    actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
     const deviceGroup = await this.deviceGroupRepository.findOne({
       where: { guid },
     });
@@ -417,25 +465,35 @@ export class DeviceGroupService {
       current: number;
       pageSize: number;
       id?: string;
+      status?: string;
+      is_online?: string;
       device_name?: string;
       user_name?: string;
       device_username?: string;
+      os?: string;
       device_group_name?: string;
+      device_group_guid?: string;
       group_name?: string;
     },
     isAdmin: boolean = false,
+    rbacScope?: PermissionScope,
   ): Promise<{ data: any[]; total: number }> {
     const {
       current,
       pageSize,
       id,
+      status,
+      is_online,
       device_name,
       user_name,
       device_username,
+      os,
       device_group_name,
+      device_group_guid,
       group_name,
     } = query;
     const skip = (current - 1) * pageSize;
+    const onlineAfter = new Date(Date.now() - 60_000);
 
     let queryBuilder = this.peerRepository
       .createQueryBuilder('peer')
@@ -445,14 +503,18 @@ export class DeviceGroupService {
         'peer.uuid',
         'peer.userGuid',
         'peer.deviceGroupGuid',
+        'peer.strategyGuid',
+        'peer.note',
+        'peer.status',
         'peer.ver',
         'peer.modifiedAt',
+        'peer.lastHeartbeat',
         'peer.updatedAt',
         'dg.name',
       ]);
 
     // 管理员可以看到所有设备
-    if (!isAdmin) {
+    if (!isAdmin && !rbacScope) {
       // 普通用户只能看到自己有权限访问的设备
       queryBuilder = queryBuilder.andWhere(
         `(peer.userGuid = :userGuid
@@ -465,6 +527,19 @@ export class DeviceGroupService {
       );
     }
 
+    // RBAC scope is an additional administrative boundary. It is applied
+    // before pagination/count and intentionally excludes ungrouped devices.
+    if (rbacScope && !rbacScope.global) {
+      if (!rbacScope.deviceGroupGuids.size) {
+        queryBuilder = queryBuilder.andWhere('1 = 0');
+      } else {
+        queryBuilder = queryBuilder.andWhere(
+          'peer.deviceGroupGuid IN (:...rbacDeviceGroups)',
+          { rbacDeviceGroups: [...rbacScope.deviceGroupGuids] },
+        );
+      }
+    }
+
     // 按设备ID过滤
     if (id) {
       queryBuilder = queryBuilder.andWhere('peer.id LIKE :id', {
@@ -472,11 +547,33 @@ export class DeviceGroupService {
       });
     }
 
+    if (status !== undefined) {
+      queryBuilder = queryBuilder.andWhere('peer.status = :status', {
+        status: Number(status),
+      });
+    }
+
+    if (is_online === '1') {
+      queryBuilder = queryBuilder.andWhere(
+        'peer.lastHeartbeat > :onlineAfter',
+        { onlineAfter },
+      );
+    } else if (is_online === '0') {
+      queryBuilder = queryBuilder.andWhere(
+        '(peer.lastHeartbeat IS NULL OR peer.lastHeartbeat <= :onlineAfter)',
+        { onlineAfter },
+      );
+    }
+
     // 按设备名称过滤
     if (device_name) {
-      queryBuilder = queryBuilder.andWhere('peer.name LIKE :deviceName', {
-        deviceName: `%${device_name}%`,
-      });
+      queryBuilder = queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM sysinfos si
+          WHERE si.uuid = peer.uuid AND si.hostname LIKE :deviceName
+        )`,
+        { deviceName: `%${device_name}%` },
+      );
     }
 
     // 按用户名过滤
@@ -493,7 +590,10 @@ export class DeviceGroupService {
     // 按设备用户名过滤
     if (device_username) {
       queryBuilder = queryBuilder.andWhere(
-        'peer.deviceUsername LIKE :deviceUsername',
+        `EXISTS (
+          SELECT 1 FROM sysinfos si
+          WHERE si.uuid = peer.uuid AND si.username LIKE :deviceUsername
+        )`,
         { deviceUsername: `%${device_username}%` },
       );
     }
@@ -503,6 +603,23 @@ export class DeviceGroupService {
       queryBuilder = queryBuilder.andWhere('dg.name = :deviceGroupName', {
         deviceGroupName: device_group_name,
       });
+    }
+
+    if (device_group_guid) {
+      queryBuilder = queryBuilder.andWhere(
+        'peer.deviceGroupGuid = :deviceGroupGuid',
+        { deviceGroupGuid: device_group_guid },
+      );
+    }
+
+    if (os) {
+      queryBuilder = queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM sysinfos si
+          WHERE si.uuid = peer.uuid AND si.os LIKE :os
+        )`,
+        { os: `%${os}%` },
+      );
     }
 
     // 按组名过滤（通过设备组）
@@ -518,18 +635,82 @@ export class DeviceGroupService {
       .take(pageSize)
       .getManyAndCount();
 
-    return {
-      data: peers.map((p) => ({
-        guid: p.uuid,
-        id: p.id,
-        userGuid: p.userGuid,
-        deviceGroupGuid: p.deviceGroupGuid,
-        device_group_name:
-          (p.deviceGroup as { name?: string } | null)?.name || '',
-        last_online: p.updatedAt,
-      })),
-      total,
+    const uuids = peers.map((peer) => peer.uuid);
+    const userGuids = [
+      ...new Set(
+        peers
+          .map((peer) => peer.userGuid)
+          .filter((guid): guid is string => guid !== null),
+      ),
+    ];
+    const strategyGuids = [
+      ...new Set(
+        peers
+          .map((peer) => peer.strategyGuid)
+          .filter((guid): guid is string => guid !== null),
+      ),
+    ];
+    const [sysinfos, users, strategies]: [Sysinfo[], User[], Strategy[]] =
+      await Promise.all([
+        uuids.length
+          ? this.sysinfoRepository.find({ where: { uuid: In(uuids) } })
+          : [],
+        userGuids.length
+          ? this.userRepository.find({ where: { guid: In(userGuids) } })
+          : [],
+        strategyGuids.length
+          ? this.strategyRepository.find({
+              where: { guid: In(strategyGuids) },
+            })
+          : [],
+      ]);
+    const sysinfoByUuid = new Map(sysinfos.map((item) => [item.uuid, item]));
+    const userByGuid = new Map(users.map((item) => [item.guid, item]));
+    const strategyByGuid = new Map(strategies.map((item) => [item.guid, item]));
+    const formatVersion = (version: number): string => {
+      if (!version) return '';
+      const major = Math.floor(version / 1_000_000);
+      const minor = Math.floor((version % 1_000_000) / 1_000);
+      const patch = Math.floor((version % 1_000) / 10);
+      const suffix = version % 10;
+      return `${major}.${minor}.${patch}${suffix ? `-${suffix}` : ''}`;
     };
+
+    const data = peers.map((peer) => {
+      const sysinfo = sysinfoByUuid.get(peer.uuid);
+      return {
+        guid: peer.uuid,
+        id: peer.id,
+        userGuid: peer.userGuid,
+        user: peer.userGuid || '',
+        user_name: peer.userGuid
+          ? userByGuid.get(peer.userGuid)?.username || ''
+          : '',
+        deviceGroupGuid: peer.deviceGroupGuid,
+        device_group_name:
+          (peer.deviceGroup as { name?: string } | null)?.name || '',
+        strategy_name: peer.strategyGuid
+          ? strategyByGuid.get(peer.strategyGuid)?.name || ''
+          : '',
+        note: peer.note || '',
+        status: peer.status,
+        is_online: peer.lastHeartbeat
+          ? peer.lastHeartbeat > onlineAfter
+          : false,
+        last_online: peer.lastHeartbeat?.toISOString() || null,
+        info: {
+          device_name: sysinfo?.hostname || '',
+          username: sysinfo?.username || '',
+          os: sysinfo?.os || '',
+          version: formatVersion(peer.ver),
+          cpu: sysinfo?.cpu || '',
+          memory: sysinfo?.memory || '',
+          ip: '',
+        },
+      };
+    });
+
+    return { data, total };
   }
 
   /**
@@ -542,14 +723,19 @@ export class DeviceGroupService {
    * @param guid 设备GUID
    * @param dto 更新数据
    */
-  async updateDevice(guid: string, dto: UpdateDeviceDto) {
-    const peer = await this.peerRepository.findOne({
-      where: { uuid: guid },
-    });
-    if (!peer) {
-      throw new NotFoundException('设备不存在');
+  async updateDevice(guid: string, dto: UpdateDeviceDto, actorGuid: string) {
+    const { scope } = await this.rbacAuthorizationService.assertDeviceAccess(
+      actorGuid,
+      'devices.edit',
+      guid,
+    );
+    if (
+      dto.userName !== undefined ||
+      dto.deviceGroupName !== undefined ||
+      dto.strategyName !== undefined
+    ) {
+      await this.rbacAuthorizationService.requireSuperAdmin(actorGuid);
     }
-
     const updateData: Partial<Peer> = {};
 
     if (dto.userName !== undefined) {
@@ -599,7 +785,23 @@ export class DeviceGroupService {
     }
 
     if (Object.keys(updateData).length > 0) {
-      await this.peerRepository.update({ uuid: guid }, updateData);
+      const result = await this.peerRepository.update(
+        scope.global
+          ? { uuid: guid }
+          : {
+              uuid: guid,
+              deviceGroupGuid: In([...scope.deviceGroupGuids]),
+            },
+        updateData,
+      );
+      if (result.affected !== 1) {
+        await this.rbacAuthorizationService.assertDeviceAccess(
+          actorGuid,
+          'devices.edit',
+          guid,
+        );
+        throw new ConflictException('设备信息已发生变化，请重试');
+      }
     }
   }
 
@@ -614,15 +816,17 @@ export class DeviceGroupService {
   async updateDeviceStatus(
     guids: string[],
     status: DeviceStatus,
+    actorGuid: string,
   ): Promise<DeviceOperationResult> {
+    const { peers: existingPeers, scope } =
+      await this.rbacAuthorizationService.assertDevicesAccess(
+        actorGuid,
+        'devices.status',
+        guids,
+      );
     const uniqueGuids = [...new Set(guids)];
     const succeeded: string[] = [];
     const failed: DeviceOperationFailure[] = [];
-
-    const existingPeers = await this.peerRepository.find({
-      where: { uuid: In(uniqueGuids) },
-      select: ['uuid'],
-    });
 
     const existingUuids = new Set(existingPeers.map((p) => p.uuid));
 
@@ -640,12 +844,35 @@ export class DeviceGroupService {
           ? PeerStatus.ACTIVE
           : PeerStatus.DISABLED;
 
-      await this.peerRepository
-        .createQueryBuilder()
-        .update(Peer)
-        .set({ status: statusValue })
-        .where('uuid IN (:...uuids)', { uuids: guidsToUpdate })
-        .execute();
+      const concurrentChange = new ConflictException(
+        '设备信息已发生变化，请重试',
+      );
+      try {
+        await this.dataSource.transaction(async (manager) => {
+          const result = await manager.update(
+            Peer,
+            scope.global
+              ? { uuid: In(guidsToUpdate) }
+              : {
+                  uuid: In(guidsToUpdate),
+                  deviceGroupGuid: In([...scope.deviceGroupGuids]),
+                },
+            { status: statusValue },
+          );
+          if (result.affected !== guidsToUpdate.length) {
+            throw concurrentChange;
+          }
+        });
+      } catch (error) {
+        if (error === concurrentChange) {
+          await this.rbacAuthorizationService.assertDevicesAccess(
+            actorGuid,
+            'devices.status',
+            guidsToUpdate,
+          );
+        }
+        throw error;
+      }
 
       succeeded.push(...guidsToUpdate);
     }
@@ -663,14 +890,27 @@ export class DeviceGroupService {
    * 删除设备
    * @param guid 设备GUID
    */
-  async deleteDevice(guid: string) {
-    const peer = await this.peerRepository.findOne({
-      where: { uuid: guid },
-    });
-    if (!peer) {
-      throw new NotFoundException('设备不存在');
+  async deleteDevice(guid: string, actorGuid: string) {
+    const { scope } = await this.rbacAuthorizationService.assertDeviceAccess(
+      actorGuid,
+      'devices.delete',
+      guid,
+    );
+    const result = await this.peerRepository.delete(
+      scope.global
+        ? { uuid: guid }
+        : {
+            uuid: guid,
+            deviceGroupGuid: In([...scope.deviceGroupGuids]),
+          },
+    );
+    if (result.affected !== 1) {
+      await this.rbacAuthorizationService.assertDeviceAccess(
+        actorGuid,
+        'devices.delete',
+        guid,
+      );
+      throw new ConflictException('设备信息已发生变化，请重试');
     }
-
-    await this.peerRepository.remove(peer);
   }
 }

--- a/src/modules/device-group/dto/device.dto.ts
+++ b/src/modules/device-group/dto/device.dto.ts
@@ -1,4 +1,11 @@
-import { IsNumber, Min, IsInt, IsString, IsOptional } from 'class-validator';
+import {
+  IsNumber,
+  Min,
+  IsInt,
+  IsString,
+  IsOptional,
+  IsIn,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 /**
@@ -23,6 +30,16 @@ export class DeviceQueryDto {
   id?: string;
 
   @IsString()
+  @IsIn(['0', '1'])
+  @IsOptional()
+  status?: string;
+
+  @IsString()
+  @IsIn(['0', '1'])
+  @IsOptional()
+  is_online?: string;
+
+  @IsString()
   @IsOptional()
   device_name?: string;
 
@@ -36,5 +53,13 @@ export class DeviceQueryDto {
 
   @IsString()
   @IsOptional()
+  os?: string;
+
+  @IsString()
+  @IsOptional()
   device_group_name?: string;
+
+  @IsString()
+  @IsOptional()
+  device_group_guid?: string;
 }

--- a/src/modules/ldap/ldap.module.ts
+++ b/src/modules/ldap/ldap.module.ts
@@ -6,6 +6,7 @@ import { LdapController } from './ldap.controller';
 import { LdapService } from './ldap.service';
 import { LdapSettingsService } from './ldap-settings.service';
 import { UserGroupModule } from '../user-group/user-group.module';
+import { AdminGuard } from '../../common/guards/admin.guard';
 
 /**
  * LDAP 认证模块
@@ -21,7 +22,7 @@ import { UserGroupModule } from '../user-group/user-group.module';
 @Module({
   imports: [TypeOrmModule.forFeature([SystemSetting, User]), UserGroupModule],
   controllers: [LdapController],
-  providers: [LdapService, LdapSettingsService],
+  providers: [LdapService, LdapSettingsService, AdminGuard],
   exports: [LdapService, LdapSettingsService],
 })
 export class LdapModule {}

--- a/src/modules/ldap/ldap.service.ts
+++ b/src/modules/ldap/ldap.service.ts
@@ -330,7 +330,7 @@ export class LdapService {
    */
   private async findOrCreateUser(
     ldapUserInfo: LdapUserInfo,
-    config: LdapConfig,
+    _config: LdapConfig,
   ): Promise<User> {
     // 通过 LDAP subject 查找已关联的用户
     const ldapSubject = `ldap:${ldapUserInfo.username}`;
@@ -339,21 +339,12 @@ export class LdapService {
     });
 
     if (existingUser) {
-      // 更新用户信息（邮箱、管理员角色）
+      // LDAP may authenticate and update profile data, but never controls the
+      // immutable system-owner marker.
       let needsUpdate = false;
 
       if (ldapUserInfo.email && existingUser.email !== ldapUserInfo.email) {
         existingUser.email = ldapUserInfo.email;
-        needsUpdate = true;
-      }
-
-      // 根据组映射更新管理员角色
-      const shouldBeAdmin = this.isAdminByGroups(
-        ldapUserInfo.groups,
-        config.adminGroups,
-      );
-      if (existingUser.isAdmin !== shouldBeAdmin) {
-        existingUser.isAdmin = shouldBeAdmin;
         needsUpdate = true;
       }
 
@@ -395,10 +386,7 @@ export class LdapService {
         user.email = ldapUserInfo.email || null;
         user.password = null as unknown as string;
         user.status = UserStatus.ACTIVE;
-        user.isAdmin = this.isAdminByGroups(
-          ldapUserInfo.groups,
-          config.adminGroups,
-        );
+        user.isAdmin = false;
         user.note = ldapUserInfo.displayName
           ? `LDAP用户 (${ldapUserInfo.displayName})`
           : 'LDAP用户';
@@ -424,34 +412,6 @@ export class LdapService {
     }
 
     throw new Error(`创建 LDAP 用户失败，用户名冲突已重试 ${maxRetries} 次`);
-  }
-
-  /**
-   * 根据组映射判断用户是否为管理员
-   *
-   * @param userGroups 用户所属组 DN 列表
-   * @param adminGroups 管理员组 DN 列表
-   * @returns 是否为管理员
-   */
-  private isAdminByGroups(
-    userGroups: string[],
-    adminGroups: string[],
-  ): boolean {
-    if (!adminGroups || adminGroups.length === 0) {
-      return false;
-    }
-
-    return userGroups.some((userGroup) =>
-      adminGroups.some((adminGroup) => this.dnEquals(userGroup, adminGroup)),
-    );
-  }
-
-  /**
-   * DN 大小写不敏感比较
-   * LDAP DN 是大小写不敏感的
-   */
-  private dnEquals(dn1: string, dn2: string): boolean {
-    return dn1.toLowerCase() === dn2.toLowerCase();
   }
 
   /**

--- a/src/modules/oidc/oidc.module.ts
+++ b/src/modules/oidc/oidc.module.ts
@@ -11,6 +11,7 @@ import { User } from '../user/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
 import { UserGroupModule } from '../user-group/user-group.module';
 import { SettingsModule } from '../settings/settings.module';
+import { AdminGuard } from '../../common/guards/admin.guard';
 
 @Module({
   imports: [
@@ -20,7 +21,12 @@ import { SettingsModule } from '../settings/settings.module';
     SettingsModule,
   ],
   controllers: [OidcController, OidcAdminController],
-  providers: [OidcService, OidcAdminService, OidcAuthStateCleanupService],
+  providers: [
+    OidcService,
+    OidcAdminService,
+    OidcAuthStateCleanupService,
+    AdminGuard,
+  ],
   exports: [OidcService],
 })
 export class OidcModule {}

--- a/src/modules/oidc/services/oidc.service.ts
+++ b/src/modules/oidc/services/oidc.service.ts
@@ -638,6 +638,7 @@ export class OidcService {
       access_token: authState.accessToken,
       type: 'access_token',
       user: {
+        guid: user.guid,
         name: user.username,
         email: user.email || undefined,
         note: user.note || undefined,

--- a/src/modules/rbac/constants/permission-catalog.ts
+++ b/src/modules/rbac/constants/permission-catalog.ts
@@ -1,0 +1,289 @@
+/**
+ * Backend-owned permission catalog. Permission identifiers are intentionally
+ * fixed: roles may compose these values, but callers cannot create new ones.
+ */
+export type PermissionCode =
+  | 'users.view'
+  | 'users.create'
+  | 'users.edit'
+  | 'users.status'
+  | 'users.delete'
+  | 'users.security'
+  | 'users.force_logout'
+  | 'user_groups.view'
+  | 'user_groups.create'
+  | 'user_groups.edit'
+  | 'user_groups.delete'
+  | 'user_groups.membership'
+  | 'devices.view'
+  | 'devices.edit'
+  | 'devices.status'
+  | 'devices.delete'
+  | 'devices.disconnect'
+  | 'address_books.view'
+  | 'address_books.edit'
+  | 'address_books.share'
+  | 'strategies.view'
+  | 'strategies.create'
+  | 'strategies.edit'
+  | 'strategies.delete'
+  | 'strategies.assign'
+  | 'audit.view'
+  | 'roles.view'
+  | 'roles.assign';
+
+export type SystemPermissionCode =
+  'roles.create' | 'roles.edit' | 'roles.delete';
+
+export type CatalogPermissionCode = PermissionCode | SystemPermissionCode;
+
+export interface PermissionDefinition {
+  code: CatalogPermissionCode;
+  resource: string;
+  action: string;
+  name: string;
+  description: string;
+  scope: 'global' | 'device_group';
+  /** System-only capabilities are display-only and cannot be stored on roles. */
+  assignable: boolean;
+  system_only: boolean;
+  requires?: PermissionCode[];
+}
+
+const definition = (
+  code: PermissionCode,
+  resource: string,
+  action: string,
+  name: string,
+  scope: PermissionDefinition['scope'] = 'global',
+  requires: PermissionCode[] = [],
+): PermissionDefinition => ({
+  code,
+  resource,
+  action,
+  name,
+  description: `${name} (${code})`,
+  scope,
+  assignable: true,
+  system_only: false,
+  ...(requires.length ? { requires } : {}),
+});
+
+const systemDefinition = (
+  code: SystemPermissionCode,
+  action: string,
+  name: string,
+): PermissionDefinition => ({
+  code,
+  resource: 'roles',
+  action,
+  name,
+  description: `${name} (${code})`,
+  scope: 'global',
+  assignable: false,
+  system_only: true,
+});
+
+export const PERMISSION_CATALOG: readonly PermissionDefinition[] = [
+  definition('users.view', 'users', 'view', 'View users'),
+  definition('users.create', 'users', 'create', 'Create users', 'global', [
+    'users.view',
+  ]),
+  definition('users.edit', 'users', 'edit', 'Edit users', 'global', [
+    'users.view',
+  ]),
+  definition(
+    'users.status',
+    'users',
+    'status',
+    'Change user status',
+    'global',
+    ['users.view'],
+  ),
+  definition('users.delete', 'users', 'delete', 'Delete users', 'global', [
+    'users.view',
+  ]),
+  definition(
+    'users.security',
+    'users',
+    'security',
+    'Manage user security',
+    'global',
+    ['users.view'],
+  ),
+  definition(
+    'users.force_logout',
+    'users',
+    'force_logout',
+    'Force user logout',
+    'global',
+    ['users.view'],
+  ),
+  definition('user_groups.view', 'user_groups', 'view', 'View user groups'),
+  definition(
+    'user_groups.create',
+    'user_groups',
+    'create',
+    'Create user groups',
+    'global',
+    ['user_groups.view'],
+  ),
+  definition(
+    'user_groups.edit',
+    'user_groups',
+    'edit',
+    'Edit user groups',
+    'global',
+    ['user_groups.view'],
+  ),
+  definition(
+    'user_groups.delete',
+    'user_groups',
+    'delete',
+    'Delete user groups',
+    'global',
+    ['user_groups.view'],
+  ),
+  definition(
+    'user_groups.membership',
+    'user_groups',
+    'membership',
+    'Manage user group membership',
+    'global',
+    ['user_groups.view'],
+  ),
+  definition('devices.view', 'devices', 'view', 'View devices', 'device_group'),
+  definition(
+    'devices.edit',
+    'devices',
+    'edit',
+    'Edit device metadata',
+    'device_group',
+    ['devices.view'],
+  ),
+  definition(
+    'devices.status',
+    'devices',
+    'status',
+    'Change device status',
+    'device_group',
+    ['devices.view'],
+  ),
+  definition(
+    'devices.delete',
+    'devices',
+    'delete',
+    'Delete devices',
+    'device_group',
+    ['devices.view'],
+  ),
+  definition(
+    'devices.disconnect',
+    'devices',
+    'disconnect',
+    'Disconnect devices',
+    'device_group',
+    ['devices.view'],
+  ),
+  definition(
+    'address_books.view',
+    'address_books',
+    'view',
+    'View address books',
+  ),
+  definition(
+    'address_books.edit',
+    'address_books',
+    'edit',
+    'Edit address books',
+    'global',
+    ['address_books.view'],
+  ),
+  definition(
+    'address_books.share',
+    'address_books',
+    'share',
+    'Share address books',
+    'global',
+    ['address_books.view'],
+  ),
+  definition('strategies.view', 'strategies', 'view', 'View strategies'),
+  definition(
+    'strategies.create',
+    'strategies',
+    'create',
+    'Create strategies',
+    'global',
+    ['strategies.view'],
+  ),
+  definition(
+    'strategies.edit',
+    'strategies',
+    'edit',
+    'Edit strategies',
+    'global',
+    ['strategies.view'],
+  ),
+  definition(
+    'strategies.delete',
+    'strategies',
+    'delete',
+    'Delete strategies',
+    'global',
+    ['strategies.view'],
+  ),
+  definition(
+    'strategies.assign',
+    'strategies',
+    'assign',
+    'Assign strategies',
+    'device_group',
+  ),
+  definition('audit.view', 'audit', 'view', 'View audit data'),
+  systemDefinition('roles.create', 'create', 'Create roles'),
+  systemDefinition('roles.edit', 'edit', 'Edit roles'),
+  systemDefinition('roles.delete', 'delete', 'Delete roles'),
+  definition('roles.view', 'roles', 'view', 'View roles'),
+  definition('roles.assign', 'roles', 'assign', 'Assign roles', 'global', [
+    'roles.view',
+    'users.view',
+  ]),
+];
+
+export const PERMISSION_CODES: readonly PermissionCode[] =
+  PERMISSION_CATALOG.filter((item) => item.assignable).map(
+    (item) => item.code as PermissionCode,
+  );
+
+export const isDeviceGroupScopedPermission = (
+  code: string,
+): code is PermissionCode =>
+  PERMISSION_CATALOG.some(
+    (permission) =>
+      permission.code === code && permission.scope === 'device_group',
+  );
+
+export const isAssignablePermissionCode = (
+  code: string,
+): code is PermissionCode => PERMISSION_CODES.includes(code as PermissionCode);
+
+const PERMISSION_REQUIREMENTS = new Map(
+  PERMISSION_CATALOG.filter((permission) => permission.assignable).map(
+    (permission) => [permission.code, permission.requires || []],
+  ),
+);
+
+export const getPermissionRequirements = (
+  code: PermissionCode,
+): readonly PermissionCode[] => PERMISSION_REQUIREMENTS.get(code) || [];
+
+export const filterEffectivePermissionCodes = (
+  codes: readonly string[],
+): PermissionCode[] => {
+  const known = new Set(codes.filter(isAssignablePermissionCode));
+  return [...known]
+    .filter((code) =>
+      getPermissionRequirements(code).every((required) => known.has(required)),
+    )
+    .sort();
+};

--- a/src/modules/rbac/decorators/require-permission.decorator.ts
+++ b/src/modules/rbac/decorators/require-permission.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+import { PermissionCode } from '../constants/permission-catalog';
+
+export const REQUIRE_PERMISSION_KEY = 'rbac:required_permissions';
+export const REQUIRE_SUPER_ADMIN_KEY = 'rbac:super_admin';
+
+export const RequirePermission = (...permissions: PermissionCode[]) =>
+  SetMetadata(REQUIRE_PERMISSION_KEY, permissions);
+
+export const RequireSuperAdmin = () =>
+  SetMetadata(REQUIRE_SUPER_ADMIN_KEY, true);

--- a/src/modules/rbac/dto/role.dto.ts
+++ b/src/modules/rbac/dto/role.dto.ts
@@ -1,0 +1,88 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  IsBoolean,
+} from 'class-validator';
+
+export class RoleQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  current = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize = 20;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+}
+
+export class CreateRoleDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  @MaxLength(100, { each: true })
+  permissions: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  protected_account?: boolean;
+}
+
+export class UpdateRoleDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  @MaxLength(100, { each: true })
+  permissions?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  protected_account?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  confirm_protected_account_change?: boolean;
+}

--- a/src/modules/rbac/dto/user-role.dto.ts
+++ b/src/modules/rbac/dto/user-role.dto.ts
@@ -1,0 +1,33 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+
+export class UserRoleAssignmentDto {
+  @IsUUID('4')
+  role_guid: string;
+
+  @IsString()
+  @IsIn(['global', 'device_group'])
+  scope_type: 'global' | 'device_group';
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(200)
+  @IsUUID('4', { each: true })
+  device_group_guids?: string[];
+}
+
+export class ReplaceUserRolesDto {
+  @IsArray()
+  @ArrayMaxSize(100)
+  @ValidateNested({ each: true })
+  @Type(() => UserRoleAssignmentDto)
+  assignments: UserRoleAssignmentDto[];
+}

--- a/src/modules/rbac/entities/console-audit.entity.ts
+++ b/src/modules/rbac/entities/console-audit.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+} from 'typeorm';
+
+@Entity('console_audits')
+@Index(['actorUserGuid', 'createdAt'])
+@Index(['targetType', 'targetGuid', 'createdAt'])
+export class ConsoleAudit {
+  @PrimaryColumn()
+  guid: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  @Index()
+  actorUserGuid: string | null;
+
+  @Column({ type: 'varchar' })
+  targetType: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  targetGuid: string | null;
+
+  @Column({ type: 'varchar' })
+  action: string;
+
+  @Column({ type: 'varchar' })
+  result: 'allowed' | 'denied';
+
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  beforeState: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  afterState: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  requestId: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/rbac/entities/role-permission.entity.ts
+++ b/src/modules/rbac/entities/role-permission.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Role } from './role.entity';
+
+@Entity('role_permissions')
+export class RolePermission {
+  @PrimaryColumn()
+  roleGuid: string;
+
+  @PrimaryColumn({ type: 'varchar' })
+  permissionCode: string;
+
+  @ManyToOne(() => Role, (role) => role.rolePermissions, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'roleGuid', referencedColumnName: 'guid' })
+  role: Role;
+}

--- a/src/modules/rbac/entities/role.entity.ts
+++ b/src/modules/rbac/entities/role.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { RolePermission } from './role-permission.entity';
+import { UserRoleAssignment } from './user-role-assignment.entity';
+
+@Entity('roles')
+export class Role {
+  @PrimaryColumn()
+  guid: string;
+
+  @Column({ type: 'varchar', unique: true, collation: 'NOCASE' })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  note: string | null;
+
+  /** Protected roles make every assigned account protected from delegated administration. */
+  @Column({ default: false })
+  protectedAccount: boolean;
+
+  @OneToMany(() => RolePermission, (permission) => permission.role)
+  rolePermissions: RolePermission[];
+
+  @OneToMany(() => UserRoleAssignment, (assignment) => assignment.role)
+  assignments: UserRoleAssignment[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/rbac/entities/user-role-assignment-device-group.entity.ts
+++ b/src/modules/rbac/entities/user-role-assignment-device-group.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { DeviceGroup } from '../../device-group/entities/device-group.entity';
+import { UserRoleAssignment } from './user-role-assignment.entity';
+
+@Entity('user_role_assignment_device_groups')
+export class UserRoleAssignmentDeviceGroup {
+  @PrimaryColumn()
+  assignmentGuid: string;
+
+  @PrimaryColumn()
+  @Index()
+  deviceGroupGuid: string;
+
+  @ManyToOne(
+    () => UserRoleAssignment,
+    (assignment) => assignment.deviceGroups,
+    {
+      onDelete: 'CASCADE',
+    },
+  )
+  @JoinColumn({ name: 'assignmentGuid', referencedColumnName: 'guid' })
+  assignment: UserRoleAssignment;
+
+  @ManyToOne(() => DeviceGroup, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'deviceGroupGuid', referencedColumnName: 'guid' })
+  deviceGroup: DeviceGroup;
+}

--- a/src/modules/rbac/entities/user-role-assignment.entity.ts
+++ b/src/modules/rbac/entities/user-role-assignment.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+import { Role } from './role.entity';
+import { UserRoleAssignmentDeviceGroup } from './user-role-assignment-device-group.entity';
+
+export type AssignmentScopeType = 'global' | 'device_group';
+
+@Entity('user_role_assignments')
+@Index(['userGuid', 'roleGuid'], { unique: true })
+export class UserRoleAssignment {
+  @PrimaryColumn()
+  guid: string;
+
+  @Column({ type: 'varchar' })
+  userGuid: string;
+
+  @Column({ type: 'varchar' })
+  @Index()
+  roleGuid: string;
+
+  @Column({ type: 'varchar' })
+  scopeType: AssignmentScopeType;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userGuid', referencedColumnName: 'guid' })
+  user: User;
+
+  @ManyToOne(() => Role, (role) => role.assignments, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'roleGuid', referencedColumnName: 'guid' })
+  role: Role;
+
+  @OneToMany(() => UserRoleAssignmentDeviceGroup, (group) => group.assignment)
+  deviceGroups: UserRoleAssignmentDeviceGroup[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/rbac/guards/rbac.guard.ts
+++ b/src/modules/rbac/guards/rbac.guard.ts
@@ -1,0 +1,66 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  REQUIRE_PERMISSION_KEY,
+  REQUIRE_SUPER_ADMIN_KEY,
+} from '../decorators/require-permission.decorator';
+import { RbacAuditService } from '../services/rbac-audit.service';
+import { RbacAuthorizationService } from '../services/rbac-authorization.service';
+
+interface RequestWithUser {
+  user?: { id?: string };
+  id?: string;
+}
+
+@Injectable()
+export class RbacGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly authorizationService: RbacAuthorizationService,
+    private readonly auditService: RbacAuditService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const permissions = this.reflector.getAllAndOverride<string[]>(
+      REQUIRE_PERMISSION_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    const requiresSuperAdmin = this.reflector.getAllAndOverride<boolean>(
+      REQUIRE_SUPER_ADMIN_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if ((!permissions || permissions.length === 0) && !requiresSuperAdmin) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const userGuid = request.user?.id;
+    if (!userGuid) {
+      throw new ForbiddenException('请先登录');
+    }
+
+    try {
+      if (requiresSuperAdmin) {
+        await this.authorizationService.requireSuperAdmin(userGuid);
+      }
+      for (const permission of permissions || []) {
+        await this.authorizationService.requirePermission(userGuid, permission);
+      }
+      return true;
+    } catch (error: unknown) {
+      await this.auditService.recordDenied({
+        actorUserGuid: userGuid,
+        targetType: 'route',
+        action: permissions?.join(',') || 'super_admin',
+        reason: error instanceof Error ? error.message : String(error),
+        requestId: request.id,
+      });
+      throw error;
+    }
+  }
+}

--- a/src/modules/rbac/permission.controller.ts
+++ b/src/modules/rbac/permission.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get } from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PERMISSION_CATALOG } from './constants/permission-catalog';
+import { RequirePermission } from './decorators/require-permission.decorator';
+import { RbacAuthorizationService } from './services/rbac-authorization.service';
+
+@Controller('permissions')
+export class PermissionController {
+  constructor(
+    private readonly authorizationService: RbacAuthorizationService,
+  ) {}
+
+  @Get()
+  @RequirePermission('roles.view')
+  getPermissions() {
+    return {
+      data: PERMISSION_CATALOG.map((permission) => ({
+        code: permission.code,
+        resource: permission.resource,
+        action: permission.action,
+        name: permission.name,
+        description: permission.description,
+        scope: permission.scope,
+        assignable: permission.assignable,
+        system_only: permission.system_only,
+        ...(permission.requires ? { requires: permission.requires } : {}),
+      })),
+    };
+  }
+
+  @Get('me')
+  getMyPermissions(@CurrentUser('id') userGuid: string) {
+    return this.authorizationService.getEffectivePermissions(userGuid);
+  }
+}

--- a/src/modules/rbac/rbac-authorization.service.spec.ts
+++ b/src/modules/rbac/rbac-authorization.service.spec.ts
@@ -1,0 +1,1520 @@
+import 'reflect-metadata';
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { DataSource, Repository } from 'typeorm';
+import { Peer } from '../../common/entities/peer.entity';
+import { AuditsController } from '../audit/audit.controller';
+import { DashboardController } from '../dashboard/dashboard.controller';
+import { DeviceGroup } from '../device-group/entities/device-group.entity';
+import { DeviceGroupController } from '../device-group/device-group.controller';
+import { DeviceStatus } from '../device-group/dto/device-status.dto';
+import { DeviceGroupService } from '../device-group/device-group.service';
+import { UserGroupController } from '../user-group/user-group.controller';
+import { User, UserStatus } from '../user/entities/user.entity';
+import { PermissionController } from './permission.controller';
+import { PERMISSION_CATALOG } from './constants/permission-catalog';
+import {
+  REQUIRE_PERMISSION_KEY,
+  REQUIRE_SUPER_ADMIN_KEY,
+} from './decorators/require-permission.decorator';
+import { ConsoleAudit } from './entities/console-audit.entity';
+import { Role } from './entities/role.entity';
+import { RolePermission } from './entities/role-permission.entity';
+import { UserRoleAssignment } from './entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from './entities/user-role-assignment-device-group.entity';
+import { RbacGuard } from './guards/rbac.guard';
+import { RoleController } from './role.controller';
+import { RbacAuditService } from './services/rbac-audit.service';
+import { RbacAuthorizationService } from './services/rbac-authorization.service';
+import { RoleService } from './services/role.service';
+import { UserRoleService } from './services/user-role.service';
+import { UserRoleController } from './user-role.controller';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+type MockRepository = {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+  exist: jest.Mock;
+};
+
+const repository = (): MockRepository => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn((value) => value),
+  save: jest.fn((value) => value),
+  exist: jest.fn(),
+});
+
+describe('RbacAuthorizationService', () => {
+  let userRepository: MockRepository;
+  let rolePermissionRepository: MockRepository;
+  let assignmentRepository: MockRepository;
+  let assignmentGroupRepository: MockRepository;
+  let peerRepository: MockRepository;
+  let deviceGroupRepository: MockRepository;
+  let roleRepository: MockRepository;
+  let auditService: { recordDenied: jest.Mock };
+  let service: RbacAuthorizationService;
+
+  const activeUser = {
+    guid: 'actor',
+    status: UserStatus.ACTIVE,
+    isAdmin: false,
+  } as User;
+
+  beforeEach(() => {
+    userRepository = repository();
+    rolePermissionRepository = repository();
+    assignmentRepository = repository();
+    assignmentGroupRepository = repository();
+    peerRepository = repository();
+    deviceGroupRepository = repository();
+    roleRepository = repository();
+    auditService = { recordDenied: jest.fn().mockResolvedValue(undefined) };
+    userRepository.findOne.mockResolvedValue(activeUser);
+    assignmentRepository.find.mockResolvedValue([]);
+    rolePermissionRepository.find.mockResolvedValue([]);
+    assignmentGroupRepository.find.mockResolvedValue([]);
+    roleRepository.find.mockResolvedValue([]);
+    peerRepository.find.mockResolvedValue([]);
+    service = new RbacAuthorizationService(
+      userRepository as unknown as Repository<User>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      assignmentGroupRepository as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      peerRepository as unknown as Repository<Peer>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      auditService as unknown as RbacAuditService,
+      roleRepository as unknown as Repository<Role>,
+    );
+  });
+
+  it('rejects disabled users before reading role grants', async () => {
+    userRepository.findOne.mockResolvedValue({
+      ...activeUser,
+      status: UserStatus.DISABLED,
+    });
+
+    await expect(
+      service.requirePermission('actor', 'devices.view'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(assignmentRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('uses the transaction manager for target protection rechecks', async () => {
+    const managerUserRepository = repository();
+    const managerAssignmentRepository = repository();
+    const managerRoleRepository = repository();
+    const manager = {
+      getRepository: jest.fn((entity: unknown) =>
+        entity === User
+          ? managerUserRepository
+          : entity === UserRoleAssignment
+            ? managerAssignmentRepository
+            : managerRoleRepository,
+      ),
+    };
+    managerUserRepository.findOne
+      .mockResolvedValueOnce({
+        guid: 'actor',
+        status: UserStatus.ACTIVE,
+        isAdmin: false,
+      })
+      .mockResolvedValueOnce({ guid: 'target', isAdmin: false });
+    managerAssignmentRepository.find.mockResolvedValue([]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'actor-role', permissionCode: 'users.edit' },
+    ]);
+    await expect(
+      service.assertUserMutation(
+        'actor',
+        'target',
+        'users.edit',
+        undefined,
+        manager as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(managerUserRepository.findOne).toHaveBeenCalled();
+    expect(userRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('applies a device-group grant and never treats it as global', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+
+    await expect(
+      service.getPermissionScope('actor', 'devices.view'),
+    ).resolves.toEqual({
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    });
+  });
+
+  it('makes a global grant win over narrower grants for the same action', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+      { guid: 'assignment-2', roleGuid: 'role-2', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+      { roleGuid: 'role-2', permissionCode: 'devices.view' },
+    ]);
+
+    await expect(
+      service.getPermissionScope('actor', 'devices.view'),
+    ).resolves.toEqual({
+      global: true,
+      deviceGroupGuids: new Set(),
+    });
+    expect(assignmentGroupRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('ignores a damaged device-group grant for a global-only action', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'users.edit' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+
+    await expect(
+      service.requirePermission('actor', 'users.edit'),
+    ).rejects.toThrow('无权限访问');
+    expect(assignmentGroupRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct and batch access outside the selected groups', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+      { roleGuid: 'role-1', permissionCode: 'devices.delete' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+    peerRepository.findOne.mockResolvedValue({
+      uuid: 'peer-2',
+      deviceGroupGuid: 'group-2',
+    });
+
+    await expect(
+      service.assertDeviceAccess('actor', 'devices.delete', 'peer-2'),
+    ).rejects.toThrow('设备不在授权设备组内');
+
+    peerRepository.find.mockResolvedValue([
+      { uuid: 'peer-1', deviceGroupGuid: 'group-1' },
+      { uuid: 'peer-2', deviceGroupGuid: 'group-2' },
+    ] as Peer[]);
+    await expect(
+      service.assertDevicesAccess('actor', 'devices.delete', [
+        'peer-1',
+        'peer-2',
+      ]),
+    ).rejects.toThrow('批量请求包含未授权设备');
+    expect(auditService.recordDenied).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserGuid: 'actor',
+        targetType: 'device',
+        targetGuid: 'peer-2',
+        action: 'devices.delete',
+      }),
+    );
+  });
+
+  it('reflects role revocation on the next authorization request', async () => {
+    assignmentRepository.find
+      .mockResolvedValueOnce([
+        { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+      ])
+      .mockResolvedValueOnce([]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'strategies.view' },
+    ]);
+
+    await expect(
+      service.requirePermission('actor', 'strategies.view'),
+    ).resolves.toEqual({ global: true, deviceGroupGuids: new Set() });
+    await expect(
+      service.requirePermission('actor', 'strategies.view'),
+    ).rejects.toThrow('无权限访问');
+  });
+
+  it('requires global scope for strategy assignment to a user', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'strategies.assign' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+
+    await expect(
+      service.assertStrategyTargets('actor', 'user', ['user-1']),
+    ).rejects.toThrow('按用户分配策略需要全局权限');
+  });
+
+  it('protects administrator users from global strategy assignment', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'strategies.assign' },
+    ]);
+    userRepository.find.mockResolvedValue([
+      { guid: 'protected-user', isAdmin: true },
+    ]);
+
+    await expect(
+      service.assertStrategyTargets('actor', 'user', ['protected-user']),
+    ).rejects.toThrow('需要超级管理员权限');
+    expect(auditService.recordDenied).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserGuid: 'actor',
+        targetGuid: 'protected-user',
+        action: 'super_admin',
+      }),
+    );
+  });
+
+  it('protects administrator users on alternate batch mutation paths', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'user_groups.view' },
+      { roleGuid: 'role-1', permissionCode: 'user_groups.membership' },
+    ]);
+    userRepository.find.mockResolvedValue([
+      { guid: 'protected-user', isAdmin: true },
+    ]);
+
+    await expect(
+      service.assertUsersMutation(
+        'actor',
+        ['protected-user'],
+        'user_groups.membership',
+      ),
+    ).rejects.toThrow('需要超级管理员权限');
+  });
+
+  it('does not expose unknown persisted permission rows as effective grants', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'future.admin' },
+      { roleGuid: 'role-1', permissionCode: 'roles.create' },
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+    ]);
+
+    const result = await service.getEffectivePermissions('actor');
+    expect(result.permissions).toEqual(['devices.view']);
+    expect(result.scopes['future.admin']).toBeUndefined();
+    expect(result.scopes['roles.create']).toBeUndefined();
+    expect(
+      PERMISSION_CATALOG.map((permission) => permission.code),
+    ).not.toContain('future.admin');
+  });
+
+  it('fails closed when a persisted write permission lacks its same-role view dependency', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+      { guid: 'assignment-2', roleGuid: 'role-2', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'users.edit' },
+      { roleGuid: 'role-2', permissionCode: 'users.view' },
+    ]);
+
+    await expect(
+      service.requirePermission('actor', 'users.edit'),
+    ).rejects.toThrow('无权限访问');
+    await expect(service.getEffectivePermissions('actor')).resolves.toEqual({
+      permissions: ['users.view'],
+      scopes: {
+        'users.view': {
+          scope_type: 'global',
+          device_group_guids: [],
+        },
+      },
+    });
+  });
+
+  it('keeps a persisted write permission effective when its dependency is in the same role', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'global' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'users.view' },
+      { roleGuid: 'role-1', permissionCode: 'users.edit' },
+    ]);
+
+    await expect(
+      service.requirePermission('actor', 'users.edit'),
+    ).resolves.toEqual({ global: true, deviceGroupGuids: new Set() });
+  });
+
+  it('does not expose a damaged scoped assignment with no device groups', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+    ]);
+
+    await expect(service.getEffectivePermissions('actor')).resolves.toEqual({
+      permissions: [],
+      scopes: {},
+    });
+  });
+
+  it('lets missing strategy device groups reach the established partial-error path', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'strategies.assign' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+    deviceGroupRepository.find.mockResolvedValue([{ guid: 'group-1' }]);
+
+    await expect(
+      service.assertStrategyTargets('actor', 'device_group', [
+        'group-1',
+        'missing-group',
+      ]),
+    ).resolves.toEqual({
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    });
+  });
+
+  it('rejects an existing out-of-scope strategy device group', async () => {
+    assignmentRepository.find.mockResolvedValue([
+      { guid: 'assignment-1', roleGuid: 'role-1', scopeType: 'device_group' },
+    ]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'strategies.assign' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+    deviceGroupRepository.find.mockResolvedValue([{ guid: 'group-2' }]);
+
+    await expect(
+      service.assertStrategyTargets('actor', 'device_group', ['group-2']),
+    ).rejects.toThrow('目标设备组不在授权范围内');
+  });
+});
+
+describe('UserRoleService', () => {
+  it('does not present global-only role permissions as device-group grants', async () => {
+    const userRepository = repository();
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const assignmentGroupRepository = repository();
+    const deviceGroupRepository = repository();
+    userRepository.exist.mockResolvedValue(true);
+    assignmentRepository.find.mockResolvedValue([
+      {
+        guid: 'assignment-1',
+        userGuid: 'user-1',
+        roleGuid: 'role-1',
+        scopeType: 'device_group',
+      },
+    ]);
+    roleRepository.find.mockResolvedValue([
+      { guid: 'role-1', name: 'Device operator' },
+    ] as Role[]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'devices.view' },
+      { roleGuid: 'role-1', permissionCode: 'users.edit' },
+    ]);
+    assignmentGroupRepository.find.mockResolvedValue([
+      { assignmentGuid: 'assignment-1', deviceGroupGuid: 'group-1' },
+    ]);
+
+    const service = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      assignmentGroupRepository as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      {} as DataSource,
+      {} as RbacAuditService,
+      {} as RbacAuthorizationService,
+    );
+
+    const result = await service.getUserRoles('user-1');
+    expect(result.data[0].permissions).toEqual(['devices.view']);
+    expect(result.effective_scope).toEqual({
+      'devices.view': {
+        scope_type: 'device_group',
+        device_group_guids: ['group-1'],
+      },
+    });
+  });
+
+  it('returns the agreed role eligibility scope contract', async () => {
+    const userRepository = repository();
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const deviceGroupRepository = repository();
+    userRepository.findOne.mockResolvedValue({
+      guid: 'target',
+      isAdmin: false,
+    });
+    roleRepository.find.mockResolvedValue([
+      { guid: 'device-role', name: 'Device role', protectedAccount: false },
+      { guid: 'global-role', name: 'Global role', protectedAccount: false },
+      { guid: 'mixed-role', name: 'Mixed role', protectedAccount: false },
+    ]);
+    assignmentRepository.find.mockResolvedValue([]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'device-role', permissionCode: 'devices.view' },
+      { roleGuid: 'global-role', permissionCode: 'users.view' },
+      { roleGuid: 'mixed-role', permissionCode: 'devices.view' },
+      { roleGuid: 'mixed-role', permissionCode: 'users.view' },
+    ]);
+    deviceGroupRepository.find.mockResolvedValue([
+      { guid: 'group-1', name: 'Group 1' },
+      { guid: 'group-2', name: 'Group 2' },
+    ]);
+    const eligibilityService = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      {} as DataSource,
+      {} as RbacAuditService,
+      {
+        getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: true }),
+        getEffectivePermissions: jest.fn(),
+        isProtectedUser: jest.fn().mockResolvedValue(false),
+      } as unknown as RbacAuthorizationService,
+    );
+    const result = await eligibilityService.getRoleEligibility(
+      'target',
+      'owner',
+    );
+    expect(result.data.map((role) => role.allowed_scope_types)).toEqual([
+      ['global', 'device_group'],
+      ['global'],
+      ['global'],
+    ]);
+    expect(result.data[0].assignable_device_groups).toEqual([
+      { guid: 'group-1', name: 'Group 1' },
+      { guid: 'group-2', name: 'Group 2' },
+    ]);
+
+    userRepository.findOne.mockResolvedValue({
+      guid: 'owner',
+      isAdmin: true,
+    });
+    const ownerTarget = await eligibilityService.getRoleEligibility(
+      'owner',
+      'owner',
+    );
+    expect(
+      ownerTarget.data.every(
+        (role) =>
+          role.reason_code === 'super_admin_target' &&
+          !role.can_assign &&
+          !role.can_remove,
+      ),
+    ).toBe(true);
+  });
+
+  it('computes delegated scope types and group intersections from effective grants', async () => {
+    const userRepository = repository();
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const deviceGroupRepository = repository();
+    userRepository.findOne.mockResolvedValue({
+      guid: 'target',
+      isAdmin: false,
+    });
+    roleRepository.find.mockResolvedValue([
+      { guid: 'group-role', name: 'Group role', protectedAccount: false },
+      {
+        guid: 'global-device-role',
+        name: 'Device role',
+        protectedAccount: false,
+      },
+      { guid: 'mixed-role', name: 'Mixed role', protectedAccount: false },
+      { guid: 'empty-role', name: 'Empty role', protectedAccount: false },
+      {
+        guid: 'no-overlap-role',
+        name: 'No overlap role',
+        protectedAccount: false,
+      },
+    ] as Role[]);
+    assignmentRepository.find.mockResolvedValue([]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'group-role', permissionCode: 'devices.view' },
+      { roleGuid: 'global-device-role', permissionCode: 'devices.view' },
+      { roleGuid: 'mixed-role', permissionCode: 'devices.view' },
+      { roleGuid: 'mixed-role', permissionCode: 'users.view' },
+      { roleGuid: 'no-overlap-role', permissionCode: 'devices.view' },
+      { roleGuid: 'no-overlap-role', permissionCode: 'strategies.assign' },
+    ]);
+    deviceGroupRepository.find.mockResolvedValue([
+      { guid: 'group-1', name: 'Group 1' },
+      { guid: 'group-2', name: 'Group 2' },
+    ]);
+    const authorizationService = {
+      getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: false }),
+      getEffectivePermissions: jest.fn().mockResolvedValue({
+        permissions: ['devices.view', 'users.view'],
+        scopes: {
+          'devices.view': {
+            scope_type: 'device_group',
+            device_group_guids: ['group-1'],
+          },
+          'users.view': {
+            scope_type: 'global',
+            device_group_guids: [],
+          },
+          'strategies.assign': {
+            scope_type: 'device_group',
+            device_group_guids: ['group-2'],
+          },
+        },
+      }),
+      isProtectedUser: jest.fn().mockResolvedValue(false),
+    };
+    const eligibilityService = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      {} as DataSource,
+      {} as RbacAuditService,
+      authorizationService as unknown as RbacAuthorizationService,
+    );
+
+    const result = await eligibilityService.getRoleEligibility(
+      'target',
+      'delegated-actor',
+    );
+
+    expect(
+      Object.fromEntries(
+        result.data.map((role) => [
+          role.name,
+          {
+            can_assign: role.can_assign,
+            reason_code: role.reason_code,
+            allowed_scope_types: role.allowed_scope_types,
+            assignable_device_groups: role.assignable_device_groups,
+          },
+        ]),
+      ),
+    ).toEqual({
+      'Device role': {
+        can_assign: true,
+        reason_code: null,
+        allowed_scope_types: ['device_group'],
+        assignable_device_groups: [{ guid: 'group-1', name: 'Group 1' }],
+      },
+      'Empty role': {
+        can_assign: false,
+        reason_code: 'scope_exceeds_caller',
+        allowed_scope_types: [],
+        assignable_device_groups: [],
+      },
+      'Group role': {
+        can_assign: true,
+        reason_code: null,
+        allowed_scope_types: ['device_group'],
+        assignable_device_groups: [{ guid: 'group-1', name: 'Group 1' }],
+      },
+      'Mixed role': {
+        can_assign: false,
+        reason_code: 'scope_exceeds_caller',
+        allowed_scope_types: [],
+        assignable_device_groups: [],
+      },
+      'No overlap role': {
+        can_assign: false,
+        reason_code: 'scope_exceeds_caller',
+        allowed_scope_types: [],
+        assignable_device_groups: [],
+      },
+    });
+
+    authorizationService.getEffectivePermissions.mockResolvedValue({
+      permissions: ['devices.view', 'users.view'],
+      scopes: {
+        'devices.view': { scope_type: 'global', device_group_guids: [] },
+        'users.view': { scope_type: 'global', device_group_guids: [] },
+      },
+    });
+    const globallyCovered = await eligibilityService.getRoleEligibility(
+      'target',
+      'delegated-actor',
+    );
+    const deviceRole = globallyCovered.data.find(
+      (role) => role.name === 'Device role',
+    );
+    expect(deviceRole).toMatchObject({
+      allowed_scope_types: ['global', 'device_group'],
+      assignable_device_groups: [
+        { guid: 'group-1', name: 'Group 1' },
+        { guid: 'group-2', name: 'Group 2' },
+      ],
+    });
+  });
+
+  it('reports stable self, protected-target, and locked-role reasons', async () => {
+    const userRepository = repository();
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const deviceGroupRepository = repository();
+    userRepository.findOne.mockResolvedValue({
+      guid: 'target',
+      isAdmin: false,
+    });
+    roleRepository.find.mockResolvedValue([
+      {
+        guid: 'protected-role',
+        name: 'Protected role',
+        protectedAccount: true,
+      },
+      { guid: 'assign-role', name: 'Assign role', protectedAccount: false },
+    ] as Role[]);
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'protected-role', permissionCode: 'users.view' },
+      { roleGuid: 'assign-role', permissionCode: 'roles.assign' },
+      { roleGuid: 'assign-role', permissionCode: 'roles.view' },
+      { roleGuid: 'assign-role', permissionCode: 'users.view' },
+    ]);
+    assignmentRepository.find.mockResolvedValue([]);
+    deviceGroupRepository.find.mockResolvedValue([]);
+    const authorizationService = {
+      getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: false }),
+      getEffectivePermissions: jest.fn().mockResolvedValue({
+        permissions: ['users.view', 'roles.assign'],
+        scopes: {
+          'users.view': { scope_type: 'global', device_group_guids: [] },
+          'roles.assign': { scope_type: 'global', device_group_guids: [] },
+        },
+      }),
+      isProtectedUser: jest.fn().mockResolvedValue(true),
+    };
+    const eligibilityService = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      {} as DataSource,
+      {} as RbacAuditService,
+      authorizationService as unknown as RbacAuthorizationService,
+    );
+
+    const protectedResult = await eligibilityService.getRoleEligibility(
+      'target',
+      'delegated-actor',
+    );
+    expect(
+      protectedResult.data.every(
+        (role) =>
+          role.reason_code === 'protected_target' &&
+          !role.can_assign &&
+          !role.can_remove &&
+          role.allowed_scope_types.length === 0,
+      ),
+    ).toBe(true);
+
+    authorizationService.isProtectedUser.mockResolvedValue(false);
+    const lockedResult = await eligibilityService.getRoleEligibility(
+      'target',
+      'delegated-actor',
+    );
+    expect(lockedResult.data.map((role) => role.reason_code)).toEqual([
+      'protected_role',
+      'role_grants_roles_assign',
+    ]);
+    const selfResult = await eligibilityService.getRoleEligibility(
+      'target',
+      'target',
+    );
+    expect(
+      selfResult.data.every((role) => role.reason_code === 'self_target'),
+    ).toBe(true);
+  });
+
+  it('rejects assigning an empty role to device-group scope', async () => {
+    const userRepository = repository();
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const authorizationService = {
+      requireSuperAdmin: jest.fn().mockResolvedValue(undefined),
+      getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: true }),
+      requirePermission: jest.fn().mockResolvedValue({
+        global: true,
+        deviceGroupGuids: new Set<string>(),
+      }),
+      isProtectedUser: jest.fn().mockResolvedValue(false),
+    };
+    userRepository.exist.mockResolvedValue(true);
+    roleRepository.find.mockResolvedValue([{ guid: 'empty-role' }] as Role[]);
+    rolePermissionRepository.find.mockResolvedValue([]);
+    const transaction = jest.fn();
+    const service = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      repository() as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      repository() as unknown as Repository<DeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      authorizationService as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.replaceUserRoles(
+        'user-1',
+        {
+          assignments: [
+            {
+              role_guid: 'empty-role',
+              scope_type: 'device_group',
+              device_group_guids: ['group-1'],
+            },
+          ],
+        },
+        'actor',
+      ),
+    ).rejects.toThrow('device_group scope only supports');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('classifies an empty device-group assignment as invalid input', async () => {
+    const service = new UserRoleService(
+      repository() as unknown as Repository<User>,
+      repository() as unknown as Repository<Role>,
+      repository() as unknown as Repository<RolePermission>,
+      repository() as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      repository() as unknown as Repository<DeviceGroup>,
+      { transaction: jest.fn() } as unknown as DataSource,
+      {} as RbacAuditService,
+      {} as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.replaceUserRoles(
+        'user-1',
+        {
+          assignments: [
+            {
+              role_guid: 'role-1',
+              scope_type: 'device_group',
+              device_group_guids: [],
+            },
+          ],
+        },
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects ordinary role assignments for the virtual super administrator', async () => {
+    const userRepository = repository();
+    userRepository.exist.mockResolvedValue(true);
+    userRepository.findOne.mockResolvedValue({ guid: 'owner', isAdmin: true });
+    const transaction = jest.fn();
+    const service = new UserRoleService(
+      userRepository as unknown as Repository<User>,
+      repository() as unknown as Repository<Role>,
+      repository() as unknown as Repository<RolePermission>,
+      repository() as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      repository() as unknown as Repository<DeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      {
+        getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: true }),
+      } as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.replaceUserRoles('owner', { assignments: [] }, 'owner'),
+    ).rejects.toThrow('超级管理员不能分配普通角色');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('RoleService', () => {
+  it('omits ineffective damaged permissions from role list summaries', async () => {
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const builder = {
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest
+        .fn()
+        .mockResolvedValue([[{ guid: 'role-1', name: 'Damaged role' }], 1]),
+    };
+    Object.assign(roleRepository, {
+      createQueryBuilder: jest.fn().mockReturnValue(builder),
+    });
+    rolePermissionRepository.find.mockResolvedValue([
+      { roleGuid: 'role-1', permissionCode: 'users.edit' },
+      { roleGuid: 'role-1', permissionCode: 'strategies.assign' },
+    ]);
+    const service = new RoleService(
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      repository() as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      {} as DataSource,
+      {} as RbacAuditService,
+      {} as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.listRoles({
+        current: 1,
+        pageSize: 20,
+        name: 'Damaged',
+        note: 'test note',
+      }),
+    ).resolves.toMatchObject({
+      data: [{ permissions: ['strategies.assign'] }],
+      total: 1,
+    });
+    expect(builder.andWhere).toHaveBeenNthCalledWith(
+      1,
+      'role.name LIKE :name',
+      { name: '%Damaged%' },
+    );
+    expect(builder.andWhere).toHaveBeenNthCalledWith(
+      2,
+      'role.note LIKE :note',
+      { note: '%test note%' },
+    );
+  });
+
+  it('rejects role permissions whose view dependency is missing', async () => {
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const assignmentGroupRepository = repository();
+    roleRepository.findOne.mockResolvedValue({ guid: 'role-1' });
+    rolePermissionRepository.find.mockResolvedValue([]);
+    const transaction = jest.fn();
+    const service = new RoleService(
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      assignmentGroupRepository as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      {
+        requireSuperAdmin: jest.fn().mockResolvedValue(undefined),
+      } as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.updateRole('role-1', { permissions: ['users.edit'] }, 'actor'),
+    ).rejects.toThrow('权限依赖缺失');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects system-only role capabilities in ordinary role payloads', async () => {
+    const roleRepository = repository();
+    roleRepository.findOne.mockResolvedValue({ guid: 'role-1' });
+    const transaction = jest.fn();
+    const service = new RoleService(
+      roleRepository as unknown as Repository<Role>,
+      repository() as unknown as Repository<RolePermission>,
+      repository() as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      {
+        requireSuperAdmin: jest.fn().mockResolvedValue(undefined),
+      } as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.updateRole('role-1', { permissions: ['roles.create'] }, 'owner'),
+    ).rejects.toThrow('权限码不可分配: roles.create');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not add global-only permissions to a role with scoped assignments', async () => {
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    const assignmentGroupRepository = repository();
+    roleRepository.findOne.mockResolvedValue({ guid: 'role-1' });
+    rolePermissionRepository.find.mockResolvedValue([]);
+    assignmentRepository.exist.mockResolvedValue(true);
+    const transaction = jest.fn();
+    const service = new RoleService(
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      assignmentGroupRepository as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      {
+        requireSuperAdmin: jest.fn().mockResolvedValue(undefined),
+      } as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.updateRole(
+        'role-1',
+        { permissions: ['users.view', 'users.edit'] },
+        'actor',
+      ),
+    ).rejects.toThrow('已有高级范围授权');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not empty a role that still has scoped assignments', async () => {
+    const roleRepository = repository();
+    const rolePermissionRepository = repository();
+    const assignmentRepository = repository();
+    roleRepository.findOne.mockResolvedValue({ guid: 'role-1' });
+    rolePermissionRepository.find.mockResolvedValue([]);
+    assignmentRepository.exist.mockResolvedValue(true);
+    const transaction = jest.fn();
+    const service = new RoleService(
+      roleRepository as unknown as Repository<Role>,
+      rolePermissionRepository as unknown as Repository<RolePermission>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      repository() as unknown as Repository<UserRoleAssignmentDeviceGroup>,
+      { transaction } as unknown as DataSource,
+      {} as RbacAuditService,
+      {
+        requireSuperAdmin: jest.fn().mockResolvedValue(undefined),
+      } as unknown as RbacAuthorizationService,
+    );
+
+    await expect(
+      service.updateRole('role-1', { permissions: [] }, 'actor'),
+    ).rejects.toThrow('已有高级范围授权');
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('RbacAuditService', () => {
+  it('redacts credentials before they are persisted', async () => {
+    const auditRepository = repository();
+    const service = new RbacAuditService(
+      auditRepository as unknown as Repository<ConsoleAudit>,
+    );
+
+    await service.record({
+      actorUserGuid: 'actor',
+      targetType: 'role',
+      action: 'role.update',
+      result: 'allowed',
+      afterState: {
+        password: 'secret',
+        nested: { token: 'jwt', visible: true },
+      },
+    });
+
+    expect(auditRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        afterState: JSON.stringify({
+          password: '[REDACTED]',
+          nested: { token: '[REDACTED]', visible: true },
+        }),
+      }),
+    );
+  });
+
+  it('keeps connection-audit mutation super-admin-only', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_SUPER_ADMIN_KEY,
+        AuditsController.prototype.updateConnectionAudit,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps the catalog protected while exposing only the caller effective grants', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        PermissionController.prototype.getPermissions,
+      ),
+    ).toEqual(['roles.view']);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_SUPER_ADMIN_KEY,
+        PermissionController.prototype.getMyPermissions,
+      ),
+    ).toBeUndefined();
+    expect(
+      new PermissionController({} as RbacAuthorizationService)
+        .getPermissions()
+        .data.find((permission) => permission.code === 'devices.edit'),
+    ).toMatchObject({ requires: ['devices.view'] });
+    expect(
+      PERMISSION_CATALOG.find(
+        (permission) => permission.code === 'strategies.assign',
+      )?.requires,
+    ).toBeUndefined();
+    expect(
+      new PermissionController({} as RbacAuthorizationService)
+        .getPermissions()
+        .data.filter((permission) => permission.resource === 'roles'),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'roles.view',
+          assignable: true,
+          system_only: false,
+        }),
+        expect.objectContaining({
+          code: 'roles.assign',
+          assignable: true,
+          system_only: false,
+        }),
+        expect.objectContaining({
+          code: 'roles.create',
+          assignable: false,
+          system_only: true,
+        }),
+        expect.objectContaining({
+          code: 'roles.edit',
+          assignable: false,
+          system_only: true,
+        }),
+        expect.objectContaining({
+          code: 'roles.delete',
+          assignable: false,
+          system_only: true,
+        }),
+      ]),
+    );
+  });
+
+  it('keeps global dashboard aggregates super-administrator-only', () => {
+    expect(
+      Reflect.getMetadata(REQUIRE_SUPER_ADMIN_KEY, DashboardController),
+    ).toBe(true);
+  });
+
+  it('separates delegated role viewing/assignment from owner-only definitions', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        RoleController.prototype.list,
+      ),
+    ).toEqual(['roles.view']);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_SUPER_ADMIN_KEY,
+        RoleController.prototype.create,
+      ),
+    ).toBe(true);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        UserRoleController.prototype.replaceRoles,
+      ),
+    ).toEqual(['roles.assign']);
+  });
+
+  it('allows group reads without granting membership changes', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        UserGroupController.prototype.getGroupUsers,
+      ),
+    ).toEqual(['user_groups.view']);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        UserGroupController.prototype.moveUsers,
+      ),
+    ).toEqual(['user_groups.membership']);
+  });
+});
+
+describe('RbacGuard', () => {
+  const context = {
+    getHandler: () => function handler() {},
+    getClass: () => class Controller {},
+    switchToHttp: () => ({
+      getRequest: () => ({ user: { id: 'actor' }, id: 'request-1' }),
+    }),
+  };
+
+  it('executes the declared permission check', async () => {
+    const reflector = {
+      getAllAndOverride: jest.fn((key: string) =>
+        key === REQUIRE_PERMISSION_KEY ? ['devices.view'] : undefined,
+      ),
+    };
+    const authorizationService = {
+      requirePermission: jest.fn().mockResolvedValue({
+        global: true,
+        deviceGroupGuids: new Set<string>(),
+      }),
+      requireSuperAdmin: jest.fn(),
+    };
+    const auditService = { recordDenied: jest.fn() };
+    const guard = new RbacGuard(
+      reflector as never,
+      authorizationService as never,
+      auditService as never,
+    );
+
+    await expect(guard.canActivate(context as never)).resolves.toBe(true);
+    expect(authorizationService.requirePermission).toHaveBeenCalledWith(
+      'actor',
+      'devices.view',
+    );
+    expect(auditService.recordDenied).not.toHaveBeenCalled();
+  });
+
+  it('records one route denial when the permission check fails', async () => {
+    const denial = new ForbiddenException('无权限访问');
+    const reflector = {
+      getAllAndOverride: jest.fn((key: string) =>
+        key === REQUIRE_PERMISSION_KEY ? ['devices.delete'] : undefined,
+      ),
+    };
+    const authorizationService = {
+      requirePermission: jest.fn().mockRejectedValue(denial),
+      requireSuperAdmin: jest.fn(),
+    };
+    const auditService = {
+      recordDenied: jest.fn().mockResolvedValue(undefined),
+    };
+    const guard = new RbacGuard(
+      reflector as never,
+      authorizationService as never,
+      auditService as never,
+    );
+
+    await expect(guard.canActivate(context as never)).rejects.toBe(denial);
+    expect(auditService.recordDenied).toHaveBeenCalledTimes(1);
+    expect(auditService.recordDenied).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserGuid: 'actor',
+        action: 'devices.delete',
+        requestId: 'request-1',
+      }),
+    );
+  });
+});
+
+describe('DeviceGroupController current-state authorization', () => {
+  const query = { current: 1, pageSize: 20 };
+
+  const createController = () => {
+    const deviceGroupService = {
+      getAccessibleDeviceGroups: jest.fn(),
+      getDevices: jest.fn(),
+    };
+    const heartbeatService = {
+      getActiveConnectionIds: jest.fn(),
+    };
+    const disconnectStoreService = {
+      addPendingDisconnects: jest.fn(),
+    };
+    const authorizationService = {
+      getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: true }),
+      getPermissionScope: jest.fn().mockResolvedValue({
+        global: true,
+        deviceGroupGuids: new Set<string>(),
+      }),
+      assertDeviceAccess: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+      controller: new DeviceGroupController(
+        deviceGroupService as never,
+        heartbeatService as never,
+        disconnectStoreService as never,
+        {} as never,
+        authorizationService as never,
+      ),
+      deviceGroupService,
+      heartbeatService,
+      disconnectStoreService,
+      authorizationService,
+    };
+  };
+
+  it('uses the current strategy-assignment scope for group candidates', async () => {
+    const { controller, deviceGroupService, authorizationService } =
+      createController();
+
+    await controller.getStrategyTargetDeviceGroups('actor', query);
+
+    const scope =
+      await authorizationService.getPermissionScope.mock.results[0].value;
+    expect(deviceGroupService.getAccessibleDeviceGroups).toHaveBeenCalledWith(
+      'actor',
+      query,
+      true,
+      scope,
+    );
+  });
+
+  it('uses only the current RBAC scope for the delegated device list', async () => {
+    const { controller, deviceGroupService, authorizationService } =
+      createController();
+
+    await controller.getDevices('actor', query);
+
+    const scope =
+      await authorizationService.getPermissionScope.mock.results[0].value;
+    expect(deviceGroupService.getDevices).toHaveBeenCalledWith(
+      'actor',
+      query,
+      true,
+      scope,
+    );
+  });
+
+  it('rejects an out-of-scope disconnect before inspecting or queueing it', async () => {
+    const {
+      controller,
+      heartbeatService,
+      disconnectStoreService,
+      authorizationService,
+    } = createController();
+    const denial = new ForbiddenException('设备不在授权设备组内');
+    authorizationService.assertDeviceAccess.mockRejectedValue(denial);
+
+    await expect(
+      controller.disconnectDevice('peer-2', { connIds: [123] }, 'actor'),
+    ).rejects.toBe(denial);
+
+    expect(authorizationService.assertDeviceAccess).toHaveBeenCalledWith(
+      'actor',
+      'devices.disconnect',
+      'peer-2',
+    );
+    expect(heartbeatService.getActiveConnectionIds).not.toHaveBeenCalled();
+    expect(disconnectStoreService.addPendingDisconnects).not.toHaveBeenCalled();
+  });
+
+  it('separates the admin group list from scoped strategy target candidates', () => {
+    expect(
+      Reflect.getMetadata(
+        GUARDS_METADATA,
+        DeviceGroupController.prototype.getDeviceGroups,
+      ),
+    ).toEqual(expect.arrayContaining([expect.any(Function)]));
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        DeviceGroupController.prototype.getStrategyTargetDeviceGroups,
+      ),
+    ).toEqual(['strategies.assign']);
+  });
+});
+
+describe('DeviceGroupService delegated management query', () => {
+  it('intersects an exact requested device group with the current RBAC scope', async () => {
+    const builder = {
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    const peerRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(builder),
+    };
+    const service = new DeviceGroupService(
+      {} as never,
+      {} as never,
+      peerRepository as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    await service.getDevices(
+      'actor',
+      { current: 1, pageSize: 20, device_group_guid: 'group-1' },
+      false,
+      {
+        global: false,
+        deviceGroupGuids: new Set(['group-1', 'group-2']),
+      },
+    );
+
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      'peer.deviceGroupGuid IN (:...rbacDeviceGroups)',
+      { rbacDeviceGroups: ['group-1', 'group-2'] },
+    );
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      'peer.deviceGroupGuid = :deviceGroupGuid',
+      { deviceGroupGuid: 'group-1' },
+    );
+    expect(builder.getManyAndCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies status, online, and operating-system filters before pagination', async () => {
+    const builder = {
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    const service = new DeviceGroupService(
+      {} as never,
+      {} as never,
+      { createQueryBuilder: jest.fn().mockReturnValue(builder) } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    await service.getDevices(
+      'actor',
+      {
+        current: 1,
+        pageSize: 20,
+        status: '0',
+        is_online: '1',
+        os: 'linux',
+      },
+      false,
+      { global: true, deviceGroupGuids: new Set() },
+    );
+
+    expect(builder.andWhere).toHaveBeenCalledWith('peer.status = :status', {
+      status: 0,
+    });
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      'peer.lastHeartbeat > :onlineAfter',
+      { onlineAfter: expect.any(Date) },
+    );
+    expect(builder.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('si.os LIKE :os'),
+      { os: '%linux%' },
+    );
+    expect(builder.getManyAndCount).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DeviceGroupService scoped writes', () => {
+  const scopedAuthorization = {
+    peers: [{ uuid: 'peer-1', deviceGroupGuid: 'group-1' }],
+    scope: {
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    },
+  };
+
+  const createService = (affected: number) => {
+    const manager = {
+      update: jest.fn().mockResolvedValue({ affected }),
+    };
+    const dataSource = {
+      transaction: jest.fn((callback: (value: typeof manager) => unknown) =>
+        callback(manager),
+      ),
+    };
+    const authorizationService = {
+      assertDevicesAccess: jest.fn().mockResolvedValue(scopedAuthorization),
+    };
+    const service = new DeviceGroupService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      dataSource as never,
+      authorizationService as never,
+    );
+    return { service, manager, authorizationService };
+  };
+
+  it('includes the authorized device groups in the atomic status update', async () => {
+    const { service, manager } = createService(1);
+
+    await expect(
+      service.updateDeviceStatus(['peer-1'], DeviceStatus.DISABLED, 'actor'),
+    ).resolves.toMatchObject({ succeeded: ['peer-1'], failed: [] });
+
+    expect(manager.update).toHaveBeenCalledWith(
+      Peer,
+      expect.objectContaining({
+        uuid: expect.anything(),
+        deviceGroupGuid: expect.anything(),
+      }),
+      { status: 0 },
+    );
+  });
+
+  it('rechecks authorization and rejects the whole batch after a concurrent move', async () => {
+    const { service, authorizationService } = createService(0);
+    authorizationService.assertDevicesAccess
+      .mockResolvedValueOnce(scopedAuthorization)
+      .mockRejectedValueOnce(new ForbiddenException('批量请求包含未授权设备'));
+
+    await expect(
+      service.updateDeviceStatus(['peer-1'], DeviceStatus.DISABLED, 'actor'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(authorizationService.assertDevicesAccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/rbac/rbac.module.ts
+++ b/src/modules/rbac/rbac.module.ts
@@ -1,0 +1,41 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Peer } from '../../common/entities/peer.entity';
+import { DeviceGroup } from '../device-group/entities/device-group.entity';
+import { User } from '../user/entities/user.entity';
+import { PermissionController } from './permission.controller';
+import { RoleController } from './role.controller';
+import { UserRoleController } from './user-role.controller';
+import { ConsoleAudit } from './entities/console-audit.entity';
+import { Role } from './entities/role.entity';
+import { RolePermission } from './entities/role-permission.entity';
+import { UserRoleAssignment } from './entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from './entities/user-role-assignment-device-group.entity';
+import { RbacAuditService } from './services/rbac-audit.service';
+import { RbacAuthorizationService } from './services/rbac-authorization.service';
+import { RoleService } from './services/role.service';
+import { UserRoleService } from './services/user-role.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Role,
+      RolePermission,
+      UserRoleAssignment,
+      UserRoleAssignmentDeviceGroup,
+      ConsoleAudit,
+      User,
+      DeviceGroup,
+      Peer,
+    ]),
+  ],
+  controllers: [PermissionController, RoleController, UserRoleController],
+  providers: [
+    RbacAuditService,
+    RbacAuthorizationService,
+    RoleService,
+    UserRoleService,
+  ],
+  exports: [RbacAuditService, RbacAuthorizationService],
+})
+export class RbacModule {}

--- a/src/modules/rbac/role.controller.ts
+++ b/src/modules/rbac/role.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  RequirePermission,
+  RequireSuperAdmin,
+} from './decorators/require-permission.decorator';
+import { CreateRoleDto, RoleQueryDto, UpdateRoleDto } from './dto/role.dto';
+import { RoleService } from './services/role.service';
+
+@Controller('roles')
+export class RoleController {
+  constructor(private readonly roleService: RoleService) {}
+
+  @Get()
+  @RequirePermission('roles.view')
+  list(@Query() query: RoleQueryDto) {
+    return this.roleService.listRoles(query);
+  }
+
+  @Get(':guid')
+  @RequirePermission('roles.view')
+  get(@Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string) {
+    return this.roleService.getRole(guid);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @RequireSuperAdmin()
+  create(@Body() dto: CreateRoleDto, @CurrentUser('id') actorGuid: string) {
+    return this.roleService.createRole(dto, actorGuid);
+  }
+
+  @Get(':guid/protection-impact')
+  @RequireSuperAdmin()
+  impact(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    return this.roleService.getProtectionImpact(guid, actorGuid);
+  }
+
+  @Patch(':guid')
+  @HttpCode(HttpStatus.OK)
+  @RequireSuperAdmin()
+  update(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @Body() dto: UpdateRoleDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    return this.roleService.updateRole(guid, dto, actorGuid);
+  }
+
+  @Delete(':guid')
+  @HttpCode(HttpStatus.OK)
+  @RequireSuperAdmin()
+  async remove(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.roleService.deleteRole(guid, actorGuid);
+    return { message: '角色已删除' };
+  }
+}

--- a/src/modules/rbac/services/rbac-audit.service.ts
+++ b/src/modules/rbac/services/rbac-audit.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { User } from '../../user/entities/user.entity';
+import { ConsoleAudit } from '../entities/console-audit.entity';
+
+export interface RbacAuditEvent {
+  actorUserGuid?: string | null;
+  targetType: string;
+  targetGuid?: string | null;
+  action: string;
+  result: 'allowed' | 'denied';
+  reason?: string | null;
+  beforeState?: unknown;
+  afterState?: unknown;
+  requestId?: string | null;
+}
+
+interface ConsoleAuditQueryRaw {
+  audit_guid?: string;
+  guid?: string;
+  actor_user_name?: string | null;
+}
+
+@Injectable()
+export class RbacAuditService {
+  private readonly logger = new Logger(RbacAuditService.name);
+
+  constructor(
+    @InjectRepository(ConsoleAudit)
+    private readonly repository: Repository<ConsoleAudit>,
+  ) {}
+
+  async record(
+    event: RbacAuditEvent,
+    manager?: EntityManager,
+  ): Promise<ConsoleAudit> {
+    const repository = manager?.getRepository(ConsoleAudit) || this.repository;
+    const audit = repository.create({
+      guid: uuidv4(),
+      actorUserGuid: event.actorUserGuid ?? null,
+      targetType: event.targetType,
+      targetGuid: event.targetGuid ?? null,
+      action: event.action,
+      result: event.result,
+      reason: event.reason ?? null,
+      beforeState: this.serializeState(event.beforeState),
+      afterState: this.serializeState(event.afterState),
+      requestId: event.requestId ?? null,
+    });
+    return repository.save(audit);
+  }
+
+  async recordDenied(event: Omit<RbacAuditEvent, 'result'>): Promise<void> {
+    try {
+      await this.record({ ...event, result: 'denied' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Unable to persist denied RBAC audit: ${message}`);
+    }
+  }
+
+  async query(filters: {
+    operator?: string;
+    pageSize?: number;
+    current?: number;
+    created_at?: string;
+  }): Promise<{ data: Record<string, unknown>[]; total: number }> {
+    const pageSize = filters.pageSize || 20;
+    const current = filters.current || 1;
+    const query = this.repository
+      .createQueryBuilder('audit')
+      .leftJoin(User, 'actor', 'actor.guid = audit.actorUserGuid')
+      .addSelect('actor.username', 'actor_user_name');
+    if (filters.operator) {
+      query.andWhere('actor.username LIKE :operator', {
+        operator: `%${filters.operator}%`,
+      });
+    }
+    if (filters.created_at) {
+      query.andWhere('audit.createdAt >= :createdAt', {
+        createdAt: new Date(filters.created_at),
+      });
+    }
+    const total = await query.getCount();
+    const { entities: rows, raw } = await query
+      .orderBy('audit.createdAt', 'DESC')
+      .skip((current - 1) * pageSize)
+      .take(pageSize)
+      .getRawAndEntities();
+    const rawRows = raw as ConsoleAuditQueryRaw[];
+    const actorNames = new Map(
+      rawRows.map((item) => [
+        item.audit_guid ?? item.guid,
+        item.actor_user_name ?? null,
+      ]),
+    );
+    return {
+      data: rows.map((row) => ({
+        guid: row.guid,
+        actor_user_guid: row.actorUserGuid,
+        actor_user_name: actorNames.get(row.guid) ?? null,
+        target_type: row.targetType,
+        target_guid: row.targetGuid,
+        action: row.action,
+        result: row.result,
+        reason: row.reason,
+        before_state: this.parseState(row.beforeState),
+        after_state: this.parseState(row.afterState),
+        request_id: row.requestId,
+        created_at: row.createdAt,
+      })),
+      total,
+    };
+  }
+
+  private serializeState(value: unknown): string | null {
+    if (value === undefined || value === null) return null;
+    return JSON.stringify(this.redact(value));
+  }
+
+  private parseState(value: string | null): unknown {
+    if (!value) return null;
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      return null;
+    }
+  }
+
+  private redact(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map((item) => this.redact(item));
+    if (!value || typeof value !== 'object') return value;
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (
+        /(password|token|secret|verifier|credential|authorization)/i.test(key)
+      ) {
+        result[key] = '[REDACTED]';
+      } else {
+        result[key] = this.redact(item);
+      }
+    }
+    return result;
+  }
+}

--- a/src/modules/rbac/services/rbac-audit.service.ts
+++ b/src/modules/rbac/services/rbac-audit.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
@@ -67,8 +67,8 @@ export class RbacAuditService {
     current?: number;
     created_at?: string;
   }): Promise<{ data: Record<string, unknown>[]; total: number }> {
-    const pageSize = filters.pageSize || 20;
-    const current = filters.current || 1;
+    const pageSize = this.boundPageSize(filters.pageSize);
+    const current = this.boundCurrent(filters.current);
     const query = this.repository
       .createQueryBuilder('audit')
       .leftJoin(User, 'actor', 'actor.guid = audit.actorUserGuid')
@@ -79,9 +79,11 @@ export class RbacAuditService {
       });
     }
     if (filters.created_at) {
-      query.andWhere('audit.createdAt >= :createdAt', {
-        createdAt: new Date(filters.created_at),
-      });
+      const createdAt = new Date(filters.created_at);
+      if (Number.isNaN(createdAt.getTime())) {
+        throw new BadRequestException('created_at 不是有效的日期字符串');
+      }
+      query.andWhere('audit.createdAt >= :createdAt', { createdAt });
     }
     const total = await query.getCount();
     const { entities: rows, raw } = await query
@@ -132,6 +134,7 @@ export class RbacAuditService {
   private redact(value: unknown): unknown {
     if (Array.isArray(value)) return value.map((item) => this.redact(item));
     if (!value || typeof value !== 'object') return value;
+    if (value instanceof Date) return value.toJSON();
     const result: Record<string, unknown> = {};
     for (const [key, item] of Object.entries(value)) {
       if (
@@ -143,5 +146,20 @@ export class RbacAuditService {
       }
     }
     return result;
+  }
+
+  private boundPageSize(value: number | undefined): number {
+    const DEFAULT_PAGE_SIZE = 20;
+    const MAX_PAGE_SIZE = 100;
+    if (value === undefined || value === null) return DEFAULT_PAGE_SIZE;
+    if (!Number.isFinite(value) || value <= 0) return DEFAULT_PAGE_SIZE;
+    return Math.min(Math.floor(value), MAX_PAGE_SIZE);
+  }
+
+  private boundCurrent(value: number | undefined): number {
+    const DEFAULT_CURRENT = 1;
+    if (value === undefined || value === null) return DEFAULT_CURRENT;
+    if (!Number.isFinite(value) || value <= 0) return DEFAULT_CURRENT;
+    return Math.floor(value);
   }
 }

--- a/src/modules/rbac/services/rbac-authorization.service.ts
+++ b/src/modules/rbac/services/rbac-authorization.service.ts
@@ -1,0 +1,614 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
+import { Peer } from '../../../common/entities/peer.entity';
+import { User, UserStatus } from '../../user/entities/user.entity';
+import { DeviceGroup } from '../../device-group/entities/device-group.entity';
+import { RolePermission } from '../entities/role-permission.entity';
+import { Role } from '../entities/role.entity';
+import { UserRoleAssignment } from '../entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from '../entities/user-role-assignment-device-group.entity';
+import {
+  filterEffectivePermissionCodes,
+  isDeviceGroupScopedPermission,
+  isAssignablePermissionCode,
+  PERMISSION_CATALOG,
+  PermissionCode,
+} from '../constants/permission-catalog';
+import { RbacAuditService } from './rbac-audit.service';
+
+export interface EffectivePermissionScope {
+  scope_type: 'global' | 'device_group';
+  device_group_guids: string[];
+}
+
+export interface PermissionScope {
+  global: boolean;
+  deviceGroupGuids: Set<string>;
+}
+
+@Injectable()
+export class RbacAuthorizationService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(RolePermission)
+    private readonly rolePermissionRepository: Repository<RolePermission>,
+    @InjectRepository(UserRoleAssignment)
+    private readonly assignmentRepository: Repository<UserRoleAssignment>,
+    @InjectRepository(UserRoleAssignmentDeviceGroup)
+    private readonly assignmentGroupRepository: Repository<UserRoleAssignmentDeviceGroup>,
+    @InjectRepository(Peer)
+    private readonly peerRepository: Repository<Peer>,
+    @InjectRepository(DeviceGroup)
+    private readonly deviceGroupRepository: Repository<DeviceGroup>,
+    private readonly auditService: RbacAuditService,
+    @InjectRepository(Role)
+    private readonly roleRepository: Repository<Role>,
+  ) {}
+
+  async getCurrentUser(
+    userGuid: string,
+    manager?: EntityManager,
+  ): Promise<User> {
+    const user = await (
+      manager?.getRepository(User) ?? this.userRepository
+    ).findOne({
+      where: { guid: userGuid },
+    });
+    if (!user || user.status !== UserStatus.ACTIVE) {
+      throw new UnauthorizedException('账户不存在或已被禁用');
+    }
+    return user;
+  }
+
+  async requireSuperAdmin(
+    userGuid: string,
+    manager?: EntityManager,
+  ): Promise<User> {
+    const user = await this.getCurrentUser(userGuid, manager);
+    if (!user.isAdmin) {
+      throw new ForbiddenException('需要超级管理员权限');
+    }
+    return user;
+  }
+
+  async getPermissionScope(
+    userGuid: string,
+    permissionCode: string,
+    manager?: EntityManager,
+  ): Promise<PermissionScope> {
+    const user = await this.getCurrentUser(userGuid, manager);
+    if (user.isAdmin || !isAssignablePermissionCode(permissionCode)) {
+      return {
+        global: user.isAdmin === true,
+        deviceGroupGuids: new Set<string>(),
+      };
+    }
+
+    const { assignments, effectivePermissionsByRole } =
+      await this.loadEffectiveRoleGrants(userGuid, manager);
+    const matchingAssignments = assignments.filter(
+      (assignment) =>
+        effectivePermissionsByRole
+          .get(assignment.roleGuid)
+          ?.has(permissionCode) &&
+        (assignment.scopeType === 'global' ||
+          isDeviceGroupScopedPermission(permissionCode)),
+    );
+
+    const global = matchingAssignments.some(
+      (assignment) => assignment.scopeType === 'global',
+    );
+    if (global) {
+      return { global: true, deviceGroupGuids: new Set<string>() };
+    }
+
+    const scopedAssignments = matchingAssignments.filter(
+      (assignment) => assignment.scopeType === 'device_group',
+    );
+    if (!scopedAssignments.length) {
+      return { global: false, deviceGroupGuids: new Set<string>() };
+    }
+
+    const groups = await (
+      manager?.getRepository(UserRoleAssignmentDeviceGroup) ??
+      this.assignmentGroupRepository
+    ).find({
+      where: {
+        assignmentGuid: In(
+          scopedAssignments.map((assignment) => assignment.guid),
+        ),
+      },
+      select: ['deviceGroupGuid'],
+    });
+
+    return {
+      global: false,
+      deviceGroupGuids: new Set(groups.map((group) => group.deviceGroupGuid)),
+    };
+  }
+
+  async requirePermission(
+    userGuid: string,
+    permissionCode: string,
+    manager?: EntityManager,
+  ): Promise<PermissionScope> {
+    if (!isAssignablePermissionCode(permissionCode)) {
+      throw new ForbiddenException('未知权限');
+    }
+    const scope = await this.getPermissionScope(
+      userGuid,
+      permissionCode,
+      manager,
+    );
+    if (!scope.global && scope.deviceGroupGuids.size === 0) {
+      throw new ForbiddenException('无权限访问');
+    }
+    return scope;
+  }
+
+  async getEffectivePermissions(
+    userGuid: string,
+    manager?: EntityManager,
+  ): Promise<{
+    permissions: string[];
+    scopes: Record<string, EffectivePermissionScope>;
+  }> {
+    const user = await this.getCurrentUser(userGuid, manager);
+    if (user.isAdmin) {
+      const scopes = Object.fromEntries(
+        PERMISSION_CATALOG.map((permission) => [
+          permission.code,
+          { scope_type: 'global', device_group_guids: [] },
+        ]),
+      ) as Record<string, EffectivePermissionScope>;
+      return {
+        permissions: PERMISSION_CATALOG.map((permission) => permission.code),
+        scopes,
+      };
+    }
+
+    const { assignments, effectivePermissionsByRole } =
+      await this.loadEffectiveRoleGrants(userGuid, manager);
+    const scopeRows = new Map<
+      PermissionCode,
+      { global: boolean; ids: Set<string> }
+    >();
+    const scopedPermissionsByAssignment = new Map<string, PermissionCode[]>();
+    for (const assignment of assignments) {
+      for (const permissionCode of effectivePermissionsByRole.get(
+        assignment.roleGuid,
+      ) || []) {
+        if (
+          assignment.scopeType === 'device_group' &&
+          !isDeviceGroupScopedPermission(permissionCode)
+        ) {
+          continue;
+        }
+        const current = scopeRows.get(permissionCode) || {
+          global: false,
+          ids: new Set<string>(),
+        };
+        if (assignment.scopeType === 'global') {
+          current.global = true;
+        } else {
+          const scopedPermissions =
+            scopedPermissionsByAssignment.get(assignment.guid) || [];
+          scopedPermissions.push(permissionCode);
+          scopedPermissionsByAssignment.set(assignment.guid, scopedPermissions);
+        }
+        scopeRows.set(permissionCode, current);
+      }
+    }
+    if (scopedPermissionsByAssignment.size) {
+      const groups = await (
+        manager?.getRepository(UserRoleAssignmentDeviceGroup) ??
+        this.assignmentGroupRepository
+      ).find({
+        where: {
+          assignmentGuid: In([...scopedPermissionsByAssignment.keys()]),
+        },
+        select: ['assignmentGuid', 'deviceGroupGuid'],
+      });
+      for (const group of groups) {
+        for (const permission of scopedPermissionsByAssignment.get(
+          group.assignmentGuid,
+        ) || []) {
+          scopeRows.get(permission)?.ids.add(group.deviceGroupGuid);
+        }
+      }
+    }
+    const scopes: Record<string, EffectivePermissionScope> = {};
+    for (const [permission, scope] of scopeRows) {
+      if (!scope.global && scope.ids.size === 0) continue;
+      scopes[permission] = scope.global
+        ? { scope_type: 'global', device_group_guids: [] }
+        : {
+            scope_type: 'device_group',
+            device_group_guids: [...scope.ids].sort(),
+          };
+    }
+    return { permissions: Object.keys(scopes).sort(), scopes };
+  }
+
+  private async loadEffectiveRoleGrants(
+    userGuid: string,
+    manager?: EntityManager,
+  ): Promise<{
+    assignments: UserRoleAssignment[];
+    effectivePermissionsByRole: Map<string, Set<PermissionCode>>;
+  }> {
+    const assignments = (
+      await (
+        manager?.getRepository(UserRoleAssignment) ?? this.assignmentRepository
+      ).find({
+        where: { userGuid },
+        select: ['guid', 'roleGuid', 'scopeType'],
+      })
+    ).filter(
+      (assignment) =>
+        assignment.scopeType === 'global' ||
+        assignment.scopeType === 'device_group',
+    );
+    const rows = assignments.length
+      ? await (
+          manager?.getRepository(RolePermission) ??
+          this.rolePermissionRepository
+        ).find({
+          where: {
+            roleGuid: In(assignments.map((assignment) => assignment.roleGuid)),
+          },
+        })
+      : [];
+    const permissionCodesByRole = new Map<string, string[]>();
+    for (const row of rows) {
+      const codes = permissionCodesByRole.get(row.roleGuid) || [];
+      codes.push(row.permissionCode);
+      permissionCodesByRole.set(row.roleGuid, codes);
+    }
+    return {
+      assignments,
+      effectivePermissionsByRole: new Map(
+        [...permissionCodesByRole].map(([roleGuid, codes]) => [
+          roleGuid,
+          new Set(filterEffectivePermissionCodes(codes)),
+        ]),
+      ),
+    };
+  }
+
+  async assertDeviceAccess(
+    userGuid: string,
+    permissionCode: PermissionCode,
+    deviceUuid: string,
+  ): Promise<{ peer: Peer; scope: PermissionScope }> {
+    const scope = await this.requirePermission(userGuid, permissionCode);
+    const peer = await this.peerRepository.findOne({
+      where: { uuid: deviceUuid },
+    });
+    if (!peer) throw new NotFoundException('设备不存在');
+    if (
+      !scope.global &&
+      (!peer.deviceGroupGuid ||
+        !scope.deviceGroupGuids.has(peer.deviceGroupGuid))
+    ) {
+      return this.rejectWithAudit(
+        userGuid,
+        'device',
+        deviceUuid,
+        permissionCode,
+        new ForbiddenException('设备不在授权设备组内'),
+      );
+    }
+    return { peer, scope };
+  }
+
+  async assertDevicesAccess(
+    userGuid: string,
+    permissionCode: PermissionCode,
+    deviceUuids: string[],
+  ): Promise<{ peers: Peer[]; scope: PermissionScope }> {
+    const scope = await this.requirePermission(userGuid, permissionCode);
+    const unique = [...new Set(deviceUuids)];
+    if (!unique.length) return { peers: [], scope };
+    const peers = await this.peerRepository.find({
+      where: { uuid: In(unique) },
+    });
+    if (!scope.global) {
+      const denied = peers.find(
+        (peer) =>
+          !peer.deviceGroupGuid ||
+          !scope.deviceGroupGuids.has(peer.deviceGroupGuid),
+      );
+      if (denied) {
+        return this.rejectWithAudit(
+          userGuid,
+          'device',
+          denied.uuid,
+          permissionCode,
+          new ForbiddenException('批量请求包含未授权设备'),
+        );
+      }
+    }
+    return { peers, scope };
+  }
+
+  async assertStrategyTargets(
+    userGuid: string,
+    targetType: 'device' | 'user' | 'device_group',
+    targetGuids: string[],
+    manager?: EntityManager,
+  ): Promise<PermissionScope> {
+    const scope = await this.requirePermission(
+      userGuid,
+      'strategies.assign',
+      manager,
+    );
+    if (targetType === 'user') {
+      if (!scope.global) {
+        return this.rejectWithAudit(
+          userGuid,
+          'user',
+          targetGuids[0] || null,
+          'strategies.assign',
+          new ForbiddenException('按用户分配策略需要全局权限'),
+        );
+      }
+      const users = await (
+        manager?.getRepository(User) ?? this.userRepository
+      ).find({
+        where: { guid: In([...new Set(targetGuids)]) },
+        select: ['guid', 'isAdmin'],
+      });
+      if (users.length !== new Set(targetGuids).size) {
+        throw new NotFoundException('用户不存在');
+      }
+      const protectedUsers = await this.getProtectedUserGuids(
+        users.map((user) => user.guid),
+        users.filter((user) => user.isAdmin).map((user) => user.guid),
+        manager,
+      );
+      const protectedUser = users.find((user) => protectedUsers.has(user.guid));
+      if (protectedUser) {
+        try {
+          await this.requireSuperAdmin(userGuid, manager);
+        } catch (error: unknown) {
+          return this.rejectWithAudit(
+            userGuid,
+            'user',
+            protectedUser.guid,
+            'super_admin',
+            error,
+          );
+        }
+      }
+      return scope;
+    }
+    if (targetType === 'device_group') {
+      const requested = [...new Set(targetGuids)];
+      const groups = await (
+        manager?.getRepository(DeviceGroup) ?? this.deviceGroupRepository
+      ).find({
+        where: { guid: In(requested) },
+        select: ['guid'],
+      });
+      if (scope.global) return scope;
+      const selected = new Set(scope.deviceGroupGuids);
+      const deniedGuid = groups.find(
+        (group) => !selected.has(group.guid),
+      )?.guid;
+      if (deniedGuid) {
+        return this.rejectWithAudit(
+          userGuid,
+          'device_group',
+          deniedGuid,
+          'strategies.assign',
+          new ForbiddenException('目标设备组不在授权范围内'),
+        );
+      }
+      return scope;
+    }
+    const peers = await (
+      manager?.getRepository(Peer) ?? this.peerRepository
+    ).find({
+      where: { uuid: In([...new Set(targetGuids)]) },
+      select: ['uuid', 'deviceGroupGuid'],
+    });
+    if (scope.global) return scope;
+    const denied = peers.find(
+      (peer) =>
+        !peer.deviceGroupGuid ||
+        !scope.deviceGroupGuids.has(peer.deviceGroupGuid),
+    );
+    if (denied) {
+      return this.rejectWithAudit(
+        userGuid,
+        'device',
+        denied.uuid,
+        'strategies.assign',
+        new ForbiddenException('目标设备不在授权设备组内'),
+      );
+    }
+    return scope;
+  }
+
+  async assertUserMutation(
+    actorGuid: string,
+    targetGuid: string,
+    permissionCode: PermissionCode,
+    _changes?: {
+      is_admin?: boolean;
+    },
+    manager?: EntityManager,
+  ): Promise<void> {
+    await this.requirePermission(actorGuid, permissionCode, manager);
+
+    const target = await (
+      manager?.getRepository(User) ?? this.userRepository
+    ).findOne({
+      where: { guid: targetGuid },
+      select: ['guid', 'isAdmin'],
+    });
+    if (!target) throw new NotFoundException('用户不存在');
+    if (await this.isProtectedUser(targetGuid, target.isAdmin, manager)) {
+      try {
+        await this.requireSuperAdmin(actorGuid, manager);
+      } catch (error: unknown) {
+        return this.rejectWithAudit(
+          actorGuid,
+          'user',
+          targetGuid,
+          'super_admin',
+          error,
+        );
+      }
+    }
+  }
+
+  /**
+   * Pre-authorize a user batch before the owning service performs any write.
+   * The owning service remains responsible for its missing-target contract
+   * and for making the write atomic when it promises all-or-nothing behavior.
+   */
+  async assertUsersMutation(
+    actorGuid: string,
+    targetGuids: string[],
+    permissionCode: PermissionCode,
+    manager?: EntityManager,
+  ): Promise<void> {
+    await this.requirePermission(actorGuid, permissionCode, manager);
+    const uniqueGuids = [...new Set(targetGuids)];
+    if (!uniqueGuids.length) return;
+
+    const users = await (
+      manager?.getRepository(User) ?? this.userRepository
+    ).find({
+      where: { guid: In(uniqueGuids) },
+      select: ['guid', 'isAdmin'],
+    });
+    const protectedGuids = await this.getProtectedUserGuids(
+      users.map((user) => user.guid),
+      users.filter((user) => user.isAdmin).map((user) => user.guid),
+      manager,
+    );
+    const protectedUser = users.find((user) => protectedGuids.has(user.guid));
+    if (protectedUser) {
+      try {
+        await this.requireSuperAdmin(actorGuid, manager);
+      } catch (error: unknown) {
+        return this.rejectWithAudit(
+          actorGuid,
+          'user',
+          protectedUser.guid,
+          'super_admin',
+          error,
+        );
+      }
+    }
+  }
+
+  async isProtectedUser(
+    userGuid: string,
+    isAdmin?: boolean,
+    manager?: EntityManager,
+  ): Promise<boolean> {
+    const user = manager
+      ? await manager.getRepository(User).findOne({
+          where: { guid: userGuid },
+          select: ['guid', 'isAdmin'],
+        })
+      : undefined;
+    if (user?.isAdmin === true || (!manager && isAdmin === true)) return true;
+    const assignments = await (
+      manager?.getRepository(UserRoleAssignment) ?? this.assignmentRepository
+    ).find({
+      where: { userGuid },
+      select: ['roleGuid'],
+    });
+    if (!assignments.length) return false;
+    return (
+      await (manager?.getRepository(Role) ?? this.roleRepository).find({
+        where: { guid: In([...new Set(assignments.map((a) => a.roleGuid))]) },
+        select: ['guid', 'protectedAccount'],
+      })
+    ).some((role) => role.protectedAccount === true);
+  }
+
+  /** Bulk protection projection used by administrative list endpoints. */
+  async getEffectiveProtectionMap(
+    userGuids: string[],
+    manager?: EntityManager,
+  ): Promise<Map<string, boolean>> {
+    const unique = [...new Set(userGuids)];
+    const result = new Map(unique.map((guid) => [guid, false]));
+    if (!unique.length) return result;
+    const users = await (
+      manager?.getRepository(User) ?? this.userRepository
+    ).find({
+      where: { guid: In(unique) },
+      select: ['guid', 'isAdmin'],
+    });
+    for (const user of users) if (user.isAdmin) result.set(user.guid, true);
+    const assignments = await (
+      manager?.getRepository(UserRoleAssignment) ?? this.assignmentRepository
+    ).find({
+      where: { userGuid: In(unique) },
+      select: ['userGuid', 'roleGuid'],
+    });
+    if (!assignments.length) return result;
+    const roles = await (
+      manager?.getRepository(Role) ?? this.roleRepository
+    ).find({
+      where: {
+        guid: In([
+          ...new Set(assignments.map((assignment) => assignment.roleGuid)),
+        ]),
+        protectedAccount: true,
+      },
+      select: ['guid'],
+    });
+    const protectedRoles = new Set(roles.map((role) => role.guid));
+    for (const assignment of assignments) {
+      if (protectedRoles.has(assignment.roleGuid))
+        result.set(assignment.userGuid, true);
+    }
+    return result;
+  }
+
+  private async getProtectedUserGuids(
+    userGuids: string[],
+    knownOwners: string[],
+    manager?: EntityManager,
+  ): Promise<Set<string>> {
+    const result = await this.getEffectiveProtectionMap(userGuids, manager);
+    for (const guid of knownOwners) result.set(guid, true);
+    return new Set(
+      [...result]
+        .filter(([, protectedUser]) => protectedUser)
+        .map(([guid]) => guid),
+    );
+  }
+
+  private async rejectWithAudit(
+    actorUserGuid: string,
+    targetType: string,
+    targetGuid: string | null,
+    action: string,
+    error: unknown,
+  ): Promise<never> {
+    await this.auditService.recordDenied({
+      actorUserGuid,
+      targetType,
+      targetGuid,
+      action,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}

--- a/src/modules/rbac/services/role.service.ts
+++ b/src/modules/rbac/services/role.service.ts
@@ -1,0 +1,448 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, QueryFailedError, Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Role } from '../entities/role.entity';
+import { RolePermission } from '../entities/role-permission.entity';
+import { UserRoleAssignment } from '../entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from '../entities/user-role-assignment-device-group.entity';
+import { CreateRoleDto, RoleQueryDto, UpdateRoleDto } from '../dto/role.dto';
+import {
+  filterEffectivePermissionCodes,
+  getPermissionRequirements,
+  PermissionCode,
+  isDeviceGroupScopedPermission,
+  isAssignablePermissionCode,
+} from '../constants/permission-catalog';
+import { RbacAuditService } from './rbac-audit.service';
+import { RbacAuthorizationService } from './rbac-authorization.service';
+
+@Injectable()
+export class RoleService {
+  constructor(
+    @InjectRepository(Role)
+    private readonly roleRepository: Repository<Role>,
+    @InjectRepository(RolePermission)
+    private readonly rolePermissionRepository: Repository<RolePermission>,
+    @InjectRepository(UserRoleAssignment)
+    private readonly assignmentRepository: Repository<UserRoleAssignment>,
+    @InjectRepository(UserRoleAssignmentDeviceGroup)
+    private readonly assignmentGroupRepository: Repository<UserRoleAssignmentDeviceGroup>,
+    private readonly dataSource: DataSource,
+    private readonly auditService: RbacAuditService,
+    private readonly authorizationService: RbacAuthorizationService,
+  ) {}
+
+  async listRoles(query: RoleQueryDto) {
+    const current = query.current || 1;
+    const pageSize = query.pageSize || 20;
+    const builder = this.roleRepository.createQueryBuilder('role');
+    if (query.name) {
+      builder.andWhere('role.name LIKE :name', {
+        name: `%${query.name}%`,
+      });
+    }
+    if (query.note) {
+      builder.andWhere('role.note LIKE :note', {
+        note: `%${query.note}%`,
+      });
+    }
+    const [roles, total] = await builder
+      .orderBy('role.name', 'ASC')
+      .addOrderBy('role.guid', 'ASC')
+      .skip((current - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+    const permissions = roles.length
+      ? await this.rolePermissionRepository.find({
+          where: { roleGuid: In(roles.map((role) => role.guid)) },
+        })
+      : [];
+    const permissionMap = this.groupPermissions(permissions);
+    return {
+      data: roles.map((role) =>
+        this.toResponse(role, permissionMap.get(role.guid) || []),
+      ),
+      total,
+    };
+  }
+
+  async getRole(guid: string) {
+    const role = await this.requireRole(guid);
+    return this.toResponse(role, await this.loadPermissionCodes(guid));
+  }
+
+  async getProtectionImpact(guid: string, actorGuid: string) {
+    await this.authorizationService.requireSuperAdmin(actorGuid);
+    const role = await this.requireRole(guid);
+    return {
+      guid,
+      protected_account: role.protectedAccount === true,
+      affected_member_count: await this.assignmentRepository.count({
+        where: { roleGuid: guid },
+      }),
+    };
+  }
+
+  async createRole(dto: CreateRoleDto, actorGuid: string) {
+    await this.authorizationService.requireSuperAdmin(actorGuid);
+    const name = this.normalizeName(dto.name);
+    const permissions = this.validatePermissions(dto.permissions);
+    await this.ensureNameAvailable(name);
+    return this.dataSource.transaction(async (manager) => {
+      const role = manager.getRepository(Role).create({
+        guid: uuidv4(),
+        name,
+        note: dto.note?.trim() || null,
+        protectedAccount: dto.protected_account === true,
+      });
+      try {
+        await manager.getRepository(Role).save(role);
+      } catch (error: unknown) {
+        if (this.isUniqueError(error))
+          throw new ConflictException('角色名称已存在');
+        throw error;
+      }
+      await this.replacePermissionsWithManager(manager, role.guid, permissions);
+      await this.auditService.record(
+        {
+          actorUserGuid: actorGuid,
+          targetType: 'role',
+          targetGuid: role.guid,
+          action: 'role.create',
+          result: 'allowed',
+          afterState: {
+            name: role.name,
+            note: role.note,
+            permissions,
+            protected_account: role.protectedAccount,
+          },
+        },
+        manager,
+      );
+      return this.toResponse(role, permissions);
+    });
+  }
+
+  async updateRole(guid: string, dto: UpdateRoleDto, actorGuid: string) {
+    // Reject malformed permission edits before opening a transaction. The
+    // same checks are repeated against the transaction snapshot below.
+    if (dto.permissions !== undefined) {
+      const candidate = this.validatePermissions(dto.permissions);
+      await this.ensureScopedAssignmentsRemainValid(guid, candidate);
+    }
+    return this.dataSource.transaction(async (manager) => {
+      await this.authorizationService.requireSuperAdmin(actorGuid, manager);
+      const roleRepository = manager.getRepository(Role);
+      const permissionRepository = manager.getRepository(RolePermission);
+      const assignmentRepository = manager.getRepository(UserRoleAssignment);
+      const role = await roleRepository.findOne({
+        where: { guid },
+      });
+      if (!role) throw new NotFoundException('角色不存在');
+      const beforePermissions = (
+        await permissionRepository.find({
+          where: { roleGuid: guid },
+        })
+      )
+        .map((row) => row.permissionCode)
+        .filter(isAssignablePermissionCode)
+        .sort();
+      const beforeName = role.name;
+      const beforeNote = role.note;
+      const beforeProtected = role.protectedAccount === true;
+      const name =
+        dto.name === undefined ? role.name : this.normalizeName(dto.name);
+      if (name !== role.name) {
+        const existing = await roleRepository
+          .createQueryBuilder('role')
+          .where('LOWER(role.name) = LOWER(:name)', { name })
+          .getOne();
+        if (existing && existing.guid !== guid) {
+          throw new ConflictException('角色名称已存在');
+        }
+      }
+      const permissions =
+        dto.permissions === undefined
+          ? beforePermissions
+          : this.validatePermissions(dto.permissions);
+      if (dto.permissions !== undefined) {
+        await this.ensureScopedAssignmentsRemainValid(
+          guid,
+          permissions,
+          manager,
+        );
+      }
+      const nextProtected =
+        dto.protected_account === undefined
+          ? beforeProtected
+          : dto.protected_account;
+      if (
+        dto.protected_account !== undefined &&
+        nextProtected !== beforeProtected
+      ) {
+        const affectedCount = await assignmentRepository.count({
+          where: { roleGuid: guid },
+        });
+        if (
+          !nextProtected &&
+          affectedCount > 0 &&
+          dto.confirm_protected_account_change !== true
+        ) {
+          throw new BadRequestException(
+            `取消角色保护将影响 ${affectedCount} 个账号，请确认后重试`,
+          );
+        }
+        role.protectedAccount = nextProtected;
+      }
+      role.name = name;
+      if (dto.note !== undefined) role.note = dto.note.trim() || null;
+      await roleRepository.save(role);
+      if (dto.permissions !== undefined) {
+        await this.replacePermissionsWithManager(manager, guid, permissions);
+      }
+      await this.auditService.record(
+        {
+          actorUserGuid: actorGuid,
+          targetType: 'role',
+          targetGuid: guid,
+          action: 'role.update',
+          result: 'allowed',
+          beforeState: {
+            name: beforeName,
+            note: beforeNote,
+            permissions: beforePermissions,
+            protected_account: beforeProtected,
+          },
+          afterState: {
+            name: role.name,
+            note: role.note,
+            permissions,
+            protected_account: role.protectedAccount,
+            ...(dto.protected_account !== undefined && !role.protectedAccount
+              ? {
+                  affected_member_count: await assignmentRepository.count({
+                    where: { roleGuid: guid },
+                  }),
+                }
+              : {}),
+          },
+        },
+        manager,
+      );
+      return this.toResponse(role, permissions);
+    });
+  }
+
+  async deleteRole(guid: string, actorGuid: string): Promise<void> {
+    await this.authorizationService.requireSuperAdmin(actorGuid);
+    await this.dataSource.transaction(async (manager) => {
+      const roleRepository = manager.getRepository(Role);
+      const permissionRepository = manager.getRepository(RolePermission);
+      const assignmentRepository = manager.getRepository(UserRoleAssignment);
+      const assignmentGroupRepository = manager.getRepository(
+        UserRoleAssignmentDeviceGroup,
+      );
+      const role = await roleRepository.findOne({ where: { guid } });
+      if (!role) throw new NotFoundException('角色不存在');
+
+      // Take the complete pre-delete snapshot in the same transaction as the
+      // destructive writes so the audit record explains exactly which grants
+      // and scopes were revoked.
+      const [permissionRows, assignments] = await Promise.all([
+        permissionRepository.find({
+          where: { roleGuid: guid },
+          select: ['permissionCode'],
+        }),
+        assignmentRepository.find({
+          where: { roleGuid: guid },
+          select: ['guid', 'userGuid', 'scopeType'],
+        }),
+      ]);
+      const assignmentGuids = assignments.map((assignment) => assignment.guid);
+      const assignmentGroups = assignmentGuids.length
+        ? await assignmentGroupRepository.find({
+            where: { assignmentGuid: In(assignmentGuids) },
+            select: ['assignmentGuid', 'deviceGroupGuid'],
+          })
+        : [];
+      const groupsByAssignment = new Map<string, string[]>();
+      for (const group of assignmentGroups) {
+        const groups = groupsByAssignment.get(group.assignmentGuid) || [];
+        groups.push(group.deviceGroupGuid);
+        groupsByAssignment.set(group.assignmentGuid, groups);
+      }
+      const beforeState = {
+        name: role.name,
+        note: role.note,
+        permissions: permissionRows
+          .map((permission) => permission.permissionCode)
+          .filter(isAssignablePermissionCode)
+          .sort(),
+        protected_account: role.protectedAccount === true,
+        assignments: assignments
+          .map((assignment) => ({
+            guid: assignment.guid,
+            user_guid: assignment.userGuid,
+            scope_type: assignment.scopeType,
+            device_group_guids: [
+              ...(groupsByAssignment.get(assignment.guid) || []),
+            ].sort(),
+          }))
+          .sort((left, right) => left.guid.localeCompare(right.guid)),
+      };
+
+      if (assignments.length) {
+        await assignmentGroupRepository.delete({
+          assignmentGuid: In(assignments.map((assignment) => assignment.guid)),
+        });
+        await assignmentRepository.delete({ roleGuid: guid });
+      }
+      await permissionRepository.delete({ roleGuid: guid });
+      await roleRepository.delete({ guid });
+      await this.auditService.record(
+        {
+          actorUserGuid: actorGuid,
+          targetType: 'role',
+          targetGuid: guid,
+          action: 'role.delete',
+          result: 'allowed',
+          beforeState,
+        },
+        manager,
+      );
+    });
+  }
+
+  private async loadPermissionCodes(guid: string): Promise<PermissionCode[]> {
+    const rows = await this.rolePermissionRepository.find({
+      where: { roleGuid: guid },
+    });
+    return rows
+      .map((row) => row.permissionCode)
+      .filter(isAssignablePermissionCode)
+      .sort();
+  }
+
+  private async requireRole(guid: string): Promise<Role> {
+    const role = await this.roleRepository.findOne({ where: { guid } });
+    if (!role) throw new NotFoundException('角色不存在');
+    return role;
+  }
+
+  private normalizeName(value: string): string {
+    const name = value.trim();
+    if (!name) throw new BadRequestException('角色名称不能为空');
+    return name;
+  }
+
+  private async ensureNameAvailable(name: string, ignoredGuid?: string) {
+    const existing = await this.roleRepository
+      .createQueryBuilder('role')
+      .where('LOWER(role.name) = LOWER(:name)', { name })
+      .getOne();
+    if (existing && existing.guid !== ignoredGuid) {
+      throw new ConflictException('角色名称已存在');
+    }
+  }
+
+  private validatePermissions(permissions: string[]): PermissionCode[] {
+    const unique = [...new Set(permissions)];
+    const systemOnly = unique.filter(
+      (permission) => !isAssignablePermissionCode(permission),
+    );
+    if (systemOnly.length) {
+      throw new BadRequestException(`权限码不可分配: ${systemOnly.join(', ')}`);
+    }
+    const validated = unique.filter(isAssignablePermissionCode).sort();
+    const granted = new Set(validated);
+    const missing = validated.flatMap((permission) =>
+      getPermissionRequirements(permission)
+        .filter((required) => !granted.has(required))
+        .map((required) => `${permission} requires ${required}`),
+    );
+    if (missing.length) {
+      throw new BadRequestException(`权限依赖缺失: ${missing.join(', ')}`);
+    }
+    return validated;
+  }
+
+  private async ensureScopedAssignmentsRemainValid(
+    roleGuid: string,
+    permissions: PermissionCode[],
+    manager?: import('typeorm').EntityManager,
+  ): Promise<void> {
+    if (
+      permissions.length > 0 &&
+      permissions.every((permission) =>
+        isDeviceGroupScopedPermission(permission),
+      )
+    ) {
+      return;
+    }
+    const hasScopedAssignment = await (
+      manager?.getRepository(UserRoleAssignment) ?? this.assignmentRepository
+    ).exist({
+      where: { roleGuid, scopeType: 'device_group' },
+    });
+    if (hasScopedAssignment) {
+      throw new BadRequestException(
+        '已有高级范围授权的角色只能包含设备操作和 strategies.assign',
+      );
+    }
+  }
+
+  private async replacePermissionsWithManager(
+    manager: import('typeorm').EntityManager,
+    roleGuid: string,
+    permissions: string[],
+  ) {
+    await manager.delete(RolePermission, { roleGuid });
+    if (permissions.length) {
+      await manager.insert(
+        RolePermission,
+        permissions.map((permissionCode) => ({ roleGuid, permissionCode })),
+      );
+    }
+  }
+
+  private groupPermissions(rows: RolePermission[]) {
+    const result = new Map<string, string[]>();
+    for (const row of rows) {
+      const list = result.get(row.roleGuid) || [];
+      if (isAssignablePermissionCode(row.permissionCode))
+        list.push(row.permissionCode);
+      result.set(row.roleGuid, list);
+    }
+    return new Map(
+      [...result].map(([roleGuid, permissions]) => [
+        roleGuid,
+        filterEffectivePermissionCodes(permissions),
+      ]),
+    );
+  }
+
+  private toResponse(role: Role, permissions: string[]) {
+    return {
+      guid: role.guid,
+      name: role.name,
+      note: role.note || '',
+      permissions,
+      created_at: role.createdAt,
+      updated_at: role.updatedAt,
+      protected_account: role.protectedAccount === true,
+    };
+  }
+
+  private isUniqueError(error: unknown): boolean {
+    return (
+      error instanceof QueryFailedError &&
+      error.message.toUpperCase().includes('UNIQUE')
+    );
+  }
+}

--- a/src/modules/rbac/services/role.service.ts
+++ b/src/modules/rbac/services/role.service.ts
@@ -90,11 +90,11 @@ export class RoleService {
   }
 
   async createRole(dto: CreateRoleDto, actorGuid: string) {
-    await this.authorizationService.requireSuperAdmin(actorGuid);
     const name = this.normalizeName(dto.name);
     const permissions = this.validatePermissions(dto.permissions);
     await this.ensureNameAvailable(name);
     return this.dataSource.transaction(async (manager) => {
+      await this.authorizationService.requireSuperAdmin(actorGuid, manager);
       const role = manager.getRepository(Role).create({
         guid: uuidv4(),
         name,
@@ -240,8 +240,8 @@ export class RoleService {
   }
 
   async deleteRole(guid: string, actorGuid: string): Promise<void> {
-    await this.authorizationService.requireSuperAdmin(actorGuid);
     await this.dataSource.transaction(async (manager) => {
+      await this.authorizationService.requireSuperAdmin(actorGuid, manager);
       const roleRepository = manager.getRepository(Role);
       const permissionRepository = manager.getRepository(RolePermission);
       const assignmentRepository = manager.getRepository(UserRoleAssignment);

--- a/src/modules/rbac/services/user-role.service.ts
+++ b/src/modules/rbac/services/user-role.service.ts
@@ -1,0 +1,729 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { User } from '../../user/entities/user.entity';
+import { DeviceGroup } from '../../device-group/entities/device-group.entity';
+import { Role } from '../entities/role.entity';
+import { RolePermission } from '../entities/role-permission.entity';
+import { UserRoleAssignment } from '../entities/user-role-assignment.entity';
+import { UserRoleAssignmentDeviceGroup } from '../entities/user-role-assignment-device-group.entity';
+import {
+  ReplaceUserRolesDto,
+  UserRoleAssignmentDto,
+} from '../dto/user-role.dto';
+import {
+  filterEffectivePermissionCodes,
+  isAssignablePermissionCode,
+  isDeviceGroupScopedPermission,
+  PERMISSION_CATALOG,
+  PermissionCode,
+} from '../constants/permission-catalog';
+import { RbacAuditService } from './rbac-audit.service';
+import { RbacAuthorizationService } from './rbac-authorization.service';
+
+@Injectable()
+export class UserRoleService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Role)
+    private readonly roleRepository: Repository<Role>,
+    @InjectRepository(RolePermission)
+    private readonly rolePermissionRepository: Repository<RolePermission>,
+    @InjectRepository(UserRoleAssignment)
+    private readonly assignmentRepository: Repository<UserRoleAssignment>,
+    @InjectRepository(UserRoleAssignmentDeviceGroup)
+    private readonly assignmentGroupRepository: Repository<UserRoleAssignmentDeviceGroup>,
+    @InjectRepository(DeviceGroup)
+    private readonly deviceGroupRepository: Repository<DeviceGroup>,
+    private readonly dataSource: DataSource,
+    private readonly auditService: RbacAuditService,
+    private readonly authorizationService: RbacAuthorizationService,
+  ) {}
+
+  async getUserRoles(
+    userGuid: string,
+    manager?: import('typeorm').EntityManager,
+  ) {
+    await this.ensureUserExists(manager, userGuid);
+    const assignments = await this.loadAssignments(userGuid, manager);
+    return {
+      data: assignments.map((assignment) => this.toResponse(assignment)),
+      effective_scope: this.effectiveScopes(assignments),
+    };
+  }
+
+  /** Return every role with target-specific, stable delegation decisions. */
+  async getRoleEligibility(userGuid: string, actorGuid: string) {
+    const target = await this.userRepository.findOne({
+      where: { guid: userGuid },
+      select: ['guid', 'isAdmin'],
+    });
+    if (!target) throw new NotFoundException('用户不存在');
+    const actor = await this.authorizationService.getCurrentUser(actorGuid);
+    const roles = await this.roleRepository.find({ order: { name: 'ASC' } });
+    const assignments = await this.loadAssignments(userGuid);
+    const assigned = new Set(
+      assignments.map((assignment) => assignment.roleGuid),
+    );
+    const owner = actor.isAdmin === true;
+    const actorScopes = new Map<
+      PermissionCode,
+      { global: boolean; groups: Set<string> }
+    >();
+    if (!owner) {
+      const grants =
+        await this.authorizationService.getEffectivePermissions(actorGuid);
+      for (const permission of PERMISSION_CATALOG) {
+        if (!isAssignablePermissionCode(permission.code)) continue;
+        const scope = grants.scopes[permission.code];
+        if (scope)
+          actorScopes.set(permission.code, {
+            global: scope.scope_type === 'global',
+            groups: new Set(scope.device_group_guids),
+          });
+      }
+    }
+    const roleRows = await this.rolePermissionRepository.find({
+      where: roles.length
+        ? { roleGuid: In(roles.map((role) => role.guid)) }
+        : [],
+    });
+    const permissionMap = this.groupPermissions(roleRows);
+    const allGroups = await this.deviceGroupRepository.find({
+      select: ['guid', 'name'],
+      order: { name: 'ASC' },
+    });
+    const selfTarget = userGuid === actorGuid;
+    const protectedTarget = await this.authorizationService.isProtectedUser(
+      userGuid,
+      target.isAdmin,
+    );
+    return {
+      data: roles.map((role) => {
+        const permissions = permissionMap.get(role.guid) || [];
+        const locked =
+          role.protectedAccount === true ||
+          permissions.includes('roles.assign');
+        let reason_code: string | null = null;
+        if (target.isAdmin) reason_code = 'super_admin_target';
+        else if (!owner && selfTarget) reason_code = 'self_target';
+        else if (!owner && protectedTarget) reason_code = 'protected_target';
+        else if (!owner && locked)
+          reason_code = role.protectedAccount
+            ? 'protected_role'
+            : 'role_grants_roles_assign';
+        else if (!owner) {
+          for (const permission of permissions) {
+            const callerScope = actorScopes.get(permission);
+            if (!callerScope) {
+              reason_code = 'missing_permission';
+              break;
+            }
+            if (callerScope.global) continue;
+            const definition = PERMISSION_CATALOG.find(
+              (item) => item.code === permission,
+            );
+            if (definition?.scope !== 'device_group') {
+              reason_code = 'scope_exceeds_caller';
+              break;
+            }
+          }
+        }
+        const globalAllowed =
+          owner ||
+          (permissions.length > 0 &&
+            permissions.every(
+              (permission) => actorScopes.get(permission)?.global === true,
+            ));
+        const allowedGroupGuids = new Set(allGroups.map((group) => group.guid));
+        const allPermissionsDeviceScoped =
+          permissions.length > 0 &&
+          permissions.every(
+            (permission) =>
+              PERMISSION_CATALOG.find((item) => item.code === permission)
+                ?.scope === 'device_group',
+          );
+        if (allPermissionsDeviceScoped && !owner) {
+          for (const permission of permissions) {
+            const callerScope = actorScopes.get(permission);
+            if (!callerScope) continue;
+            if (!callerScope.global) {
+              for (const guid of [...allowedGroupGuids]) {
+                if (!callerScope.groups.has(guid))
+                  allowedGroupGuids.delete(guid);
+              }
+            }
+          }
+        } else if (!allPermissionsDeviceScoped) {
+          allowedGroupGuids.clear();
+        }
+        const scopeExceeds =
+          !globalAllowed &&
+          !(allPermissionsDeviceScoped && allowedGroupGuids.size > 0);
+        if (!reason_code && scopeExceeds) reason_code = 'scope_exceeds_caller';
+        const canAssign = reason_code === null;
+        const canRemove = assigned.has(role.guid) && canAssign;
+        const allowedScopeTypes: Array<'global' | 'device_group'> = [];
+        if (canAssign) {
+          if (globalAllowed) allowedScopeTypes.push('global');
+          if (allPermissionsDeviceScoped && allowedGroupGuids.size > 0) {
+            allowedScopeTypes.push('device_group');
+          }
+        }
+        return {
+          guid: role.guid,
+          name: role.name,
+          protected_account: role.protectedAccount === true,
+          assigned: assigned.has(role.guid),
+          can_assign: canAssign,
+          can_remove: canRemove,
+          reason_code,
+          allowed_scope_types: allowedScopeTypes,
+          assignable_device_groups:
+            canAssign && allPermissionsDeviceScoped
+              ? allGroups
+                  .filter((group) => allowedGroupGuids.has(group.guid))
+                  .map((group) => ({ guid: group.guid, name: group.name }))
+              : [],
+        };
+      }),
+    };
+  }
+
+  async replaceUserRoles(
+    userGuid: string,
+    dto: ReplaceUserRolesDto,
+    actorGuid: string,
+  ) {
+    const normalized = this.validateAssignments(dto.assignments);
+    const requestedRoleGuids = new Set(
+      normalized.map((assignment) => assignment.role_guid),
+    );
+    const roleGuids = normalized.map((assignment) => assignment.role_guid);
+    const roles = roleGuids.length
+      ? await this.roleRepository.find({ where: { guid: In(roleGuids) } })
+      : [];
+    if (roles.length !== roleGuids.length) {
+      const found = new Set(roles.map((role) => role.guid));
+      throw new NotFoundException(
+        `角色不存在: ${roleGuids.filter((guid) => !found.has(guid)).join(', ')}`,
+      );
+    }
+    const rolePermissions = roles.length
+      ? await this.rolePermissionRepository.find({
+          where: { roleGuid: In(roleGuids) },
+        })
+      : [];
+    const permissionsByRole = this.groupPermissions(rolePermissions);
+    for (const assignment of normalized) {
+      const permissions = permissionsByRole.get(assignment.role_guid) || [];
+      if (
+        assignment.scope_type === 'device_group' &&
+        (permissions.length === 0 ||
+          permissions.some(
+            (permission) => !isDeviceGroupScopedPermission(permission),
+          ))
+      ) {
+        throw new BadRequestException(
+          'device_group scope only supports device actions and strategies.assign',
+        );
+      }
+    }
+    const actor = await this.authorizationService.getCurrentUser(actorGuid);
+    const owner = actor.isAdmin === true;
+    if (!owner)
+      await this.authorizationService.requirePermission(
+        actorGuid,
+        'roles.assign',
+      );
+    await this.ensureUserExists(undefined, userGuid);
+    const target = await this.userRepository.findOne({
+      where: { guid: userGuid },
+      select: ['guid', 'isAdmin'],
+    });
+    if (!target && !owner) throw new NotFoundException('用户不存在');
+    if (target?.isAdmin) {
+      throw new ForbiddenException('超级管理员不能分配普通角色');
+    }
+    if (
+      !owner &&
+      (userGuid === actorGuid ||
+        (await this.authorizationService.isProtectedUser(
+          userGuid,
+          target?.isAdmin,
+        )))
+    ) {
+      throw new ForbiddenException(
+        userGuid === actorGuid
+          ? '不能修改自己的角色'
+          : '受保护账号只能由超级管理员修改',
+      );
+    }
+    if (!owner) {
+      const current = await this.loadAssignments(userGuid);
+      const eligibility = await this.getRoleEligibility(userGuid, actorGuid);
+      const lockedCurrent = eligibility.data.filter(
+        (row) => row.assigned && !row.can_remove,
+      );
+      const omitted = lockedCurrent.find(
+        (row) => !requestedRoleGuids.has(row.guid),
+      );
+      if (omitted)
+        throw new ForbiddenException(`不可移除受保护角色: ${omitted.guid}`);
+      const denied = normalized.find((assignment) => {
+        const row = eligibility.data.find(
+          (candidate) => candidate.guid === assignment.role_guid,
+        );
+        return (
+          !row?.can_assign &&
+          !current.some(
+            (existing) => existing.roleGuid === assignment.role_guid,
+          )
+        );
+      });
+      if (denied)
+        throw new ForbiddenException(`角色不可分配: ${denied.role_guid}`);
+      const caller =
+        await this.authorizationService.getEffectivePermissions(actorGuid);
+      const proposed = new Map<
+        PermissionCode,
+        { global: boolean; groups: Set<string> }
+      >();
+      for (const assignment of normalized) {
+        const perms = permissionsByRole.get(assignment.role_guid) || [];
+        for (const permission of perms) {
+          const entry = proposed.get(permission) || {
+            global: false,
+            groups: new Set<string>(),
+          };
+          if (assignment.scope_type === 'global') entry.global = true;
+          else
+            for (const group of assignment.device_group_guids || [])
+              entry.groups.add(group);
+          proposed.set(permission, entry);
+        }
+      }
+      for (const [permission, grant] of proposed) {
+        const allowed = caller.scopes[permission];
+        if (
+          !allowed ||
+          (grant.global && allowed.scope_type !== 'global') ||
+          (!grant.global &&
+            allowed.scope_type === 'device_group' &&
+            ![...grant.groups].every((group) =>
+              allowed.device_group_guids.includes(group),
+            ))
+        ) {
+          throw new ForbiddenException(`角色权限超出操作者范围: ${permission}`);
+        }
+      }
+    }
+    const groupGuids = [
+      ...new Set(
+        normalized.flatMap((assignment) => assignment.device_group_guids || []),
+      ),
+    ];
+    if (groupGuids.length) {
+      const groups = await this.deviceGroupRepository.find({
+        where: { guid: In(groupGuids) },
+        select: ['guid'],
+      });
+      if (groups.length !== groupGuids.length) {
+        const found = new Set(groups.map((group) => group.guid));
+        throw new BadRequestException(
+          `设备组不存在: ${groupGuids.filter((guid) => !found.has(guid)).join(', ')}`,
+        );
+      }
+    }
+    await this.dataSource.transaction(async (manager) => {
+      const currentActor = await this.authorizationService.getCurrentUser(
+        actorGuid,
+        manager,
+      );
+      const currentOwner = currentActor.isAdmin === true;
+      if (!currentOwner) {
+        await this.authorizationService.requirePermission(
+          actorGuid,
+          'roles.assign',
+          manager,
+        );
+      }
+      const currentTarget = await manager
+        .getRepository(User)
+        .findOne({ where: { guid: userGuid }, select: ['guid', 'isAdmin'] });
+      if (!currentTarget) throw new NotFoundException('用户不存在');
+      if (currentTarget.isAdmin) {
+        throw new ForbiddenException('超级管理员不能分配普通角色');
+      }
+      if (
+        !currentOwner &&
+        (await this.authorizationService.isProtectedUser(
+          userGuid,
+          currentTarget.isAdmin,
+          manager,
+        ))
+      ) {
+        throw new ForbiddenException('受保护账号只能由超级管理员修改');
+      }
+      if (!currentOwner && userGuid === actorGuid) {
+        throw new ForbiddenException('不能修改自己的角色');
+      }
+      const currentRolesForWrite = roleGuids.length
+        ? await manager
+            .getRepository(Role)
+            .find({ where: { guid: In(roleGuids) } })
+        : [];
+      if (currentRolesForWrite.length !== roleGuids.length) {
+        const found = new Set(currentRolesForWrite.map((role) => role.guid));
+        throw new NotFoundException(
+          `角色不存在: ${roleGuids.filter((roleGuid) => !found.has(roleGuid)).join(', ')}`,
+        );
+      }
+      if (!currentOwner) {
+        const assignedProtectedRole = currentRolesForWrite.find(
+          (role) => role.protectedAccount === true,
+        );
+        if (assignedProtectedRole) {
+          throw new ForbiddenException(
+            `受保护角色只能由超级管理员分配: ${assignedProtectedRole.guid}`,
+          );
+        }
+      }
+      const currentPermissionRowsForWrite = roleGuids.length
+        ? await manager
+            .getRepository(RolePermission)
+            .find({ where: { roleGuid: In(roleGuids) } })
+        : [];
+      const permissionsForWrite = this.groupPermissions(
+        currentPermissionRowsForWrite,
+      );
+      if (
+        !currentOwner &&
+        [...permissionsForWrite.values()].some((permissions) =>
+          permissions.includes('roles.assign'),
+        )
+      ) {
+        throw new ForbiddenException(
+          '包含 roles.assign 的角色只能由超级管理员分配',
+        );
+      }
+      for (const assignment of normalized) {
+        const permissions = permissionsForWrite.get(assignment.role_guid) || [];
+        if (
+          assignment.scope_type === 'device_group' &&
+          (permissions.length === 0 ||
+            permissions.some(
+              (permission) => !isDeviceGroupScopedPermission(permission),
+            ))
+        ) {
+          throw new BadRequestException(
+            'device_group scope only supports device actions and strategies.assign',
+          );
+        }
+      }
+      if (groupGuids.length) {
+        const currentGroups = await manager
+          .getRepository(DeviceGroup)
+          .find({ where: { guid: In(groupGuids) }, select: ['guid'] });
+        if (currentGroups.length !== groupGuids.length) {
+          const found = new Set(currentGroups.map((group) => group.guid));
+          throw new BadRequestException(
+            `设备组不存在: ${groupGuids.filter((groupGuid) => !found.has(groupGuid)).join(', ')}`,
+          );
+        }
+      }
+      const before = await this.getUserRoles(userGuid, manager);
+      const current = await manager.getRepository(UserRoleAssignment).find({
+        where: { userGuid },
+        select: ['guid', 'roleGuid', 'scopeType'],
+      });
+      if (!currentOwner) {
+        const currentRoleGuids = new Set(
+          current.map((assignment) => assignment.roleGuid),
+        );
+        const currentRoles = currentRoleGuids.size
+          ? await manager
+              .getRepository(Role)
+              .find({ where: { guid: In([...currentRoleGuids]) } })
+          : [];
+        const currentPermissionRows = currentRoleGuids.size
+          ? await manager
+              .getRepository(RolePermission)
+              .find({ where: { roleGuid: In([...currentRoleGuids]) } })
+          : [];
+        const currentPermissions = this.groupPermissions(currentPermissionRows);
+        const lockedRoleGuids = new Set(
+          currentRoles
+            .filter((role) => role.protectedAccount)
+            .map((role) => role.guid),
+        );
+        for (const [roleGuid, permissions] of currentPermissions) {
+          if (permissions.includes('roles.assign'))
+            lockedRoleGuids.add(roleGuid);
+        }
+        const omitted = current.find(
+          (assignment) =>
+            !requestedRoleGuids.has(assignment.roleGuid) &&
+            lockedRoleGuids.has(assignment.roleGuid),
+        );
+        if (omitted)
+          throw new ForbiddenException(
+            `不可移除受保护角色: ${omitted.roleGuid}`,
+          );
+        const finalRoleRows = roleGuids.length
+          ? await manager
+              .getRepository(RolePermission)
+              .find({ where: { roleGuid: In(roleGuids) } })
+          : [];
+        const finalPermissions = this.groupPermissions(finalRoleRows);
+        const caller = await this.authorizationService.getEffectivePermissions(
+          actorGuid,
+          manager,
+        );
+        const proposed = new Map<
+          PermissionCode,
+          { global: boolean; groups: Set<string> }
+        >();
+        for (const assignment of normalized) {
+          for (const permission of finalPermissions.get(assignment.role_guid) ||
+            []) {
+            const grant = proposed.get(permission) || {
+              global: false,
+              groups: new Set<string>(),
+            };
+            if (assignment.scope_type === 'global') grant.global = true;
+            else
+              for (const group of assignment.device_group_guids || [])
+                grant.groups.add(group);
+            proposed.set(permission, grant);
+          }
+        }
+        for (const [permission, grant] of proposed) {
+          const allowed = caller.scopes[permission];
+          if (
+            !allowed ||
+            (grant.global && allowed.scope_type !== 'global') ||
+            (!grant.global &&
+              allowed.scope_type === 'device_group' &&
+              ![...grant.groups].every((group) =>
+                allowed.device_group_guids.includes(group),
+              ))
+          ) {
+            throw new ForbiddenException(
+              `角色权限超出操作者范围: ${permission}`,
+            );
+          }
+        }
+      }
+      if (current.length) {
+        await manager.delete(UserRoleAssignmentDeviceGroup, {
+          assignmentGuid: In(current.map((assignment) => assignment.guid)),
+        });
+      }
+      await manager.delete(UserRoleAssignment, { userGuid });
+      for (const assignment of normalized) {
+        const saved = await manager.getRepository(UserRoleAssignment).save({
+          guid: uuidv4(),
+          userGuid,
+          roleGuid: assignment.role_guid,
+          scopeType: assignment.scope_type,
+        });
+        if (assignment.scope_type === 'device_group') {
+          await manager.getRepository(UserRoleAssignmentDeviceGroup).insert(
+            (assignment.device_group_guids || []).map((deviceGroupGuid) => ({
+              assignmentGuid: saved.guid,
+              deviceGroupGuid,
+            })),
+          );
+        }
+      }
+      await this.auditService.record(
+        {
+          actorUserGuid: actorGuid,
+          targetType: 'user',
+          targetGuid: userGuid,
+          action: 'user_role.replace',
+          result: 'allowed',
+          beforeState: before,
+          afterState: normalized,
+        },
+        manager,
+      );
+    });
+    return this.getUserRoles(userGuid);
+  }
+
+  private async loadAssignments(
+    userGuid: string,
+    manager?: import('typeorm').EntityManager,
+  ) {
+    const assignmentRepository =
+      manager?.getRepository(UserRoleAssignment) ?? this.assignmentRepository;
+    const assignments = await assignmentRepository.find({
+      where: { userGuid },
+      order: { createdAt: 'ASC' },
+    });
+    if (!assignments.length) return [];
+    const roleGuids = [
+      ...new Set(assignments.map((assignment) => assignment.roleGuid)),
+    ];
+    const assignmentGuids = assignments.map((assignment) => assignment.guid);
+    const [roles, permissions, groups] = await Promise.all([
+      (manager?.getRepository(Role) ?? this.roleRepository).find({
+        where: { guid: In(roleGuids) },
+      }),
+      (
+        manager?.getRepository(RolePermission) ?? this.rolePermissionRepository
+      ).find({
+        where: { roleGuid: In(roleGuids) },
+      }),
+      (
+        manager?.getRepository(UserRoleAssignmentDeviceGroup) ??
+        this.assignmentGroupRepository
+      ).find({
+        where: { assignmentGuid: In(assignmentGuids) },
+      }),
+    ]);
+    const roleMap = new Map(roles.map((role) => [role.guid, role]));
+    const permissionMap = this.groupPermissions(permissions);
+    const groupMap = new Map<string, string[]>();
+    for (const group of groups) {
+      const values = groupMap.get(group.assignmentGuid) || [];
+      values.push(group.deviceGroupGuid);
+      groupMap.set(group.assignmentGuid, values);
+    }
+    return assignments.map((assignment) => {
+      const rolePermissions = permissionMap.get(assignment.roleGuid) || [];
+      return {
+        ...assignment,
+        role: roleMap.get(assignment.roleGuid),
+        permissions:
+          assignment.scopeType === 'device_group'
+            ? rolePermissions.filter((permission) =>
+                isDeviceGroupScopedPermission(permission),
+              )
+            : rolePermissions,
+        groupGuids:
+          assignment.scopeType === 'device_group'
+            ? (groupMap.get(assignment.guid) || []).sort()
+            : [],
+      };
+    });
+  }
+
+  private effectiveScopes(
+    assignments: Awaited<ReturnType<UserRoleService['loadAssignments']>>,
+  ) {
+    const scopes: Record<
+      string,
+      { scope_type: 'global' | 'device_group'; device_group_guids: string[] }
+    > = {};
+    for (const assignment of assignments) {
+      for (const permission of assignment.permissions) {
+        if (!isAssignablePermissionCode(permission)) continue;
+        const existing = scopes[permission];
+        if (existing?.scope_type === 'global') continue;
+        if (!existing || assignment.scopeType === 'global') {
+          scopes[permission] =
+            assignment.scopeType === 'global'
+              ? { scope_type: 'global', device_group_guids: [] }
+              : {
+                  scope_type: 'device_group',
+                  device_group_guids: [...assignment.groupGuids],
+                };
+          continue;
+        }
+        scopes[permission] = {
+          scope_type: 'device_group',
+          device_group_guids: [
+            ...new Set([
+              ...existing.device_group_guids,
+              ...assignment.groupGuids,
+            ]),
+          ].sort(),
+        };
+      }
+    }
+    return scopes;
+  }
+
+  private toResponse(
+    assignment: Awaited<ReturnType<UserRoleService['loadAssignments']>>[number],
+  ) {
+    return {
+      guid: assignment.guid,
+      role_guid: assignment.roleGuid,
+      role_name: assignment.role?.name || '',
+      scope_type: assignment.scopeType,
+      device_group_guids: assignment.groupGuids,
+      permissions: assignment.permissions,
+      created_at: assignment.createdAt,
+      updated_at: assignment.updatedAt,
+    };
+  }
+
+  private validateAssignments(assignments: UserRoleAssignmentDto[]) {
+    const seen = new Set<string>();
+    return assignments.map((assignment) => {
+      if (seen.has(assignment.role_guid)) {
+        throw new BadRequestException('同一用户不能重复分配角色');
+      }
+      seen.add(assignment.role_guid);
+      const groups = [...new Set(assignment.device_group_guids || [])];
+      if (assignment.scope_type === 'device_group' && groups.length === 0) {
+        throw new BadRequestException(
+          'device_group scope requires at least one device group',
+        );
+      }
+      if (assignment.scope_type === 'global' && groups.length > 0) {
+        throw new BadRequestException(
+          'global scope cannot include device groups',
+        );
+      }
+      return {
+        role_guid: assignment.role_guid,
+        scope_type: assignment.scope_type,
+        device_group_guids:
+          assignment.scope_type === 'device_group' ? groups : [],
+      };
+    });
+  }
+
+  private groupPermissions(rows: RolePermission[]) {
+    const codesByRole = new Map<string, string[]>();
+    for (const row of rows) {
+      // Damaged/legacy rows must never appear as effective permissions or be
+      // echoed back as if they were part of the code-owned catalog.
+      if (!isAssignablePermissionCode(row.permissionCode)) continue;
+      const list = codesByRole.get(row.roleGuid) || [];
+      list.push(row.permissionCode);
+      codesByRole.set(row.roleGuid, list);
+    }
+    return new Map(
+      [...codesByRole].map(([roleGuid, codes]) => [
+        roleGuid,
+        filterEffectivePermissionCodes(codes),
+      ]),
+    );
+  }
+
+  private async ensureUserExists(
+    manager: import('typeorm').EntityManager | undefined,
+    userGuid: string,
+  ) {
+    if (
+      !(await (manager?.getRepository(User) ?? this.userRepository).exist({
+        where: { guid: userGuid },
+      }))
+    ) {
+      throw new NotFoundException('用户不存在');
+    }
+  }
+}

--- a/src/modules/rbac/user-role.controller.ts
+++ b/src/modules/rbac/user-role.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Put,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { RequirePermission } from './decorators/require-permission.decorator';
+import { ReplaceUserRolesDto } from './dto/user-role.dto';
+import { UserRoleService } from './services/user-role.service';
+
+@Controller('users')
+export class UserRoleController {
+  constructor(private readonly userRoleService: UserRoleService) {}
+
+  @Get(':guid/roles')
+  @RequirePermission('roles.assign')
+  getRoles(@Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string) {
+    return this.userRoleService.getUserRoles(guid);
+  }
+
+  @Get(':guid/roles/eligibility')
+  @RequirePermission('roles.assign')
+  getEligibility(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    return this.userRoleService.getRoleEligibility(guid, actorGuid);
+  }
+
+  @Put(':guid/roles')
+  @RequirePermission('roles.assign')
+  @HttpCode(HttpStatus.OK)
+  replaceRoles(
+    @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @Body() dto: ReplaceUserRolesDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    return this.userRoleService.replaceUserRoles(guid, dto, actorGuid);
+  }
+}

--- a/src/modules/settings/services/general-settings.service.ts
+++ b/src/modules/settings/services/general-settings.service.ts
@@ -153,8 +153,7 @@ export class GeneralSettingsService {
       watermarkEnabled: dto.watermarkEnabled,
       defaultLanguage: dto.defaultLanguage ?? current.defaultLanguage,
       jwtExpiryDays: dto.jwtExpiryDays ?? current.jwtExpiryDays,
-      auditRetentionDays:
-        dto.auditRetentionDays ?? current.auditRetentionDays,
+      auditRetentionDays: dto.auditRetentionDays ?? current.auditRetentionDays,
       site: {
         frontendUrl: dto.site?.frontendUrl ?? current.site.frontendUrl,
         backendUrl: dto.site?.backendUrl ?? current.site.backendUrl,

--- a/src/modules/settings/settings.module.ts
+++ b/src/modules/settings/settings.module.ts
@@ -6,6 +6,7 @@ import { SmtpSettingsService } from './services/smtp-settings.service';
 import { GeneralSettingsController } from './general-settings.controller';
 import { FrontendSettingsController } from './frontend-settings.controller';
 import { GeneralSettingsService } from './services/general-settings.service';
+import { AdminGuard } from '../../common/guards/admin.guard';
 
 /**
  * 系统设置模块
@@ -24,7 +25,7 @@ import { GeneralSettingsService } from './services/general-settings.service';
     GeneralSettingsController,
     FrontendSettingsController,
   ],
-  providers: [SmtpSettingsService, GeneralSettingsService],
+  providers: [SmtpSettingsService, GeneralSettingsService, AdminGuard],
   exports: [SmtpSettingsService, GeneralSettingsService],
 })
 export class SettingsModule {}

--- a/src/modules/strategy/dto/strategy.dto.ts
+++ b/src/modules/strategy/dto/strategy.dto.ts
@@ -8,7 +8,9 @@ import {
   IsInt,
   IsArray,
   ArrayMaxSize,
+  ArrayMinSize,
   IsIn,
+  Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -42,24 +44,27 @@ export class UpdateStrategyDto {
 
 export class AssignStrategyDto {
   @IsString()
-  @IsNotEmpty()
+  @IsIn(['device', 'user', 'device_group'])
   target_type: 'device' | 'user' | 'device_group';
 
   @IsArray()
-  @IsNotEmpty()
+  @ArrayMinSize(1)
   @ArrayMaxSize(200)
+  @IsString({ each: true })
   target_guids: string[];
 }
 
 export class StrategyQueryDto {
   @IsNumber()
   @Min(1)
+  @Max(100000)
   @IsInt()
   @Type(() => Number)
   current: number;
 
   @IsNumber()
   @Min(1)
+  @Max(200)
   @IsInt()
   @Type(() => Number)
   pageSize: number;
@@ -67,6 +72,33 @@ export class StrategyQueryDto {
   @IsString()
   @IsOptional()
   name?: string;
+}
+
+export class StrategyCandidateDto {
+  guid: string;
+  name: string;
+  note: string;
+}
+
+export class StrategyTargetCandidateQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['device', 'user'])
+  target_type: 'device' | 'user';
+
+  @IsNumber()
+  @Min(1)
+  @Max(100000)
+  @IsInt()
+  @Type(() => Number)
+  current: number;
+
+  @IsNumber()
+  @Min(1)
+  @Max(200)
+  @IsInt()
+  @Type(() => Number)
+  pageSize: number;
 }
 
 export class AssignmentQueryDto {
@@ -77,12 +109,14 @@ export class AssignmentQueryDto {
 
   @IsNumber()
   @Min(1)
+  @Max(100000)
   @IsInt()
   @Type(() => Number)
   current: number;
 
   @IsNumber()
   @Min(1)
+  @Max(200)
   @IsInt()
   @Type(() => Number)
   pageSize: number;

--- a/src/modules/strategy/strategy.controller.ts
+++ b/src/modules/strategy/strategy.controller.ts
@@ -7,7 +7,6 @@ import {
   Body,
   Param,
   Query,
-  UseGuards,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
@@ -17,44 +16,62 @@ import {
   UpdateStrategyDto,
   AssignStrategyDto,
   StrategyQueryDto,
+  StrategyTargetCandidateQueryDto,
   AssignmentQueryDto,
 } from './dto/strategy.dto';
-import { AdminGuard } from '../../common/guards/admin.guard';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
 @Controller()
 export class StrategyController {
   constructor(private readonly strategyService: StrategyService) {}
 
   @Get('strategies')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.view')
   async getStrategies(@Query() query: StrategyQueryDto) {
     return this.strategyService.getStrategies(query);
   }
 
+  @Get('strategies/candidates')
+  @RequirePermission('strategies.assign')
+  async getStrategyCandidates(@Query() query: StrategyQueryDto) {
+    return this.strategyService.getStrategyCandidates(query);
+  }
+
+  @Get('strategies/target-candidates')
+  @RequirePermission('strategies.assign')
+  async getStrategyTargetCandidates(
+    @Query() query: StrategyTargetCandidateQueryDto,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.strategyService.getStrategyTargetCandidates(query, userId);
+  }
+
   @Get('strategies/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.view')
   async getStrategy(@Param('guid') guid: string) {
     return this.strategyService.getStrategy(guid);
   }
 
   @Get('strategies/:guid/assignments')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.assign')
   async getStrategyAssignments(
     @Param('guid') guid: string,
     @Query() query: AssignmentQueryDto,
+    @CurrentUser('id') userId: string,
   ) {
-    return this.strategyService.getStrategyAssignments(guid, query);
+    return this.strategyService.getStrategyAssignments(guid, query, userId);
   }
 
   @Post('strategies')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.create')
   @HttpCode(HttpStatus.OK)
   async createStrategy(@Body() dto: CreateStrategyDto) {
     return this.strategyService.createStrategy(dto);
   }
 
   @Patch('strategies/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.edit')
   @HttpCode(HttpStatus.OK)
   async updateStrategy(
     @Param('guid') guid: string,
@@ -64,7 +81,7 @@ export class StrategyController {
   }
 
   @Delete('strategies/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.delete')
   @HttpCode(HttpStatus.OK)
   async deleteStrategy(@Param('guid') guid: string) {
     await this.strategyService.deleteStrategy(guid);
@@ -72,26 +89,34 @@ export class StrategyController {
   }
 
   @Post('strategies/:guid/assign')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.assign')
   @HttpCode(HttpStatus.OK)
   async assignStrategy(
     @Param('guid') guid: string,
     @Body() dto: AssignStrategyDto,
+    @CurrentUser('id') userId: string,
   ) {
     return this.strategyService.assignStrategy(
       guid,
       dto.target_type,
       dto.target_guids,
+      userId,
     );
   }
 
   @Post('strategies/:guid/unassign')
-  @UseGuards(AdminGuard)
+  @RequirePermission('strategies.assign')
   @HttpCode(HttpStatus.OK)
-  async unassignStrategy(@Body() dto: AssignStrategyDto) {
+  async unassignStrategy(
+    @Param('guid') strategyGuid: string,
+    @Body() dto: AssignStrategyDto,
+    @CurrentUser('id') userId: string,
+  ) {
     return this.strategyService.unassignStrategy(
+      strategyGuid,
       dto.target_type,
       dto.target_guids,
+      userId,
     );
   }
 }

--- a/src/modules/strategy/strategy.module.ts
+++ b/src/modules/strategy/strategy.module.ts
@@ -6,9 +6,13 @@ import { Strategy } from './entities/strategy.entity';
 import { Peer } from '../../common/entities/peer.entity';
 import { User } from '../user/entities/user.entity';
 import { DeviceGroup } from '../device-group/entities/device-group.entity';
+import { RbacModule } from '../rbac/rbac.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Strategy, Peer, User, DeviceGroup])],
+  imports: [
+    TypeOrmModule.forFeature([Strategy, Peer, User, DeviceGroup]),
+    RbacModule,
+  ],
   controllers: [StrategyController],
   providers: [StrategyService],
   exports: [StrategyService],

--- a/src/modules/strategy/strategy.service.spec.ts
+++ b/src/modules/strategy/strategy.service.spec.ts
@@ -1,0 +1,519 @@
+import 'reflect-metadata';
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { Repository } from 'typeorm';
+import { Peer } from '../../common/entities/peer.entity';
+import { DeviceGroup } from '../device-group/entities/device-group.entity';
+import { REQUIRE_PERMISSION_KEY } from '../rbac/decorators/require-permission.decorator';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
+import { User } from '../user/entities/user.entity';
+import {
+  StrategyQueryDto,
+  StrategyTargetCandidateQueryDto,
+} from './dto/strategy.dto';
+import { Strategy } from './entities/strategy.entity';
+import { StrategyController } from './strategy.controller';
+import { StrategyService } from './strategy.service';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+type MockRepository = {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  findAndCount: jest.Mock;
+  update: jest.Mock;
+  createQueryBuilder: jest.Mock;
+  manager: { transaction: jest.Mock };
+};
+
+const repository = (): MockRepository => ({
+  findOne: jest.fn(),
+  find: jest.fn().mockResolvedValue([]),
+  findAndCount: jest.fn().mockResolvedValue([[], 0]),
+  update: jest.fn().mockResolvedValue(undefined),
+  createQueryBuilder: jest.fn(),
+  manager: { transaction: jest.fn() },
+});
+
+describe('Strategy candidate and target contracts', () => {
+  let strategyRepository: MockRepository;
+  let peerRepository: MockRepository;
+  let userRepository: MockRepository;
+  let deviceGroupRepository: MockRepository;
+  let authorizationService: {
+    assertStrategyTargets: jest.Mock;
+    getCurrentUser: jest.Mock;
+    requirePermission: jest.Mock;
+    getEffectiveProtectionMap: jest.Mock;
+  };
+  let transactionManager: { update: jest.Mock; getRepository: jest.Mock };
+  let service: StrategyService;
+
+  beforeEach(() => {
+    strategyRepository = repository();
+    peerRepository = repository();
+    userRepository = repository();
+    deviceGroupRepository = repository();
+    transactionManager = {
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      getRepository: jest.fn((entity: unknown) =>
+        entity === Peer
+          ? peerRepository
+          : entity === User
+            ? userRepository
+            : entity === DeviceGroup
+              ? deviceGroupRepository
+              : strategyRepository,
+      ),
+    };
+    peerRepository.manager.transaction.mockImplementation(
+      (callback: (manager: typeof transactionManager) => unknown) =>
+        callback(transactionManager),
+    );
+    authorizationService = {
+      assertStrategyTargets: jest.fn().mockResolvedValue({
+        global: true,
+        deviceGroupGuids: new Set<string>(),
+      }),
+      getCurrentUser: jest.fn().mockResolvedValue({ isAdmin: false }),
+      requirePermission: jest.fn().mockResolvedValue({
+        global: true,
+        deviceGroupGuids: new Set<string>(),
+      }),
+      getEffectiveProtectionMap: jest.fn().mockResolvedValue(new Map()),
+    };
+    service = new StrategyService(
+      strategyRepository as unknown as Repository<Strategy>,
+      peerRepository as unknown as Repository<Peer>,
+      userRepository as unknown as Repository<User>,
+      deviceGroupRepository as unknown as Repository<DeviceGroup>,
+      peerRepository.manager as unknown as import('typeorm').DataSource,
+      authorizationService as unknown as RbacAuthorizationService,
+    );
+  });
+
+  it('returns only guid, name, and note from the candidate endpoint query', async () => {
+    const queryBuilder = {
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([
+        [
+          {
+            guid: 'strategy-1',
+            name: 'Approved strategy',
+            note: 'Summary',
+            configOptions: JSON.stringify({ secret: 'sentinel-secret' }),
+            updatedAt: new Date('2026-01-01T00:00:00Z'),
+          },
+        ],
+        1,
+      ]),
+    };
+    strategyRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    const result = await service.getStrategyCandidates({
+      current: 2,
+      pageSize: 10,
+      name: 'Approved',
+    });
+
+    expect(result).toEqual({
+      data: [
+        { guid: 'strategy-1', name: 'Approved strategy', note: 'Summary' },
+      ],
+      total: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain('sentinel-secret');
+    expect(queryBuilder.skip).toHaveBeenCalledWith(10);
+    expect(queryBuilder.take).toHaveBeenCalledWith(10);
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'strategy.name LIKE :name',
+      { name: '%Approved%' },
+    );
+  });
+
+  it('requires strategies.assign and rejects an authenticated user without it', () => {
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        StrategyController.prototype.getStrategyCandidates,
+      ),
+    ).toEqual(['strategies.assign']);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        StrategyController.prototype.getStrategyTargetCandidates,
+      ),
+    ).toEqual(['strategies.assign']);
+  });
+
+  it('returns only scoped device identifiers from target candidates', async () => {
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([
+        [
+          {
+            uuid: 'device-1',
+            id: '123456789',
+            status: 1,
+            note: 'not exposed',
+          },
+        ],
+        1,
+      ]),
+    };
+    peerRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+    authorizationService.requirePermission.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set(['group-1']),
+    });
+
+    await expect(
+      service.getStrategyTargetCandidates(
+        { target_type: 'device', current: 1, pageSize: 20 },
+        'actor',
+      ),
+    ).resolves.toEqual({
+      data: [{ uuid: 'device-1', id: '123456789' }],
+      total: 1,
+    });
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'peer.deviceGroupGuid IN (:...deviceGroupGuids)',
+      { deviceGroupGuids: ['group-1'] },
+    );
+  });
+
+  it('returns no device candidates when the assignment scope is empty', async () => {
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    peerRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+    authorizationService.requirePermission.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set<string>(),
+    });
+
+    await expect(
+      service.getStrategyTargetCandidates(
+        { target_type: 'device', current: 1, pageSize: 20 },
+        'actor',
+      ),
+    ).resolves.toEqual({ data: [], total: 0 });
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('1 = 0');
+  });
+
+  it('requires global assignment scope before loading user candidates', async () => {
+    authorizationService.assertStrategyTargets.mockRejectedValue(
+      new ForbiddenException('按用户分配策略需要全局权限'),
+    );
+
+    await expect(
+      service.getStrategyTargetCandidates(
+        { target_type: 'user', current: 1, pageSize: 20 },
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(userRepository.findAndCount).not.toHaveBeenCalled();
+  });
+
+  it('uses the existing pagination validation for candidate requests', async () => {
+    const invalid = plainToInstance(StrategyQueryDto, {
+      current: 0,
+      pageSize: 20,
+      name: 'candidate',
+      config_options: { secret: true },
+    });
+
+    expect(
+      await validate(invalid, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    ).not.toHaveLength(0);
+  });
+
+  it('caps target candidate pages at 200 records', async () => {
+    const invalid = plainToInstance(StrategyTargetCandidateQueryDto, {
+      target_type: 'device',
+      current: 1,
+      pageSize: 201,
+    });
+
+    expect(await validate(invalid)).not.toHaveLength(0);
+  });
+
+  it('reports missing devices through the established partial batch response', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    peerRepository.find.mockResolvedValue([{ uuid: 'device-1' }]);
+
+    await expect(
+      service.assignStrategy(
+        'strategy-1',
+        'device',
+        ['device-1', 'missing-device'],
+        'actor',
+      ),
+    ).resolves.toEqual({
+      success: ['device-1'],
+      errors: [{ target_guid: 'missing-device', reason: '设备不存在' }],
+    });
+    expect(transactionManager.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not query or mutate targets after an out-of-scope denial', async () => {
+    authorizationService.assertStrategyTargets.mockRejectedValue(
+      new ForbiddenException('目标设备不在授权设备组内'),
+    );
+
+    await expect(
+      service.assignStrategy(
+        'strategy-1',
+        'device',
+        ['authorized-device', 'out-of-scope-device'],
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(strategyRepository.findOne).not.toHaveBeenCalled();
+    expect(peerRepository.find).not.toHaveBeenCalled();
+    expect(peerRepository.manager.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a missing strategy as a 404 after target authorization', async () => {
+    strategyRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.assignStrategy(
+        'missing-strategy',
+        'device',
+        ['device-1'],
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(peerRepository.manager.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a scoped assignment if the device leaves its authorized group before the write', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    peerRepository.find.mockResolvedValue([{ uuid: 'device-1' }]);
+    authorizationService.assertStrategyTargets
+      .mockResolvedValueOnce({
+        global: false,
+        deviceGroupGuids: new Set(['group-1']),
+      })
+      .mockRejectedValueOnce(
+        new ForbiddenException('目标设备不在授权设备组内'),
+      );
+    transactionManager.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      service.assignStrategy('strategy-1', 'device', ['device-1'], 'actor'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(authorizationService.assertStrategyTargets).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when a user assignment updates fewer rows than read', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    userRepository.find.mockResolvedValue([
+      { guid: 'user-1', strategyGuid: null },
+      { guid: 'user-2', strategyGuid: null },
+    ]);
+    userRepository.update.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      service.assignStrategy(
+        'strategy-1',
+        'user',
+        ['user-1', 'user-2'],
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(userRepository.update).toHaveBeenCalledTimes(1);
+    expect(transactionManager.update).not.toHaveBeenCalled();
+  });
+
+  it('reports missing users through the established partial batch response', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    userRepository.find.mockResolvedValue([
+      { guid: 'user-1', strategyGuid: null },
+    ]);
+    userRepository.update.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      service.assignStrategy(
+        'strategy-1',
+        'user',
+        ['user-1', 'missing-user'],
+        'actor',
+      ),
+    ).resolves.toEqual({
+      success: ['user-1'],
+      errors: [{ target_guid: 'missing-user', reason: '用户不存在' }],
+    });
+    expect(authorizationService.assertStrategyTargets).toHaveBeenCalledWith(
+      'actor',
+      'user',
+      ['user-1'],
+      transactionManager,
+    );
+  });
+
+  it('fails closed when a user unassignment updates fewer rows than read', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    userRepository.find.mockResolvedValue([
+      { guid: 'user-1', strategyGuid: 'strategy-1' },
+      { guid: 'user-2', strategyGuid: 'strategy-1' },
+    ]);
+    userRepository.update.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      service.unassignStrategy(
+        'strategy-1',
+        'user',
+        ['user-1', 'user-2'],
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(userRepository.update).toHaveBeenCalledTimes(1);
+    expect(transactionManager.update).not.toHaveBeenCalled();
+  });
+
+  it('updates only requested authorized groups when assigning', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    authorizationService.assertStrategyTargets.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set(['group-a', 'group-b']),
+    });
+    deviceGroupRepository.find.mockResolvedValue([
+      { guid: 'group-a', strategyGuid: null },
+    ]);
+
+    await expect(
+      service.assignStrategy(
+        'strategy-1',
+        'device_group',
+        ['group-a'],
+        'actor',
+      ),
+    ).resolves.toEqual({ success: ['group-a'], errors: [] });
+    expect(transactionManager.update).toHaveBeenCalledWith(
+      DeviceGroup,
+      { guid: expect.anything() },
+      { strategyGuid: 'strategy-1' },
+    );
+    const criteria = transactionManager.update.mock.calls[0][1];
+    expect(criteria).not.toHaveProperty('strategyGuid');
+    expect((criteria.guid as { _value: string[] })._value).toEqual(['group-a']);
+  });
+
+  it('updates only requested authorized groups when unassigning', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    authorizationService.assertStrategyTargets.mockResolvedValue({
+      global: false,
+      deviceGroupGuids: new Set(['group-a', 'group-b']),
+    });
+    deviceGroupRepository.find.mockResolvedValue([
+      { guid: 'group-a', strategyGuid: 'strategy-1' },
+    ]);
+
+    await expect(
+      service.unassignStrategy(
+        'strategy-1',
+        'device_group',
+        ['group-a'],
+        'actor',
+      ),
+    ).resolves.toEqual({ success: ['group-a'], errors: [] });
+    expect(transactionManager.update).toHaveBeenCalledWith(
+      DeviceGroup,
+      { guid: expect.anything(), strategyGuid: 'strategy-1' },
+      { strategyGuid: null },
+    );
+    const criteria = transactionManager.update.mock.calls[0][1];
+    expect(criteria).not.toHaveProperty('deviceGroupGuids');
+    expect((criteria.guid as { _value: string[] })._value).toEqual(['group-a']);
+  });
+
+  it('authorizes assignment reads before looking up the strategy', async () => {
+    authorizationService.requirePermission.mockRejectedValue(
+      new ForbiddenException('无权限访问'),
+    );
+
+    await expect(
+      service.getStrategyAssignments(
+        'strategy-1',
+        { target_type: 'device', current: 1, pageSize: 20 },
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(strategyRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('hides administrator assignment rows from delegated assigners', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    userRepository.findAndCount.mockResolvedValue([
+      [
+        {
+          guid: 'user-1',
+          username: 'username',
+          displayName: 'Display name',
+          email: 'secret@example.com',
+          status: 1,
+          isAdmin: false,
+        },
+      ],
+      1,
+    ]);
+
+    const result = await service.getStrategyAssignments(
+      'strategy-1',
+      { target_type: 'user', current: 1, pageSize: 20 },
+      'actor',
+    );
+
+    expect(userRepository.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { strategyGuid: 'strategy-1', isAdmin: false },
+      }),
+    );
+    expect(result).toEqual({
+      data: [{ guid: 'user-1', name: 'Display name', is_protected: false }],
+      total: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain('secret@example.com');
+  });
+
+  it('keeps administrator assignment rows visible to super administrators', async () => {
+    strategyRepository.findOne.mockResolvedValue({ guid: 'strategy-1' });
+    authorizationService.getCurrentUser.mockResolvedValue({ isAdmin: true });
+
+    await service.getStrategyAssignments(
+      'strategy-1',
+      { target_type: 'user', current: 1, pageSize: 20 },
+      'actor',
+    );
+
+    expect(userRepository.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { strategyGuid: 'strategy-1' } }),
+    );
+  });
+});

--- a/src/modules/strategy/strategy.service.ts
+++ b/src/modules/strategy/strategy.service.ts
@@ -1,11 +1,12 @@
 import {
-  Injectable,
-  NotFoundException,
   BadRequestException,
+  ConflictException,
+  Injectable,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { DataSource, Repository, In } from 'typeorm';
 import * as uuid from 'uuid';
 import { Strategy } from './entities/strategy.entity';
 import { Peer } from '../../common/entities/peer.entity';
@@ -14,9 +15,16 @@ import { DeviceGroup } from '../device-group/entities/device-group.entity';
 import {
   CreateStrategyDto,
   UpdateStrategyDto,
+  AssignStrategyDto,
+  StrategyCandidateDto,
   StrategyQueryDto,
+  StrategyTargetCandidateQueryDto,
   AssignmentQueryDto,
 } from './dto/strategy.dto';
+import {
+  PermissionScope,
+  RbacAuthorizationService,
+} from '../rbac/services/rbac-authorization.service';
 
 @Injectable()
 export class StrategyService {
@@ -31,6 +39,8 @@ export class StrategyService {
     private userRepository: Repository<User>,
     @InjectRepository(DeviceGroup)
     private deviceGroupRepository: Repository<DeviceGroup>,
+    private readonly dataSource: DataSource,
+    private readonly rbacAuthorizationService: RbacAuthorizationService,
   ) {}
 
   async createStrategy(dto: CreateStrategyDto) {
@@ -141,6 +151,78 @@ export class StrategyService {
     };
   }
 
+  async getStrategyCandidates(query: StrategyQueryDto): Promise<{
+    data: StrategyCandidateDto[];
+    total: number;
+  }> {
+    const result = await this.getStrategies(query);
+    return {
+      data: result.data.map(({ guid, name, note }) => ({ guid, name, note })),
+      total: result.total,
+    };
+  }
+
+  async getStrategyTargetCandidates(
+    query: StrategyTargetCandidateQueryDto,
+    actorGuid: string,
+  ) {
+    const { target_type, current, pageSize } = query;
+    const skip = (current - 1) * pageSize;
+
+    if (target_type === 'device') {
+      const scope = await this.rbacAuthorizationService.requirePermission(
+        actorGuid,
+        'strategies.assign',
+      );
+      let queryBuilder = this.peerRepository
+        .createQueryBuilder('peer')
+        .select(['peer.uuid', 'peer.id']);
+      if (!scope.global) {
+        queryBuilder = scope.deviceGroupGuids.size
+          ? queryBuilder.andWhere(
+              'peer.deviceGroupGuid IN (:...deviceGroupGuids)',
+              { deviceGroupGuids: [...scope.deviceGroupGuids] },
+            )
+          : queryBuilder.andWhere('1 = 0');
+      }
+      const [peers, total] = await queryBuilder
+        .orderBy('peer.id', 'ASC')
+        .skip(skip)
+        .take(pageSize)
+        .getManyAndCount();
+      return {
+        data: peers.map(({ uuid, id }) => ({ uuid, id })),
+        total,
+      };
+    }
+
+    await this.rbacAuthorizationService.assertStrategyTargets(
+      actorGuid,
+      'user',
+      [],
+    );
+    const actor = await this.rbacAuthorizationService.getCurrentUser(actorGuid);
+    const [users, total] = await this.userRepository.findAndCount({
+      where: actor.isAdmin ? {} : { isAdmin: false },
+      select: ['guid', 'username', 'displayName'],
+      skip,
+      take: pageSize,
+      order: { username: 'ASC' },
+    });
+    const protection =
+      await this.rbacAuthorizationService.getEffectiveProtectionMap(
+        users.map((user) => user.guid),
+      );
+    return {
+      data: users.map((user) => ({
+        guid: user.guid,
+        name: user.displayName || user.username,
+        is_protected: protection.get(user.guid) === true,
+      })),
+      total,
+    };
+  }
+
   async getStrategy(guid: string) {
     const strategy = await this.strategyRepository.findOne({
       where: { guid },
@@ -163,75 +245,128 @@ export class StrategyService {
 
   async assignStrategy(
     strategyGuid: string,
-    targetType: string,
+    targetType: AssignStrategyDto['target_type'],
     targetGuids: string[],
+    actorGuid: string,
   ) {
-    const strategy = await this.strategyRepository.findOne({
-      where: { guid: strategyGuid },
-    });
-    if (!strategy) {
-      throw new NotFoundException('策略不存在');
-    }
-
+    const targets = [...new Set(targetGuids)];
     const success: string[] = [];
     const errors: { target_guid: string; reason: string }[] = [];
 
     switch (targetType) {
       case 'device': {
-        const peers = await this.peerRepository.find({
-          where: { uuid: In(targetGuids) },
-        });
-        const foundUuids = new Set(peers.map((p) => p.uuid));
-        for (const targetGuid of targetGuids) {
-          if (!foundUuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '设备不存在' });
+        await this.dataSource.transaction(async (manager) => {
+          const scope =
+            await this.rbacAuthorizationService.assertStrategyTargets(
+              actorGuid,
+              targetType,
+              targets,
+              manager,
+            );
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const peers = await manager
+            .getRepository(Peer)
+            .find({ where: { uuid: In(targets) } });
+          const foundUuids = new Set(peers.map((p) => p.uuid));
+          for (const targetGuid of targets) {
+            if (!foundUuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '设备不存在' });
+            }
           }
-        }
-        if (peers.length > 0) {
-          await this.peerRepository.update(
-            { uuid: In(peers.map((p) => p.uuid)) },
-            { strategyGuid },
-          );
-          success.push(...peers.map((p) => p.uuid));
-        }
+          if (peers.length > 0) {
+            const result = await manager.update(
+              Peer,
+              {
+                uuid: In(peers.map((peer) => peer.uuid)),
+                ...(scope.global
+                  ? {}
+                  : { deviceGroupGuid: In([...scope.deviceGroupGuids]) }),
+              },
+              { strategyGuid },
+            );
+            if (result.affected !== peers.length) {
+              await this.rbacAuthorizationService.assertStrategyTargets(
+                actorGuid,
+                targetType,
+                targets,
+                manager,
+              );
+              throw new ConflictException('设备信息已发生变化，请重试');
+            }
+            success.push(...peers.map((p) => p.uuid));
+          }
+        });
         break;
       }
       case 'user': {
-        const users = await this.userRepository.find({
-          where: { guid: In(targetGuids) },
-        });
-        const foundGuids = new Set(users.map((u) => u.guid));
-        for (const targetGuid of targetGuids) {
-          if (!foundGuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '用户不存在' });
-          }
-        }
-        if (users.length > 0) {
-          await this.userRepository.update(
-            { guid: In(users.map((u) => u.guid)) },
-            { strategyGuid },
+        await this.dataSource.transaction(async (manager) => {
+          const users = await manager.getRepository(User).find({
+            where: { guid: In(targets) },
+          });
+          await this.rbacAuthorizationService.assertStrategyTargets(
+            actorGuid,
+            'user',
+            users.map((user) => user.guid),
+            manager,
           );
-          success.push(...users.map((u) => u.guid));
-        }
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const foundGuids = new Set(users.map((u) => u.guid));
+          for (const targetGuid of targets) {
+            if (!foundGuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '用户不存在' });
+            }
+          }
+          if (users.length > 0) {
+            const result = await manager
+              .getRepository(User)
+              .update({ guid: In(users.map((u) => u.guid)) }, { strategyGuid });
+            if (result.affected !== users.length)
+              throw new ConflictException('用户信息已发生变化，请重试');
+            success.push(...users.map((u) => u.guid));
+          }
+        });
         break;
       }
       case 'device_group': {
-        const groups = await this.deviceGroupRepository.find({
-          where: { guid: In(targetGuids) },
-        });
-        const foundGuids = new Set(groups.map((g) => g.guid));
-        for (const targetGuid of targetGuids) {
-          if (!foundGuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
-          }
-        }
-        if (groups.length > 0) {
-          await this.deviceGroupRepository.update(
-            { guid: In(groups.map((g) => g.guid)) },
-            { strategyGuid },
+        await this.dataSource.transaction(async (manager) => {
+          await this.rbacAuthorizationService.assertStrategyTargets(
+            actorGuid,
+            targetType,
+            targets,
+            manager,
           );
-          success.push(...groups.map((g) => g.guid));
-        }
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const groups = await manager
+            .getRepository(DeviceGroup)
+            .find({ where: { guid: In(targets) } });
+          const foundGuids = new Set(groups.map((g) => g.guid));
+          for (const targetGuid of targets) {
+            if (!foundGuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
+            }
+          }
+          if (groups.length > 0) {
+            const result = await manager.update(
+              DeviceGroup,
+              {
+                guid: In(groups.map((g) => g.guid)),
+              },
+              { strategyGuid },
+            );
+            if (result.affected !== groups.length)
+              throw new ConflictException('设备组信息已发生变化，请重试');
+            success.push(...groups.map((g) => g.guid));
+          }
+        });
         break;
       }
       default:
@@ -243,66 +378,158 @@ export class StrategyService {
     return { success, errors };
   }
 
-  async unassignStrategy(targetType: string, targetGuids: string[]) {
+  async unassignStrategy(
+    strategyGuid: string,
+    targetType: AssignStrategyDto['target_type'],
+    targetGuids: string[],
+    actorGuid: string,
+  ) {
+    const targets = [...new Set(targetGuids)];
     const success: string[] = [];
     const errors: { target_guid: string; reason: string }[] = [];
 
     switch (targetType) {
       case 'device': {
-        const peers = await this.peerRepository.find({
-          where: { uuid: In(targetGuids) },
-        });
-        const foundUuids = new Set(peers.map((p) => p.uuid));
-        for (const targetGuid of targetGuids) {
-          if (!foundUuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '设备不存在' });
-          }
-        }
-        if (peers.length > 0) {
-          await this.peerRepository.update(
-            { uuid: In(peers.map((p) => p.uuid)) },
-            { strategyGuid: null },
+        await this.dataSource.transaction(async (manager) => {
+          const scope =
+            await this.rbacAuthorizationService.assertStrategyTargets(
+              actorGuid,
+              targetType,
+              targets,
+              manager,
+            );
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const peers = await manager
+            .getRepository(Peer)
+            .find({ where: { uuid: In(targets) } });
+          const existingUuids = new Set(peers.map((peer) => peer.uuid));
+          const assignedPeers = peers.filter(
+            (peer) => peer.strategyGuid === strategyGuid,
           );
-          success.push(...peers.map((p) => p.uuid));
-        }
+          const assignedUuids = new Set(assignedPeers.map((peer) => peer.uuid));
+          for (const targetGuid of targets) {
+            if (!existingUuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '设备不存在' });
+            } else if (!assignedUuids.has(targetGuid)) {
+              errors.push({
+                target_guid: targetGuid,
+                reason: '设备未绑定该策略',
+              });
+            }
+          }
+          if (assignedPeers.length > 0) {
+            const result = await manager.update(
+              Peer,
+              {
+                uuid: In(assignedPeers.map((peer) => peer.uuid)),
+                strategyGuid,
+                ...(scope.global
+                  ? {}
+                  : { deviceGroupGuid: In([...scope.deviceGroupGuids]) }),
+              },
+              { strategyGuid: null },
+            );
+            if (result.affected !== assignedPeers.length)
+              throw new ConflictException('设备信息已发生变化，请重试');
+            success.push(...assignedPeers.map((peer) => peer.uuid));
+          }
+        });
         break;
       }
       case 'user': {
-        const users = await this.userRepository.find({
-          where: { guid: In(targetGuids) },
-        });
-        const foundGuids = new Set(users.map((u) => u.guid));
-        for (const targetGuid of targetGuids) {
-          if (!foundGuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '用户不存在' });
-          }
-        }
-        if (users.length > 0) {
-          await this.userRepository.update(
-            { guid: In(users.map((u) => u.guid)) },
-            { strategyGuid: null },
+        await this.dataSource.transaction(async (manager) => {
+          const users = await manager.getRepository(User).find({
+            where: { guid: In(targets) },
+          });
+          await this.rbacAuthorizationService.assertStrategyTargets(
+            actorGuid,
+            'user',
+            users.map((user) => user.guid),
+            manager,
           );
-          success.push(...users.map((u) => u.guid));
-        }
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const existingGuids = new Set(users.map((user) => user.guid));
+          const assignedUsers = users.filter(
+            (user) => user.strategyGuid === strategyGuid,
+          );
+          const assignedGuids = new Set(assignedUsers.map((user) => user.guid));
+          for (const targetGuid of targets) {
+            if (!existingGuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '用户不存在' });
+            } else if (!assignedGuids.has(targetGuid)) {
+              errors.push({
+                target_guid: targetGuid,
+                reason: '用户未绑定该策略',
+              });
+            }
+          }
+          if (assignedUsers.length > 0) {
+            const result = await manager.getRepository(User).update(
+              {
+                guid: In(assignedUsers.map((user) => user.guid)),
+                strategyGuid,
+              },
+              { strategyGuid: null },
+            );
+            if (result.affected !== assignedUsers.length)
+              throw new ConflictException('用户信息已发生变化，请重试');
+            success.push(...assignedUsers.map((user) => user.guid));
+          }
+        });
         break;
       }
       case 'device_group': {
-        const groups = await this.deviceGroupRepository.find({
-          where: { guid: In(targetGuids) },
-        });
-        const foundGuids = new Set(groups.map((g) => g.guid));
-        for (const targetGuid of targetGuids) {
-          if (!foundGuids.has(targetGuid)) {
-            errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
-          }
-        }
-        if (groups.length > 0) {
-          await this.deviceGroupRepository.update(
-            { guid: In(groups.map((g) => g.guid)) },
-            { strategyGuid: null },
+        await this.dataSource.transaction(async (manager) => {
+          await this.rbacAuthorizationService.assertStrategyTargets(
+            actorGuid,
+            targetType,
+            targets,
+            manager,
           );
-          success.push(...groups.map((g) => g.guid));
-        }
+          const strategy = await manager
+            .getRepository(Strategy)
+            .findOne({ where: { guid: strategyGuid } });
+          if (!strategy) throw new NotFoundException('策略不存在');
+          const groups = await manager
+            .getRepository(DeviceGroup)
+            .find({ where: { guid: In(targets) } });
+          const existingGuids = new Set(groups.map((group) => group.guid));
+          const assignedGroups = groups.filter(
+            (group) => group.strategyGuid === strategyGuid,
+          );
+          const assignedGuids = new Set(
+            assignedGroups.map((group) => group.guid),
+          );
+          for (const targetGuid of targets) {
+            if (!existingGuids.has(targetGuid)) {
+              errors.push({ target_guid: targetGuid, reason: '设备组不存在' });
+            } else if (!assignedGuids.has(targetGuid)) {
+              errors.push({
+                target_guid: targetGuid,
+                reason: '设备组未绑定该策略',
+              });
+            }
+          }
+          if (assignedGroups.length > 0) {
+            const result = await manager.update(
+              DeviceGroup,
+              {
+                guid: In(assignedGroups.map((group) => group.guid)),
+                strategyGuid,
+              },
+              { strategyGuid: null },
+            );
+            if (result.affected !== assignedGroups.length)
+              throw new ConflictException('设备组信息已发生变化，请重试');
+            success.push(...assignedGroups.map((group) => group.guid));
+          }
+        });
         break;
       }
       default:
@@ -314,7 +541,65 @@ export class StrategyService {
     return { success, errors };
   }
 
-  async getStrategyAssignments(guid: string, query: AssignmentQueryDto) {
+  private async updateAuthorizedDevices(
+    actorGuid: string,
+    deviceUuids: string[],
+    scope: PermissionScope,
+    update: Partial<Peer>,
+    expectedStrategyGuid?: string,
+  ): Promise<void> {
+    const concurrentChange = new ConflictException(
+      '设备信息已发生变化，请重试',
+    );
+    try {
+      await this.peerRepository.manager.transaction(async (manager) => {
+        const result = await manager.update(
+          Peer,
+          {
+            uuid: In(deviceUuids),
+            ...(scope.global
+              ? {}
+              : { deviceGroupGuid: In([...scope.deviceGroupGuids]) }),
+            ...(expectedStrategyGuid === undefined
+              ? {}
+              : { strategyGuid: expectedStrategyGuid }),
+          },
+          update,
+        );
+        if (result.affected !== deviceUuids.length) {
+          throw concurrentChange;
+        }
+      });
+    } catch (error) {
+      if (error === concurrentChange) {
+        await this.rbacAuthorizationService.assertStrategyTargets(
+          actorGuid,
+          'device',
+          deviceUuids,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async getStrategyAssignments(
+    guid: string,
+    query: AssignmentQueryDto,
+    actorGuid: string,
+  ) {
+    const { target_type, current, pageSize } = query;
+    const skip = (current - 1) * pageSize;
+    const scope = await this.rbacAuthorizationService.requirePermission(
+      actorGuid,
+      'strategies.assign',
+    );
+    if (target_type === 'user') {
+      await this.rbacAuthorizationService.assertStrategyTargets(
+        actorGuid,
+        'user',
+        [],
+      );
+    }
     const strategy = await this.strategyRepository.findOne({
       where: { guid },
     });
@@ -322,59 +607,82 @@ export class StrategyService {
       throw new NotFoundException('策略不存在');
     }
 
-    const { target_type, current, pageSize } = query;
-    const skip = (current - 1) * pageSize;
-
     switch (target_type) {
       case 'device': {
-        const [peers, total] = await this.peerRepository.findAndCount({
-          where: { strategyGuid: guid },
-          select: ['uuid', 'id', 'status'],
-          skip,
-          take: pageSize,
-          order: { id: 'ASC' },
-        });
+        let queryBuilder = this.peerRepository
+          .createQueryBuilder('peer')
+          .where('peer.strategyGuid = :strategyGuid', { strategyGuid: guid })
+          .select(['peer.uuid', 'peer.id']);
+        if (!scope.global) {
+          queryBuilder = scope.deviceGroupGuids.size
+            ? queryBuilder.andWhere(
+                'peer.deviceGroupGuid IN (:...deviceGroupGuids)',
+                { deviceGroupGuids: [...scope.deviceGroupGuids] },
+              )
+            : queryBuilder.andWhere('1 = 0');
+        }
+        const [peers, total] = await queryBuilder
+          .orderBy('peer.id', 'ASC')
+          .skip(skip)
+          .take(pageSize)
+          .getManyAndCount();
         return {
           data: peers.map((p) => ({
             uuid: p.uuid,
             id: p.id,
-            status: p.status,
           })),
           total,
         };
       }
       case 'user': {
+        const actor =
+          await this.rbacAuthorizationService.getCurrentUser(actorGuid);
         const [users, total] = await this.userRepository.findAndCount({
-          where: { strategyGuid: guid },
-          select: ['guid', 'username', 'email', 'status', 'isAdmin'],
+          where: actor.isAdmin
+            ? { strategyGuid: guid }
+            : { strategyGuid: guid, isAdmin: false },
+          select: ['guid', 'username', 'displayName'],
           skip,
           take: pageSize,
           order: { username: 'ASC' },
         });
+        const protection =
+          await this.rbacAuthorizationService.getEffectiveProtectionMap(
+            users.map((user) => user.guid),
+          );
         return {
           data: users.map((u) => ({
             guid: u.guid,
-            username: u.username,
-            email: u.email,
-            status: u.status,
-            is_admin: u.isAdmin,
+            name: u.displayName || u.username,
+            is_protected: protection.get(u.guid) === true,
           })),
           total,
         };
       }
       case 'device_group': {
-        const [groups, total] = await this.deviceGroupRepository.findAndCount({
-          where: { strategyGuid: guid },
-          select: ['guid', 'name', 'note'],
-          skip,
-          take: pageSize,
-          order: { name: 'ASC' },
-        });
+        let queryBuilder = this.deviceGroupRepository
+          .createQueryBuilder('deviceGroup')
+          .where('deviceGroup.strategyGuid = :strategyGuid', {
+            strategyGuid: guid,
+          })
+          .select(['deviceGroup.guid', 'deviceGroup.name']);
+        if (!scope.global) {
+          queryBuilder = scope.deviceGroupGuids.size
+            ? queryBuilder.andWhere(
+                'deviceGroup.guid IN (:...deviceGroupGuids)',
+                { deviceGroupGuids: [...scope.deviceGroupGuids] },
+              )
+            : queryBuilder.andWhere('1 = 0');
+        }
+        const [groups, total] = await queryBuilder
+          .orderBy('deviceGroup.name', 'ASC')
+          .skip(skip)
+          .take(pageSize)
+          .getManyAndCount();
         return {
           data: groups.map((g) => ({
             guid: g.guid,
             name: g.name,
-            note: g.note || '',
           })),
           total,
         };

--- a/src/modules/update-check/update-check.module.ts
+++ b/src/modules/update-check/update-check.module.ts
@@ -23,6 +23,7 @@ import { NexusToken } from '../nexus/entities/nexus-token.entity';
 import { ActiveConnection } from '../heartbeat/entities/active-connection.entity';
 import { UpdateCheckController } from './update-check.controller';
 import { UpdateCheckService } from './update-check.service';
+import { AdminGuard } from '../../common/guards/admin.guard';
 
 /**
  * 更新检查模块
@@ -55,7 +56,7 @@ import { UpdateCheckService } from './update-check.service';
     ]),
   ],
   controllers: [UpdateCheckController],
-  providers: [UpdateCheckService],
+  providers: [UpdateCheckService, AdminGuard],
   exports: [UpdateCheckService],
 })
 export class UpdateCheckModule {}

--- a/src/modules/user-group/user-group.controller.ts
+++ b/src/modules/user-group/user-group.controller.ts
@@ -10,9 +10,9 @@ import {
   Post,
   Put,
   Query,
-  UseGuards,
 } from '@nestjs/common';
-import { AdminGuard } from '../../common/guards/admin.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
 import {
   CreateUserGroupDto,
   UpdateUserGroupDto,
@@ -22,22 +22,24 @@ import {
 import { UserGroupService } from './user-group.service';
 
 @Controller('user-groups')
-@UseGuards(AdminGuard)
 export class UserGroupController {
   constructor(private readonly userGroupService: UserGroupService) {}
 
   @Get()
+  @RequirePermission('user_groups.view')
   getGroups(@Query() query: UserGroupQueryDto) {
     return this.userGroupService.getGroups(query);
   }
 
   @Post()
+  @RequirePermission('user_groups.create')
   @HttpCode(HttpStatus.OK)
   createGroup(@Body() dto: CreateUserGroupDto) {
     return this.userGroupService.createGroup(dto);
   }
 
   @Put(':guid')
+  @RequirePermission('user_groups.edit')
   @HttpCode(HttpStatus.OK)
   updateGroup(
     @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
@@ -47,14 +49,17 @@ export class UserGroupController {
   }
 
   @Delete(':guid')
+  @RequirePermission('user_groups.delete')
   @HttpCode(HttpStatus.OK)
   deleteGroup(
     @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
+    @CurrentUser('id') actorGuid: string,
   ) {
-    return this.userGroupService.deleteGroup(guid);
+    return this.userGroupService.deleteGroup(guid, actorGuid);
   }
 
   @Get(':guid/users')
+  @RequirePermission('user_groups.view')
   getGroupUsers(
     @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
     @Query() query: UserGroupQueryDto,
@@ -63,11 +68,13 @@ export class UserGroupController {
   }
 
   @Post(':guid/users')
+  @RequirePermission('user_groups.membership')
   @HttpCode(HttpStatus.OK)
   moveUsers(
     @Param('guid', new ParseUUIDPipe({ version: '4' })) guid: string,
     @Body() dto: UserGroupMembersDto,
+    @CurrentUser('id') actorGuid: string,
   ) {
-    return this.userGroupService.moveUsers(guid, dto.user_guids);
+    return this.userGroupService.moveUsers(guid, dto.user_guids, actorGuid);
   }
 }

--- a/src/modules/user-group/user-group.integration.spec.ts
+++ b/src/modules/user-group/user-group.integration.spec.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { randomUUID } from 'node:crypto';
 import { Server } from 'node:http';
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   INestApplication,
@@ -13,8 +14,9 @@ import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { DataSource, Repository } from 'typeorm';
 import request from 'supertest';
-import { AdminGuard } from '../../common/guards/admin.guard';
+import * as bcrypt from 'bcryptjs';
 import { DatabaseInitService } from '../../database/database-init.service';
+import { AdminGuard } from '../../common/guards/admin.guard';
 import { AddressBookPeerTag } from '../address-book/entities/address-book-peer-tag.entity';
 import { AddressBookPeer } from '../address-book/entities/address-book-peer.entity';
 import {
@@ -31,6 +33,7 @@ import { AddressBookRuleService } from '../address-book/services/address-book-ru
 import { DeviceGroupUserPermission } from '../device-group/entities/device-group-user-permission.entity';
 import { UserUserPermission } from '../device-group/entities/user-user-permission.entity';
 import { AuthService } from '../auth/services/auth.service';
+import { LoginSession } from '../auth/entities/login-session.entity';
 import { LdapService } from '../ldap/ldap.service';
 import { OidcService } from '../oidc/services/oidc.service';
 import { Strategy } from '../strategy/entities/strategy.entity';
@@ -45,6 +48,8 @@ import { UserGroupMembersDto, UserGroupQueryDto } from './dto/user-group.dto';
 import { UserGroup } from './entities/user-group.entity';
 import { UserGroupController } from './user-group.controller';
 import { UserGroupService } from './user-group.service';
+import { REQUIRE_PERMISSION_KEY } from '../rbac/decorators/require-permission.decorator';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 interface UserGroupHttpBody {
   guid: string;
@@ -75,6 +80,11 @@ describe('User group integration', () => {
   let permissionService: AddressBookPermissionService;
   let ruleService: AddressBookRuleService;
   let userService: UserService;
+  let authorizationService: {
+    assertUsersMutation: jest.Mock;
+    getEffectiveProtectionMap: jest.Mock;
+    isProtectedUser: jest.Mock;
+  };
 
   beforeEach(async () => {
     dataSource = new DataSource({
@@ -87,6 +97,7 @@ describe('User group integration', () => {
         UserGroup,
         User,
         UserToken,
+        LoginSession,
         Strategy,
         AddressBook,
         AddressBookPeer,
@@ -101,12 +112,18 @@ describe('User group integration', () => {
     userRepository = dataSource.getRepository(User);
     ruleRepository = dataSource.getRepository(AddressBookRule);
     addressBookRepository = dataSource.getRepository(AddressBook);
+    authorizationService = {
+      assertUsersMutation: jest.fn().mockResolvedValue(undefined),
+      getEffectiveProtectionMap: jest.fn().mockResolvedValue(new Map()),
+      isProtectedUser: jest.fn().mockResolvedValue(false),
+    };
 
     userGroupService = new UserGroupService(
       groupRepository,
       userRepository,
       ruleRepository,
       dataSource,
+      authorizationService as unknown as RbacAuthorizationService,
     );
     permissionService = new AddressBookPermissionService(
       addressBookRepository,
@@ -117,6 +134,7 @@ describe('User group integration', () => {
       ruleRepository,
       addressBookRepository,
       userRepository,
+      groupRepository,
       permissionService,
       userGroupService,
       dataSource,
@@ -142,6 +160,9 @@ describe('User group integration', () => {
         getWebAuthnSettings: () =>
           Promise.resolve({ enabled: true, rpName: 'RustDesk Console' }),
       } as unknown as GeneralSettingsService,
+      dataSource,
+      authorizationService as unknown as RbacAuthorizationService,
+      dataSource.getRepository(LoginSession),
     );
   });
 
@@ -268,7 +289,11 @@ describe('User group integration', () => {
     const alice = await createUser('alice', defaultGroup.guid);
     const bob = await createUser('bob', defaultGroup.guid);
     await expect(
-      userGroupService.moveUsers(operations.guid, [alice.guid, randomUUID()]),
+      userGroupService.moveUsers(
+        operations.guid,
+        [alice.guid, randomUUID()],
+        'actor',
+      ),
     ).rejects.toThrow('一个或多个用户不存在');
     expect(
       (await userRepository.findOneByOrFail({ guid: alice.guid }))
@@ -276,7 +301,11 @@ describe('User group integration', () => {
     ).toBe(defaultGroup.guid);
 
     await expect(
-      userGroupService.moveUsers(operations.guid, [alice.guid, bob.guid]),
+      userGroupService.moveUsers(
+        operations.guid,
+        [alice.guid, bob.guid],
+        'actor',
+      ),
     ).resolves.toMatchObject({ moved_user_count: 2 });
 
     const groups = await userGroupService.getGroups({
@@ -346,6 +375,122 @@ describe('User group integration', () => {
     ).toBe(selectedGroup.guid);
   });
 
+  it('updates user security as one strict batch', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const alice = await createUser('security-alice', defaultGroup.guid);
+    const bob = await createUser('security-bob', defaultGroup.guid);
+
+    await expect(
+      userService.batchUpdateSecurity(
+        {
+          user_guids: [alice.guid, alice.guid, bob.guid],
+          tfa_enforce: true,
+          email_verification: true,
+        },
+        alice.guid,
+      ),
+    ).resolves.toEqual({ message: '批量安全设置已更新' });
+
+    for (const guid of [alice.guid, bob.guid]) {
+      const info = (
+        await userRepository.findOneByOrFail({ guid })
+      ).getUserInfo();
+      expect(info.other?.tfa_enforce).toBe(true);
+      expect(info.email_verification).toBe(true);
+    }
+
+    await expect(
+      userService.batchUpdateSecurity(
+        {
+          user_guids: [alice.guid, randomUUID()],
+          tfa_enforce: false,
+        },
+        alice.guid,
+      ),
+    ).rejects.toThrow('用户不存在');
+    expect(
+      (await userRepository.findOneByOrFail({ guid: alice.guid })).getUserInfo()
+        .other?.tfa_enforce,
+    ).toBe(true);
+  });
+
+  it('changes a password and atomically revokes tokens and pending sessions', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const user = await createUser('password-user', defaultGroup.guid);
+    user.password = await bcrypt.hash('old-password', 10);
+    await userRepository.save(user);
+    await dataSource.getRepository(UserToken).save({
+      guid: randomUUID(),
+      userGuid: user.guid,
+      jti: randomUUID(),
+      expiresAt: new Date(Date.now() + 60_000),
+      isRevoked: false,
+    });
+    await dataSource.getRepository(LoginSession).save({
+      guid: randomUUID(),
+      userGuid: user.guid,
+      method: 'tfa',
+      expiresAt: new Date(Date.now() + 60_000),
+      used: false,
+    });
+
+    await userService.changePassword(user.guid, {
+      current_password: 'old-password',
+      new_password: 'new-password',
+    });
+
+    expect(
+      (
+        await dataSource
+          .getRepository(UserToken)
+          .findOneBy({ userGuid: user.guid })
+      )?.isRevoked,
+    ).toBe(true);
+    expect(
+      await dataSource.getRepository(LoginSession).countBy({
+        userGuid: user.guid,
+        used: false,
+      }),
+    ).toBe(0);
+    const reloaded = await userRepository
+      .createQueryBuilder('user')
+      .where('user.guid = :guid', { guid: user.guid })
+      .addSelect('user.password')
+      .getOneOrFail();
+    expect(await bcrypt.compare('new-password', reloaded.password)).toBe(true);
+  });
+
+  it('rolls back every user security change when a later update fails', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const first = await createUser('security-first', defaultGroup.guid);
+    const second = await createUser('security-second', defaultGroup.guid);
+    await dataSource.query(
+      `CREATE TRIGGER fail_second_security_update
+       BEFORE UPDATE OF info ON users
+       WHEN OLD.guid = '${second.guid}'
+       BEGIN
+         SELECT RAISE(ABORT, 'forced security update failure');
+       END`,
+    );
+
+    await expect(
+      userService.batchUpdateSecurity(
+        {
+          user_guids: [first.guid, second.guid],
+          tfa_enforce: true,
+        },
+        first.guid,
+      ),
+    ).rejects.toThrow('forced security update failure');
+
+    for (const guid of [first.guid, second.guid]) {
+      expect(
+        (await userRepository.findOneByOrFail({ guid })).getUserInfo().other
+          ?.tfa_enforce,
+      ).toBeUndefined();
+    }
+  });
+
   it('assigns the default group in admin seed, registration, LDAP JIT, and OIDC JIT paths', async () => {
     const defaultGroup = await userGroupService.initializeStorage();
     const authService = new AuthService(
@@ -366,6 +511,7 @@ describe('User group integration', () => {
       undefined as never,
       undefined as never,
       userGroupService,
+      dataSource,
     );
     const ldapService = new LdapService(
       userRepository,
@@ -468,7 +614,7 @@ describe('User group integration', () => {
     );
 
     await expect(
-      userGroupService.deleteGroup(temporaryGroup.guid),
+      userGroupService.deleteGroup(temporaryGroup.guid, 'actor'),
     ).resolves.toEqual({
       message: '用户组删除成功',
       moved_user_count: 1,
@@ -487,8 +633,59 @@ describe('User group integration', () => {
       }),
     ).toBe(0);
     await expect(
-      userGroupService.deleteGroup(defaultGroup.guid),
+      userGroupService.deleteGroup(defaultGroup.guid, 'actor'),
     ).rejects.toThrow('默认用户组不能删除');
+  });
+
+  it('protects administrator members on move and group deletion paths', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const protectedGroup = await userGroupService.createGroup({
+      name: 'Protected administrators',
+    });
+    const administrator = await createUser(
+      'protected-administrator',
+      protectedGroup.guid,
+    );
+    administrator.isAdmin = true;
+    await userRepository.save(administrator);
+
+    authorizationService.assertUsersMutation.mockRejectedValueOnce(
+      new ForbiddenException('不能修改超级管理员'),
+    );
+    await expect(
+      userGroupService.moveUsers(
+        defaultGroup.guid,
+        [administrator.guid],
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(
+      (await userRepository.findOneByOrFail({ guid: administrator.guid }))
+        .userGroupGuid,
+    ).toBe(protectedGroup.guid);
+
+    authorizationService.assertUsersMutation.mockRejectedValueOnce(
+      new ForbiddenException('不能修改超级管理员'),
+    );
+    await expect(
+      userGroupService.deleteGroup(protectedGroup.guid, 'actor'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(
+      await groupRepository.findOneBy({ guid: protectedGroup.guid }),
+    ).not.toBeNull();
+
+    expect(authorizationService.assertUsersMutation).toHaveBeenNthCalledWith(
+      1,
+      'actor',
+      [administrator.guid],
+      'user_groups.membership',
+    );
+    expect(authorizationService.assertUsersMutation).toHaveBeenNthCalledWith(
+      2,
+      'actor',
+      [administrator.guid],
+      'user_groups.delete',
+    );
   });
 
   it('rolls back member and rule changes when group deletion fails', async () => {
@@ -515,7 +712,7 @@ describe('User group integration', () => {
     );
 
     await expect(
-      userGroupService.deleteGroup(protectedGroup.guid),
+      userGroupService.deleteGroup(protectedGroup.guid, 'actor'),
     ).rejects.toThrow('forced delete failure');
     expect(
       (await userRepository.findOneByOrFail({ guid: member.guid }))
@@ -546,6 +743,31 @@ describe('User group integration', () => {
     await createRule(addressBook.guid, null, null, ShareRule.READ_WRITE);
 
     await expect(
+      ruleService.getWebSharedAddressBook(addressBook.guid, owner.guid),
+    ).resolves.toMatchObject({
+      guid: addressBook.guid,
+      rule: ShareRule.FULL_CONTROL,
+      is_owner: true,
+    });
+    await expect(
+      ruleService.getWebSharedAddressBook(addressBook.guid, member.guid),
+    ).resolves.toMatchObject({
+      guid: addressBook.guid,
+      rule: ShareRule.FULL_CONTROL,
+      is_owner: false,
+    });
+    const everyoneAccess = await ruleService.getWebSharedAddressBook(
+      addressBook.guid,
+      outsider.guid,
+    );
+    expect(everyoneAccess).toMatchObject({
+      guid: addressBook.guid,
+      rule: ShareRule.READ_WRITE,
+      is_owner: false,
+    });
+    expect(everyoneAccess).not.toHaveProperty('info');
+
+    await expect(
       permissionService.checkAddressBookAccess(
         addressBook.guid,
         owner.guid,
@@ -574,7 +796,7 @@ describe('User group integration', () => {
       ),
     ).rejects.toBeInstanceOf(ForbiddenException);
 
-    await userGroupService.moveUsers(guests.guid, [member.guid]);
+    await userGroupService.moveUsers(guests.guid, [member.guid], 'actor');
     await expect(
       permissionService.checkAddressBookAccess(
         addressBook.guid,
@@ -589,6 +811,108 @@ describe('User group integration', () => {
         ShareRule.READ_WRITE,
       ),
     ).resolves.toMatchObject({ guid: addressBook.guid });
+  });
+
+  it('deletes address-book rules as one strict batch', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const owner = await createUser('rule-delete-owner', defaultGroup.guid);
+    const firstBook = await createAddressBook(owner.guid, 'First delete book');
+    const secondBook = await createAddressBook(
+      owner.guid,
+      'Second delete book',
+    );
+    const first = await createRule(firstBook.guid, null, null, ShareRule.READ);
+    const second = await createRule(
+      secondBook.guid,
+      null,
+      null,
+      ShareRule.READ,
+    );
+
+    await expect(
+      ruleService.deleteRules(['not-a-uuid'], owner.guid),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(await ruleRepository.findOneBy({ guid: first.guid })).not.toBeNull();
+
+    await expect(
+      ruleService.deleteRules([first.guid, randomUUID()], owner.guid),
+    ).rejects.toThrow('未找到任何规则');
+    expect(await ruleRepository.findOneBy({ guid: first.guid })).not.toBeNull();
+
+    await expect(
+      ruleService.deleteRules(
+        [first.guid, first.guid, second.guid],
+        owner.guid,
+      ),
+    ).resolves.toEqual({ message: '删除成功' });
+    expect(await ruleRepository.findOneBy({ guid: first.guid })).toBeNull();
+    expect(await ruleRepository.findOneBy({ guid: second.guid })).toBeNull();
+  });
+
+  it('checks every address-book ACL before deleting any rule', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const owner = await createUser('rule-delete-authorized', defaultGroup.guid);
+    const otherOwner = await createUser(
+      'rule-delete-unauthorized',
+      defaultGroup.guid,
+    );
+    const authorizedBook = await createAddressBook(owner.guid);
+    const unauthorizedBook = await createAddressBook(otherOwner.guid);
+    const authorizedRule = await createRule(
+      authorizedBook.guid,
+      null,
+      null,
+      ShareRule.READ,
+    );
+    const unauthorizedRule = await createRule(
+      unauthorizedBook.guid,
+      null,
+      null,
+      ShareRule.READ,
+    );
+
+    await expect(
+      ruleService.deleteRules(
+        [authorizedRule.guid, unauthorizedRule.guid],
+        owner.guid,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(
+      await ruleRepository.findOneBy({ guid: authorizedRule.guid }),
+    ).not.toBeNull();
+    expect(
+      await ruleRepository.findOneBy({ guid: unauthorizedRule.guid }),
+    ).not.toBeNull();
+  });
+
+  it('rolls back every address-book rule when a later delete fails', async () => {
+    const defaultGroup = await userGroupService.initializeStorage();
+    const owner = await createUser('rule-delete-rollback', defaultGroup.guid);
+    const firstBook = await createAddressBook(owner.guid);
+    const secondBook = await createAddressBook(owner.guid);
+    const first = await createRule(firstBook.guid, null, null, ShareRule.READ);
+    const second = await createRule(
+      secondBook.guid,
+      null,
+      null,
+      ShareRule.READ,
+    );
+    await dataSource.query(
+      `CREATE TRIGGER fail_second_rule_delete
+       BEFORE DELETE ON address_book_rules
+       WHEN OLD.guid = '${second.guid}'
+       BEGIN
+         SELECT RAISE(ABORT, 'forced rule delete failure');
+       END`,
+    );
+
+    await expect(
+      ruleService.deleteRules([first.guid, second.guid], owner.guid),
+    ).rejects.toThrow('forced rule delete failure');
+    expect(await ruleRepository.findOneBy({ guid: first.guid })).not.toBeNull();
+    expect(
+      await ruleRepository.findOneBy({ guid: second.guid }),
+    ).not.toBeNull();
   });
 
   it('validates group rules and aggregates shared address books without duplicates', async () => {
@@ -654,7 +978,7 @@ describe('User group integration', () => {
       data: [{ guid: addressBook.guid, rule: ShareRule.READ }],
     });
 
-    await userGroupService.moveUsers(guests.guid, [member.guid]);
+    await userGroupService.moveUsers(guests.guid, [member.guid], 'actor');
     const movedMemberBooks = await ruleService.getSharedAddressBooks(
       member.guid,
       { current: 1, pageSize: 20 },
@@ -663,6 +987,7 @@ describe('User group integration', () => {
   });
 
   it('separates private, shared, and protocol address book profiles', async () => {
+    const sharedPassword = 'managed-shared-secret';
     const defaultGroup = await userGroupService.initializeStorage();
     const operators = await userGroupService.createGroup({
       name: 'Address book operators',
@@ -677,6 +1002,8 @@ describe('User group integration', () => {
     const sharedGuid = await ruleService.addSharedAddressBook(
       'Managed shared',
       owner.guid,
+      undefined,
+      sharedPassword,
     );
     await ruleService.createRule(
       {
@@ -708,6 +1035,8 @@ describe('User group integration', () => {
       [legacyShared.guid, true],
       [sharedGuid, true],
     ]);
+    expect(JSON.stringify(ownerSharedProfiles)).not.toContain(sharedPassword);
+    expect(ownerSharedProfiles.data.some((book) => 'info' in book)).toBe(false);
 
     const memberSharedProfiles = await ruleService.getWebSharedAddressBooks(
       member.guid,
@@ -719,6 +1048,28 @@ describe('User group integration', () => {
       [legacyShared.guid, false],
       [sharedGuid, false],
     ]);
+    expect(JSON.stringify(memberSharedProfiles)).not.toContain(sharedPassword);
+    expect(memberSharedProfiles.data.some((book) => 'info' in book)).toBe(
+      false,
+    );
+
+    const memberSharedProfile = await ruleService.getWebSharedAddressBook(
+      sharedGuid,
+      member.guid,
+    );
+    expect(memberSharedProfile).toMatchObject({
+      guid: sharedGuid,
+      name: 'Managed shared',
+      rule: ShareRule.READ_WRITE,
+      is_owner: false,
+    });
+    expect(memberSharedProfile).not.toHaveProperty('info');
+    expect(JSON.stringify(memberSharedProfile)).not.toContain(sharedPassword);
+
+    const outsider = await createUser('profile-outsider', defaultGroup.guid);
+    await expect(
+      ruleService.getWebSharedAddressBook(sharedGuid, outsider.guid),
+    ).rejects.toThrow('共享地址簿不存在');
 
     const ownerProtocolProfiles = await ruleService.getSharedAddressBooks(
       owner.guid,
@@ -729,6 +1080,9 @@ describe('User group integration', () => {
       sharedGuid,
       privateGuid,
     ]);
+    expect(
+      ownerProtocolProfiles.data.find((book) => book.guid === sharedGuid),
+    ).toMatchObject({ info: { password: sharedPassword } });
 
     await ruleService.updateCustomAddressBook(
       privateGuid,
@@ -748,13 +1102,7 @@ describe('User group integration', () => {
     ).toBeNull();
   });
 
-  it('publishes validated DTOs and protects every user-group route with AdminGuard', async () => {
-    const guards = Reflect.getMetadata(
-      GUARDS_METADATA,
-      UserGroupController,
-    ) as unknown[];
-    expect(guards).toContain(AdminGuard);
-
+  it('publishes validated DTOs and declares permissions on every admin route', async () => {
     const validLegacyCreate = plainToInstance(CreateUserDto, {
       name: 'new-user',
       password: 'test-password',
@@ -799,20 +1147,43 @@ describe('User group integration', () => {
     });
     expect(await validate(invalidAddressBookDelete)).not.toHaveLength(0);
 
-    for (const methodName of [
-      'addSharedAddressBook',
-      'updateSharedAddressBook',
-      'deleteSharedAddressBooks',
-      'addRule',
-      'updateRule',
-      'deleteRules',
-    ] as const) {
-      const method = AddressBookController.prototype[methodName];
-      const methodGuards = Reflect.getMetadata(
-        GUARDS_METADATA,
-        method,
-      ) as unknown[];
-      expect(methodGuards).toContain(AdminGuard);
+    const expectedPermissions = {
+      addSharedAddressBook: ['address_books.share'],
+      updateSharedAddressBook: ['address_books.edit'],
+      deleteSharedAddressBooks: ['address_books.edit'],
+      addRule: ['address_books.share'],
+      updateRule: ['address_books.share'],
+      deleteRules: ['address_books.share'],
+    } as const;
+    for (const [methodName, permissions] of Object.entries(
+      expectedPermissions,
+    )) {
+      expect(
+        Reflect.getMetadata(
+          REQUIRE_PERMISSION_KEY,
+          AddressBookController.prototype[
+            methodName as keyof AddressBookController
+          ],
+        ),
+      ).toEqual(permissions);
+    }
+
+    const authenticatedSelfServiceMethods = [
+      'getCustomAddressBooks',
+      'addCustomAddressBook',
+      'updateCustomAddressBook',
+      'deleteCustomAddressBooks',
+      'getWebSharedAddressBooks',
+      'getWebSharedAddressBook',
+    ] as const;
+    for (const methodName of authenticatedSelfServiceMethods) {
+      const handler = AddressBookController.prototype[methodName];
+      expect(
+        Reflect.getMetadata(REQUIRE_PERMISSION_KEY, handler),
+      ).toBeUndefined();
+      expect(Reflect.getMetadata(GUARDS_METADATA, handler) ?? []).not.toContain(
+        AdminGuard,
+      );
     }
   });
 
@@ -820,14 +1191,8 @@ describe('User group integration', () => {
     await userGroupService.initializeStorage();
     const moduleRef = await Test.createTestingModule({
       controllers: [UserGroupController],
-      providers: [
-        { provide: UserGroupService, useValue: userGroupService },
-        AdminGuard,
-      ],
-    })
-      .overrideGuard(AdminGuard)
-      .useValue({ canActivate: () => true })
-      .compile();
+      providers: [{ provide: UserGroupService, useValue: userGroupService }],
+    }).compile();
     const app: INestApplication = moduleRef.createNestApplication();
     app.setGlobalPrefix('api');
     app.useGlobalPipes(

--- a/src/modules/user-group/user-group.module.ts
+++ b/src/modules/user-group/user-group.module.ts
@@ -5,9 +5,13 @@ import { User } from '../user/entities/user.entity';
 import { UserGroup } from './entities/user-group.entity';
 import { UserGroupController } from './user-group.controller';
 import { UserGroupService } from './user-group.service';
+import { RbacModule } from '../rbac/rbac.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserGroup, User, AddressBookRule])],
+  imports: [
+    TypeOrmModule.forFeature([UserGroup, User, AddressBookRule]),
+    RbacModule,
+  ],
   controllers: [UserGroupController],
   providers: [UserGroupService],
   exports: [UserGroupService],

--- a/src/modules/user-group/user-group.service.ts
+++ b/src/modules/user-group/user-group.service.ts
@@ -16,6 +16,7 @@ import {
   UserGroupQueryDto,
 } from './dto/user-group.dto';
 import { UserGroup } from './entities/user-group.entity';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 const DEFAULT_USER_GROUP_NAME = 'Default';
 
@@ -33,6 +34,7 @@ export class UserGroupService {
     @InjectRepository(AddressBookRule)
     private readonly ruleRepository: Repository<AddressBookRule>,
     private readonly dataSource: DataSource,
+    private readonly authorizationService: RbacAuthorizationService,
   ) {}
 
   async initializeStorage(): Promise<UserGroup> {
@@ -223,7 +225,18 @@ export class UserGroupService {
     }
   }
 
-  async deleteGroup(guid: string) {
+  async deleteGroup(guid: string, actorGuid: string) {
+    const affectedUsers = await this.userRepository.find({
+      where: { userGroupGuid: guid },
+      select: ['guid'],
+    });
+    if (affectedUsers.length) {
+      await this.authorizationService.assertUsersMutation(
+        actorGuid,
+        affectedUsers.map((user) => user.guid),
+        'user_groups.delete',
+      );
+    }
     return this.dataSource.transaction(async (manager) => {
       const groupRepository = manager.getRepository(UserGroup);
       const userRepository = manager.getRepository(User);
@@ -243,6 +256,17 @@ export class UserGroupService {
       if (!defaultGroup) {
         throw new BadRequestException('默认用户组不存在');
       }
+
+      const currentUsers = await userRepository.find({
+        where: { userGroupGuid: guid },
+        select: ['guid'],
+      });
+      await this.authorizationService.assertUsersMutation(
+        actorGuid,
+        currentUsers.map((user) => user.guid),
+        'user_groups.delete',
+        manager,
+      );
 
       const movedUsers = await userRepository.update(
         { userGroupGuid: guid },
@@ -283,6 +307,10 @@ export class UserGroupService {
       .take(pageSize)
       .getManyAndCount();
 
+    const protection =
+      await this.authorizationService.getEffectiveProtectionMap(
+        users.map((user) => user.guid),
+      );
     return {
       data: users.map((user) => ({
         guid: user.guid,
@@ -291,6 +319,7 @@ export class UserGroupService {
         note: user.note || '',
         status: user.status,
         is_admin: user.isAdmin,
+        is_protected: protection.get(user.guid) === true,
         user_group_guid: group.guid,
         user_group_name: group.name,
       })),
@@ -298,7 +327,12 @@ export class UserGroupService {
     };
   }
 
-  async moveUsers(guid: string, userGuids: string[]) {
+  async moveUsers(guid: string, userGuids: string[], actorGuid: string) {
+    await this.authorizationService.assertUsersMutation(
+      actorGuid,
+      userGuids,
+      'user_groups.membership',
+    );
     const uniqueGuids = [...new Set(userGuids)];
 
     return this.dataSource.transaction(async (manager) => {
@@ -317,6 +351,15 @@ export class UserGroupService {
       if (users.length !== uniqueGuids.length) {
         throw new NotFoundException('一个或多个用户不存在');
       }
+
+      // Re-check immediately before the conditional writes so a role-based
+      // protection change cannot turn this into a partial membership update.
+      await this.authorizationService.assertUsersMutation(
+        actorGuid,
+        users.map((user) => user.guid),
+        'user_groups.membership',
+        manager,
+      );
 
       const guidsToMove = users
         .filter((user) => user.userGroupGuid !== guid)

--- a/src/modules/user/admin-user.controller.ts
+++ b/src/modules/user/admin-user.controller.ts
@@ -1,15 +1,19 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { AdminUserService } from './admin-user.service';
-import { AdminGuard } from '../../common/guards/admin.guard';
 import { AdminUserQueryDto } from './dto/admin-user.dto';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
 @Controller('admin/users')
-@UseGuards(AdminGuard)
 export class AdminUserController {
   constructor(private readonly adminUserService: AdminUserService) {}
 
   @Get()
-  async getAdminUsers(@Query() query: AdminUserQueryDto) {
-    return this.adminUserService.getAdminUsers(query);
+  @RequirePermission('users.view')
+  async getAdminUsers(
+    @Query() query: AdminUserQueryDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    return this.adminUserService.getAdminUsers(query, actorGuid);
   }
 }

--- a/src/modules/user/admin-user.service.spec.ts
+++ b/src/modules/user/admin-user.service.spec.ts
@@ -102,11 +102,7 @@ describe('AdminUserService role names', () => {
     expect(authorizationService.getCurrentUser).toHaveBeenCalledWith('actor');
     expect(assignmentRepository.find).toHaveBeenCalledTimes(1);
     expect(roleRepository.find).toHaveBeenCalledTimes(1);
-    expect(result.data[0].role_names).toEqual([
-      'Super Admin',
-      'Alpha',
-      'Zulu',
-    ]);
+    expect(result.data[0].role_names).toEqual(['Super Admin', 'Alpha', 'Zulu']);
     expect(result.data[1].role_names).toEqual([]);
   });
 

--- a/src/modules/user/admin-user.service.spec.ts
+++ b/src/modules/user/admin-user.service.spec.ts
@@ -82,7 +82,7 @@ describe('AdminUserService role names', () => {
     authorizationService.getCurrentUser.mockResolvedValue({ isAdmin: true });
     queryBuilder.getManyAndCount.mockResolvedValue([
       [
-        { guid: 'user-1', username: 'alice' },
+        { guid: 'user-1', username: 'alice', isAdmin: true },
         { guid: 'user-2', username: 'bob' },
       ] as User[],
       2,
@@ -102,7 +102,11 @@ describe('AdminUserService role names', () => {
     expect(authorizationService.getCurrentUser).toHaveBeenCalledWith('actor');
     expect(assignmentRepository.find).toHaveBeenCalledTimes(1);
     expect(roleRepository.find).toHaveBeenCalledTimes(1);
-    expect(result.data[0].role_names).toEqual(['Alpha', 'Zulu']);
+    expect(result.data[0].role_names).toEqual([
+      'Super Admin',
+      'Alpha',
+      'Zulu',
+    ]);
     expect(result.data[1].role_names).toEqual([]);
   });
 

--- a/src/modules/user/admin-user.service.spec.ts
+++ b/src/modules/user/admin-user.service.spec.ts
@@ -1,0 +1,158 @@
+import 'reflect-metadata';
+import { Repository } from 'typeorm';
+import { Strategy } from '../strategy/entities/strategy.entity';
+import { Role } from '../rbac/entities/role.entity';
+import { UserRoleAssignment } from '../rbac/entities/user-role-assignment.entity';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
+import { AdminUserController } from './admin-user.controller';
+import { AdminUserService } from './admin-user.service';
+import { AdminUserQueryDto } from './dto/admin-user.dto';
+import { User } from './entities/user.entity';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+type MockRepository = {
+  find: jest.Mock;
+  createQueryBuilder: jest.Mock;
+};
+
+const repository = (): MockRepository => ({
+  find: jest.fn(),
+  createQueryBuilder: jest.fn(),
+});
+
+describe('AdminUserService role names', () => {
+  const query = { current: 1, pageSize: 20 } as AdminUserQueryDto;
+  let userRepository: MockRepository;
+  let strategyRepository: MockRepository;
+  let assignmentRepository: MockRepository;
+  let roleRepository: MockRepository;
+  let queryBuilder: {
+    leftJoinAndSelect: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    skip: jest.Mock;
+    take: jest.Mock;
+    getManyAndCount: jest.Mock;
+  };
+  let authorizationService: { getCurrentUser: jest.Mock };
+  let service: AdminUserService;
+
+  beforeEach(() => {
+    userRepository = repository();
+    strategyRepository = repository();
+    assignmentRepository = repository();
+    roleRepository = repository();
+    queryBuilder = {
+      leftJoinAndSelect: jest.fn(),
+      andWhere: jest.fn(),
+      orderBy: jest.fn(),
+      skip: jest.fn(),
+      take: jest.fn(),
+      getManyAndCount: jest.fn(),
+    };
+    for (const method of [
+      queryBuilder.leftJoinAndSelect,
+      queryBuilder.andWhere,
+      queryBuilder.orderBy,
+      queryBuilder.skip,
+      queryBuilder.take,
+    ]) {
+      method.mockReturnValue(queryBuilder);
+    }
+    userRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+    strategyRepository.find.mockResolvedValue([]);
+    assignmentRepository.find.mockResolvedValue([]);
+    roleRepository.find.mockResolvedValue([]);
+    authorizationService = { getCurrentUser: jest.fn() };
+    service = new AdminUserService(
+      userRepository as unknown as Repository<User>,
+      strategyRepository as unknown as Repository<Strategy>,
+      assignmentRepository as unknown as Repository<UserRoleAssignment>,
+      roleRepository as unknown as Repository<Role>,
+      authorizationService as unknown as RbacAuthorizationService,
+    );
+  });
+
+  it('bulk aggregates stable unique role names for a current super-admin', async () => {
+    authorizationService.getCurrentUser.mockResolvedValue({ isAdmin: true });
+    queryBuilder.getManyAndCount.mockResolvedValue([
+      [
+        { guid: 'user-1', username: 'alice' },
+        { guid: 'user-2', username: 'bob' },
+      ] as User[],
+      2,
+    ]);
+    assignmentRepository.find.mockResolvedValue([
+      { userGuid: 'user-1', roleGuid: 'role-z' },
+      { userGuid: 'user-1', roleGuid: 'role-a' },
+      { userGuid: 'user-1', roleGuid: 'role-a' },
+    ] as UserRoleAssignment[]);
+    roleRepository.find.mockResolvedValue([
+      { guid: 'role-z', name: 'Zulu' },
+      { guid: 'role-a', name: 'Alpha' },
+    ] as Role[]);
+
+    const result = await service.getAdminUsers(query, 'actor');
+
+    expect(authorizationService.getCurrentUser).toHaveBeenCalledWith('actor');
+    expect(assignmentRepository.find).toHaveBeenCalledTimes(1);
+    expect(roleRepository.find).toHaveBeenCalledTimes(1);
+    expect(result.data[0].role_names).toEqual(['Alpha', 'Zulu']);
+    expect(result.data[1].role_names).toEqual([]);
+  });
+
+  it('returns role names to a delegated caller authorized to view users', async () => {
+    authorizationService.getCurrentUser.mockResolvedValue({ isAdmin: false });
+    queryBuilder.getManyAndCount.mockResolvedValue([
+      [{ guid: 'user-1', username: 'alice' }] as User[],
+      1,
+    ]);
+    assignmentRepository.find.mockResolvedValue([
+      { userGuid: 'user-1', roleGuid: 'role-delegated' },
+    ] as UserRoleAssignment[]);
+    roleRepository.find.mockResolvedValue([
+      { guid: 'role-delegated', name: 'Delegated Role' },
+    ] as Role[]);
+
+    const result = await service.getAdminUsers(query, 'delegated-actor');
+
+    expect(result.data[0].role_names).toEqual(['Delegated Role']);
+    expect(result.data[0]).toHaveProperty('is_protected', false);
+    expect(assignmentRepository.find).toHaveBeenCalledTimes(1);
+    expect(roleRepository.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty page without assignment or role queries', async () => {
+    authorizationService.getCurrentUser.mockResolvedValue({ isAdmin: true });
+    queryBuilder.getManyAndCount.mockResolvedValue([[], 0]);
+
+    await expect(service.getAdminUsers(query, 'actor')).resolves.toEqual({
+      data: [],
+      total: 0,
+    });
+    expect(assignmentRepository.find).not.toHaveBeenCalled();
+    expect(roleRepository.find).not.toHaveBeenCalled();
+    expect(strategyRepository.find).not.toHaveBeenCalled();
+  });
+});
+
+describe('AdminUserController', () => {
+  it('passes the current actor guid to the service', async () => {
+    const adminUserService = {
+      getAdminUsers: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+    };
+    const controller = new AdminUserController(
+      adminUserService as unknown as AdminUserService,
+    );
+    const query = { current: 1, pageSize: 20 } as AdminUserQueryDto;
+
+    await controller.getAdminUsers(query, 'actor');
+
+    expect(adminUserService.getAdminUsers).toHaveBeenCalledWith(query, 'actor');
+  });
+});

--- a/src/modules/user/admin-user.service.ts
+++ b/src/modules/user/admin-user.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { Strategy } from '../strategy/entities/strategy.entity';
 import { AdminUserQueryDto } from './dto/admin-user.dto';
+import { UserRoleAssignment } from '../rbac/entities/user-role-assignment.entity';
+import { Role } from '../rbac/entities/role.entity';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 
 @Injectable()
 export class AdminUserService {
@@ -12,11 +15,18 @@ export class AdminUserService {
     private userRepository: Repository<User>,
     @InjectRepository(Strategy)
     private strategyRepository: Repository<Strategy>,
+    @InjectRepository(UserRoleAssignment)
+    private assignmentRepository: Repository<UserRoleAssignment>,
+    @InjectRepository(Role)
+    private roleRepository: Repository<Role>,
+    private readonly authorizationService: RbacAuthorizationService,
   ) {}
 
   async getAdminUsers(
     query: AdminUserQueryDto,
+    actorGuid: string,
   ): Promise<{ data: any[]; total: number }> {
+    await this.authorizationService.getCurrentUser(actorGuid);
     const {
       current,
       pageSize,
@@ -104,6 +114,45 @@ export class AdminUserService {
         : [];
     const strategyMap = new Map(strategies.map((s) => [s.guid, s.name]));
 
+    const roleNamesByUser = new Map<string, string[]>();
+    const protectedUsers = new Set(
+      users.filter((user) => user.isAdmin).map((user) => user.guid),
+    );
+    if (users.length > 0) {
+      const assignments = await this.assignmentRepository.find({
+        where: { userGuid: In(users.map((user) => user.guid)) },
+        select: ['userGuid', 'roleGuid'],
+      });
+      const roleGuids = [
+        ...new Set(assignments.map((assignment) => assignment.roleGuid)),
+      ];
+      const roles = roleGuids.length
+        ? await this.roleRepository.find({
+            where: { guid: In(roleGuids) },
+            select: ['guid', 'name', 'protectedAccount'],
+          })
+        : [];
+      const roleNameByGuid = new Map(
+        roles.map((role) => [role.guid, role.name]),
+      );
+      const roleNameSetsByUser = new Map<string, Set<string>>();
+      for (const assignment of assignments) {
+        const role = roles.find(
+          (candidate) => candidate.guid === assignment.roleGuid,
+        );
+        if (role?.protectedAccount) protectedUsers.add(assignment.userGuid);
+        const roleName = roleNameByGuid.get(assignment.roleGuid);
+        if (!roleName) continue;
+        const roleNames =
+          roleNameSetsByUser.get(assignment.userGuid) ?? new Set();
+        roleNames.add(roleName);
+        roleNameSetsByUser.set(assignment.userGuid, roleNames);
+      }
+      for (const [userGuid, roleNames] of roleNameSetsByUser) {
+        roleNamesByUser.set(userGuid, [...roleNames].sort());
+      }
+    }
+
     return {
       data: users.map((u) => ({
         guid: u.guid,
@@ -113,6 +162,7 @@ export class AdminUserService {
         note: u.note || '',
         status: u.status,
         is_admin: u.isAdmin,
+        is_protected: protectedUsers.has(u.guid),
         third_auth_type: u.thirdAuthType || '',
         strategy_guid: u.strategyGuid || '',
         strategy_name: u.strategyGuid
@@ -123,6 +173,10 @@ export class AdminUserService {
         avatar: u.avatar || '',
         created_at: u.createdAt,
         updated_at: u.updatedAt,
+        role_names: [
+          ...(u.isAdmin ? ['Super Admin'] : []),
+          ...(roleNamesByUser.get(u.guid) ?? []),
+        ],
       })),
       total,
     };

--- a/src/modules/user/entities/user.entity.spec.ts
+++ b/src/modules/user/entities/user.entity.spec.ts
@@ -1,0 +1,19 @@
+import 'reflect-metadata';
+import { getMetadataArgsStorage } from 'typeorm';
+import { User } from './user.entity';
+
+describe('User owner constraint metadata', () => {
+  it('declares the single-owner partial unique index in TypeORM metadata', () => {
+    const index = getMetadataArgsStorage().indices.find(
+      (candidate) =>
+        candidate.target === User && candidate.name === 'UQ_users_single_owner',
+    );
+
+    expect(index).toMatchObject({
+      columns: ['isAdmin'],
+      unique: true,
+      where: '"isAdmin" = 1',
+      synchronize: false,
+    });
+  });
+});

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -9,6 +9,7 @@ import {
   JoinColumn,
   Index,
 } from 'typeorm';
+import type { IndexOptions } from 'typeorm';
 import { UserToken } from './user-token.entity';
 import { Strategy } from '../../strategy/entities/strategy.entity';
 import { UserGroup } from '../../user-group/entities/user-group.entity';
@@ -39,6 +40,13 @@ export interface UserInfo {
  * 管理所有用户信息
  */
 @Entity('users')
+// DatabaseInitService creates this index after validating legacy owner rows.
+// Registering it with synchronize=false prevents schema sync from dropping it.
+@Index('UQ_users_single_owner', ['isAdmin'], {
+  unique: true,
+  where: '"isAdmin" = 1',
+  synchronize: false,
+} as IndexOptions & { synchronize: false })
 export class User {
   /**
    * 用户唯一标识符

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -1,0 +1,101 @@
+import 'reflect-metadata';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { UserStatus } from './entities/user.entity';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
+
+jest.mock('uuid', () => {
+  const cryptoModule =
+    jest.requireActual<typeof import('node:crypto')>('node:crypto');
+  return { v4: cryptoModule.randomUUID };
+});
+
+describe('UserController field-owned updates', () => {
+  const userService = { updateUser: jest.fn() };
+  const authorizationService = { assertUserMutation: jest.fn() };
+  const controller = new UserController(
+    userService as unknown as UserService,
+    authorizationService as unknown as RbacAuthorizationService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizationService.assertUserMutation.mockResolvedValue(undefined);
+    userService.updateUser.mockResolvedValue({ message: 'ok' });
+  });
+
+  it('allows a status-only update without requiring users.edit', async () => {
+    await controller.updateUser(
+      'target',
+      { status: UserStatus.DISABLED },
+      'actor',
+    );
+
+    expect(authorizationService.assertUserMutation).toHaveBeenCalledTimes(1);
+    expect(authorizationService.assertUserMutation).toHaveBeenCalledWith(
+      'actor',
+      'target',
+      'users.status',
+    );
+  });
+
+  it('checks each permission before applying a combined update', async () => {
+    await controller.updateUser(
+      'target',
+      {
+        display_name: 'Display name',
+        user_group_guid: '3d2bedb2-537f-4ac4-b916-89b5b272aacb',
+      },
+      'actor',
+    );
+
+    expect(authorizationService.assertUserMutation).toHaveBeenNthCalledWith(
+      1,
+      'actor',
+      'target',
+      'users.edit',
+    );
+    expect(authorizationService.assertUserMutation).toHaveBeenNthCalledWith(
+      2,
+      'actor',
+      'target',
+      'user_groups.membership',
+    );
+    expect(userService.updateUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply a combined update when any field permission is denied', async () => {
+    authorizationService.assertUserMutation
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new ForbiddenException());
+
+    await expect(
+      controller.updateUser(
+        'target',
+        {
+          display_name: 'Display name',
+          status: UserStatus.DISABLED,
+        },
+        'actor',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(userService.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty update before writing', async () => {
+    await expect(
+      controller.updateUser('target', {}, 'actor'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(userService.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('passes the stable actor guid into the service write boundary', async () => {
+    await controller.updateUser('target', { note: 'updated' }, 'actor-guid');
+    expect(userService.updateUser).toHaveBeenCalledWith(
+      'target',
+      { note: 'updated' },
+      'actor-guid',
+    );
+  });
+});

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -7,7 +7,6 @@ import {
   Body,
   Param,
   Query,
-  UseGuards,
   HttpCode,
   HttpStatus,
   UseInterceptors,
@@ -17,9 +16,10 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
 import { UserService } from './user.service';
-import { AdminGuard } from '../../common/guards/admin.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Public } from '../auth/decorators/public.decorator';
+import { RequirePermission } from '../rbac/decorators/require-permission.decorator';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
 import {
   CreateUserDto,
   InviteUserDto,
@@ -37,21 +37,38 @@ import {
 
 @Controller()
 export class UserController {
-  constructor(private readonly userService: UserService) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly rbacAuthorizationService: RbacAuthorizationService,
+  ) {}
 
   @Get('users')
   async getAccessibleUsers(
     @CurrentUser('id') userId: string,
-    @CurrentUser('isAdmin') isAdmin: boolean,
     @Query() query: UserQueryDto,
   ) {
-    return this.userService.getAccessibleUsers(userId, query, isAdmin);
+    const currentUser =
+      await this.rbacAuthorizationService.getCurrentUser(userId);
+    return this.userService.getAccessibleUsers(
+      userId,
+      query,
+      currentUser.isAdmin,
+    );
   }
 
   @Post('users')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.create')
   @HttpCode(HttpStatus.OK)
-  async createUser(@Body() dto: CreateUserDto) {
+  async createUser(
+    @Body() dto: CreateUserDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    if (dto.user_group_guid !== undefined) {
+      await this.rbacAuthorizationService.requirePermission(
+        actorGuid,
+        'user_groups.membership',
+      );
+    }
     return this.userService.createUser(dto);
   }
 
@@ -98,9 +115,18 @@ export class UserController {
   }
 
   @Post('users/invite')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.create')
   @HttpCode(HttpStatus.OK)
-  async inviteUser(@Body() dto: InviteUserDto) {
+  async inviteUser(
+    @Body() dto: InviteUserDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    if (dto.user_group_guid !== undefined) {
+      await this.rbacAuthorizationService.requirePermission(
+        actorGuid,
+        'user_groups.membership',
+      );
+    }
     return this.userService.inviteUser(dto);
   }
 
@@ -119,62 +145,156 @@ export class UserController {
   }
 
   @Patch('users/batch/status')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.status')
   @HttpCode(HttpStatus.OK)
-  async batchUpdateStatus(@Body() dto: BatchStatusDto) {
-    return this.userService.batchUpdateStatus(dto);
+  async batchUpdateStatus(
+    @Body() dto: BatchStatusDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.assertUsersMutation(
+      actorGuid,
+      dto.user_guids,
+      'users.status',
+    );
+    return this.userService.batchUpdateStatus(dto, actorGuid);
   }
 
   @Patch('users/batch/security')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.security')
   @HttpCode(HttpStatus.OK)
-  async batchUpdateSecurity(@Body() dto: BatchSecurityDto) {
-    return this.userService.batchUpdateSecurity(dto);
+  async batchUpdateSecurity(
+    @Body() dto: BatchSecurityDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.assertUsersMutation(
+      actorGuid,
+      dto.user_guids,
+      'users.security',
+    );
+    return this.userService.batchUpdateSecurity(dto, actorGuid);
   }
 
   @Delete('users/batch/sessions')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.force_logout')
   @HttpCode(HttpStatus.OK)
-  async batchDeleteSessions(@Body() dto: BatchSessionsDto) {
-    return this.userService.forceLogout(dto.user_guids);
+  async batchDeleteSessions(
+    @Body() dto: BatchSessionsDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.assertUsersMutation(
+      actorGuid,
+      dto.user_guids,
+      'users.force_logout',
+    );
+    return this.userService.forceLogout(dto.user_guids, actorGuid);
   }
 
   @Get('users/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.view')
   async getUser(@Param('guid') guid: string) {
-    return this.userService.getUser(guid);
+    const user = await this.userService.getUser(guid);
+    return {
+      ...user,
+      is_protected: await this.rbacAuthorizationService.isProtectedUser(
+        guid,
+        user.is_admin,
+      ),
+    };
   }
 
   @Patch('users/:guid')
-  @UseGuards(AdminGuard)
   @HttpCode(HttpStatus.OK)
-  async updateUser(@Param('guid') guid: string, @Body() dto: UpdateUserDto) {
-    return this.userService.updateUser(guid, dto);
+  async updateUser(
+    @Param('guid') guid: string,
+    @Body() dto: UpdateUserDto,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    // This endpoint accepts fields governed by different permissions, so each
+    // requested field is authorized before the single atomic update below.
+    let authorizedField = false;
+    if (
+      dto.name !== undefined ||
+      dto.display_name !== undefined ||
+      dto.email !== undefined ||
+      dto.note !== undefined
+    ) {
+      authorizedField = true;
+      await this.rbacAuthorizationService.assertUserMutation(
+        actorGuid,
+        guid,
+        'users.edit',
+      );
+    }
+    if (dto.status !== undefined) {
+      authorizedField = true;
+      await this.rbacAuthorizationService.assertUserMutation(
+        actorGuid,
+        guid,
+        'users.status',
+      );
+    }
+    if (dto.user_group_guid !== undefined) {
+      authorizedField = true;
+      await this.rbacAuthorizationService.assertUserMutation(
+        actorGuid,
+        guid,
+        'user_groups.membership',
+      );
+    }
+    if (dto.is_admin !== undefined) {
+      throw new BadRequestException('系统所有者身份不可通过用户编辑修改');
+    }
+    if (!authorizedField) {
+      throw new BadRequestException('没有可更新的字段');
+    }
+    return this.userService.updateUser(guid, dto, actorGuid);
   }
 
   @Delete('users/:guid')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.delete')
   @HttpCode(HttpStatus.OK)
-  async deleteUser(@Param('guid') guid: string) {
-    await this.userService.deleteUser(guid);
+  async deleteUser(
+    @Param('guid') guid: string,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.assertUserMutation(
+      actorGuid,
+      guid,
+      'users.delete',
+    );
+    await this.userService.deleteUser(guid, actorGuid);
     return { message: '用户已删除' };
   }
 
   @Patch('users/:guid/security')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.security')
   @HttpCode(HttpStatus.OK)
   async updateUserSecurity(
     @Param('guid') guid: string,
     @Body() dto: UpdateUserSecurityDto,
+    @CurrentUser('id') actorGuid: string,
   ) {
-    await this.userService.updateUserSecurity(guid, dto);
+    await this.rbacAuthorizationService.assertUserMutation(
+      actorGuid,
+      guid,
+      'users.security',
+    );
+    await this.userService.updateUserSecurity(guid, dto, actorGuid);
     return { message: '安全设置已更新' };
   }
 
   @Delete('users/:guid/sessions')
-  @UseGuards(AdminGuard)
+  @RequirePermission('users.force_logout')
   @HttpCode(HttpStatus.OK)
-  async deleteUserSessions(@Param('guid') guid: string) {
-    return this.userService.forceLogout([guid]);
+  async deleteUserSessions(
+    @Param('guid') guid: string,
+    @CurrentUser('id') actorGuid: string,
+  ) {
+    await this.rbacAuthorizationService.assertUserMutation(
+      actorGuid,
+      guid,
+      'users.force_logout',
+    );
+    return this.userService.forceLogout([guid], actorGuid);
   }
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -17,6 +17,10 @@ import { Strategy } from '../strategy/entities/strategy.entity';
 import { UserGroupModule } from '../user-group/user-group.module';
 import { EmailModule } from '../email/email.module';
 import { SettingsModule } from '../settings/settings.module';
+import { RbacModule } from '../rbac/rbac.module';
+import { Role } from '../rbac/entities/role.entity';
+import { UserRoleAssignment } from '../rbac/entities/user-role-assignment.entity';
+import { LoginSession } from '../auth/entities/login-session.entity';
 
 @Module({
   imports: [
@@ -30,11 +34,15 @@ import { SettingsModule } from '../settings/settings.module';
       DeviceGroupUserPermission,
       UserUserPermission,
       Strategy,
+      Role,
+      UserRoleAssignment,
+      LoginSession,
     ]),
     AuthModule,
     UserGroupModule,
     EmailModule,
     SettingsModule,
+    RbacModule,
   ],
   controllers: [UserController, AvatarController, AdminUserController],
   providers: [UserService, AdminUserService],

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -2,10 +2,11 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { DataSource, Repository, In } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import * as crypto from 'crypto';
@@ -29,6 +30,8 @@ import {
   ChangePasswordDto,
 } from './dto/user.dto';
 import { UserGroupService } from '../user-group/user-group.service';
+import { RbacAuthorizationService } from '../rbac/services/rbac-authorization.service';
+import { LoginSession } from '../auth/entities/login-session.entity';
 import { EmailService } from '../email/email.service';
 import { GeneralSettingsService } from '../settings/services/general-settings.service';
 import { getAvatarDir } from '../../common/utils/data-dir.util';
@@ -59,6 +62,10 @@ export class UserService {
     private readonly userGroupService: UserGroupService,
     private readonly emailService: EmailService,
     private readonly generalSettingsService: GeneralSettingsService,
+    private readonly dataSource: DataSource,
+    private readonly authorizationService: RbacAuthorizationService,
+    @InjectRepository(LoginSession)
+    private readonly loginSessionRepository: Repository<LoginSession>,
   ) {}
 
   async getAccessibleUsers(
@@ -107,8 +114,14 @@ export class UserService {
         .take(pageSize)
         .getManyAndCount();
 
+      const protection =
+        await this.authorizationService.getEffectiveProtectionMap(
+          users.map((user) => user.guid),
+        );
       return {
-        data: users.map((user) => this.buildUserResponse(user)),
+        data: users.map((user) =>
+          this.buildUserResponse(user, protection.get(user.guid) === true),
+        ),
         total,
       };
     }
@@ -158,8 +171,14 @@ export class UserService {
       .take(pageSize)
       .getManyAndCount();
 
+    const protection =
+      await this.authorizationService.getEffectiveProtectionMap(
+        users.map((user) => user.guid),
+      );
     return {
-      data: users.map((user) => this.buildUserResponse(user)),
+      data: users.map((user) =>
+        this.buildUserResponse(user, protection.get(user.guid) === true),
+      ),
       total,
     };
   }
@@ -385,61 +404,82 @@ export class UserService {
     };
   }
 
-  async updateUser(guid: string, dto: UpdateUserDto) {
-    const user = await this.userRepository.findOne({
-      where: { guid },
-    });
-    if (!user) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    if (dto.name !== undefined) {
-      const existingUser = await this.userRepository.findOne({
-        where: { username: dto.name },
-      });
-      if (existingUser && existingUser.guid !== guid) {
-        throw new BadRequestException('用户名已存在');
+  async updateUser(guid: string, dto: UpdateUserDto, actorGuid: string) {
+    return this.dataSource.transaction(async (manager) => {
+      const users = manager.getRepository(User);
+      const user = await users.findOne({ where: { guid } });
+      if (!user) throw new NotFoundException('用户不存在');
+      if (dto.is_admin !== undefined) {
+        throw new BadRequestException('系统所有者身份不可修改');
       }
-      user.username = dto.name;
-    }
-
-    if (dto.display_name !== undefined) {
-      user.displayName = dto.display_name || null;
-    }
-
-    if (dto.email !== undefined) {
-      if (dto.email) {
-        const existingEmail = await this.userRepository.findOne({
-          where: { email: dto.email },
+      if (
+        dto.name !== undefined ||
+        dto.display_name !== undefined ||
+        dto.email !== undefined ||
+        dto.note !== undefined
+      ) {
+        await this.authorizationService.assertUserMutation(
+          actorGuid,
+          guid,
+          'users.edit',
+          undefined,
+          manager,
+        );
+      }
+      if (dto.status !== undefined) {
+        await this.authorizationService.assertUserMutation(
+          actorGuid,
+          guid,
+          'users.status',
+          undefined,
+          manager,
+        );
+      }
+      if (dto.user_group_guid !== undefined) {
+        await this.authorizationService.assertUserMutation(
+          actorGuid,
+          guid,
+          'user_groups.membership',
+          undefined,
+          manager,
+        );
+      }
+      const previousStatus = user.status;
+      if (dto.name !== undefined) {
+        const existingUser = await users.findOne({
+          where: { username: dto.name },
         });
-        if (existingEmail && existingEmail.guid !== guid) {
-          throw new BadRequestException('邮箱已存在');
+        if (existingUser && existingUser.guid !== guid) {
+          throw new BadRequestException('用户名已存在');
         }
+        user.username = dto.name;
       }
-      user.email = dto.email || null;
-    }
-
-    if (dto.note !== undefined) {
-      user.note = dto.note;
-    }
-
-    if (dto.status !== undefined) {
-      user.status = dto.status;
-    }
-
-    if (dto.is_admin !== undefined) {
-      user.isAdmin = dto.is_admin;
-    }
-
-    if (dto.user_group_guid !== undefined) {
-      user.userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
-        dto.user_group_guid,
-      );
-    }
-
-    await this.userRepository.save(user);
-
-    return { message: '用户已更新' };
+      if (dto.display_name !== undefined)
+        user.displayName = dto.display_name || null;
+      if (dto.email !== undefined) {
+        if (dto.email) {
+          const existingEmail = await users.findOne({
+            where: { email: dto.email },
+          });
+          if (existingEmail && existingEmail.guid !== guid) {
+            throw new BadRequestException('邮箱已存在');
+          }
+        }
+        user.email = dto.email || null;
+      }
+      if (dto.note !== undefined) user.note = dto.note;
+      if (dto.status !== undefined) user.status = dto.status;
+      if (dto.user_group_guid !== undefined) {
+        user.userGroupGuid = await this.userGroupService.resolveUserGroupGuid(
+          dto.user_group_guid,
+        );
+      }
+      await users.save(user);
+      if (dto.status !== undefined && dto.status !== previousStatus) {
+        await this.revokeActiveTokens([guid], manager);
+      }
+      return { message: '用户已更新' };
+    });
   }
 
   async updateCurrentUser(userId: string, dto: UpdateCurrentUserDto) {
@@ -476,122 +516,161 @@ export class UserService {
   }
 
   async changePassword(userId: string, dto: ChangePasswordDto) {
-    const user = await this.userRepository
-      .createQueryBuilder('user')
-      .where('user.guid = :guid', { guid: userId })
-      .addSelect('user.password')
-      .addSelect('user.thirdAuthType')
-      .getOne();
+    return this.dataSource.transaction(async (manager) => {
+      const user = await manager
+        .getRepository(User)
+        .createQueryBuilder('user')
+        .where('user.guid = :guid', { guid: userId })
+        .addSelect('user.password')
+        .addSelect('user.thirdAuthType')
+        .getOne();
 
-    if (!user) {
-      throw new NotFoundException('用户不存在');
-    }
+      if (!user) throw new NotFoundException('用户不存在');
 
-    if (user.thirdAuthType) {
-      throw new BadRequestException('第三方登录用户不支持修改密码');
-    }
+      if (user.thirdAuthType) {
+        throw new BadRequestException('第三方登录用户不支持修改密码');
+      }
 
-    if (!user.password) {
-      throw new BadRequestException('当前账户未设置密码，请联系管理员');
-    }
+      if (!user.password) {
+        throw new BadRequestException('当前账户未设置密码，请联系管理员');
+      }
 
-    const isPasswordValid = await bcrypt.compare(
-      dto.current_password,
-      user.password,
-    );
-    if (!isPasswordValid) {
-      throw new BadRequestException('当前密码错误');
-    }
+      const isPasswordValid = await bcrypt.compare(
+        dto.current_password,
+        user.password,
+      );
+      if (!isPasswordValid) throw new BadRequestException('当前密码错误');
 
-    user.password = await bcrypt.hash(dto.new_password, 10);
-    await this.userRepository.save(user);
+      user.password = await bcrypt.hash(dto.new_password, 10);
+      await manager.getRepository(User).save(user);
+      await this.revokeActiveTokens([userId], manager);
 
-    return { message: '密码修改成功' };
+      return { message: '密码修改成功' };
+    });
   }
 
-  async updateUserSecurity(guid: string, dto: UpdateUserSecurityDto) {
-    const user = await this.userRepository.findOne({
-      where: { guid },
+  async updateUserSecurity(
+    guid: string,
+    dto: UpdateUserSecurityDto,
+    actorGuid: string,
+  ) {
+    await this.dataSource.transaction(async (manager) => {
+      const users = manager.getRepository(User);
+      const user = await users.findOne({ where: { guid } });
+      if (!user) throw new NotFoundException('用户不存在');
+      await this.authorizationService.assertUserMutation(
+        actorGuid,
+        guid,
+        'users.security',
+        undefined,
+        manager,
+      );
+      const userInfo: UserInfo = user.getUserInfo();
+      userInfo.other = userInfo.other || {};
+      if (dto.tfa_enforce !== undefined)
+        userInfo.other.tfa_enforce = dto.tfa_enforce;
+      if (dto.email_verification !== undefined) {
+        userInfo.email_verification = dto.email_verification;
+      }
+      user.setUserInfo(userInfo);
+      await users.save(user);
+      await this.revokeActiveTokens([guid], manager);
     });
-    if (!user) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    const userInfo: UserInfo = user.getUserInfo();
-    userInfo.other = userInfo.other || {};
-
-    if (dto.tfa_enforce !== undefined) {
-      userInfo.other.tfa_enforce = dto.tfa_enforce;
-    }
-
-    if (dto.email_verification !== undefined) {
-      userInfo.email_verification = dto.email_verification;
-    }
-
-    user.setUserInfo(userInfo);
-    await this.userRepository.save(user);
   }
 
-  async deleteUser(guid: string) {
-    const user = await this.userRepository.findOne({
-      where: { guid },
+  async deleteUser(guid: string, actorGuid: string) {
+    await this.dataSource.transaction(async (manager) => {
+      const users = manager.getRepository(User);
+      const user = await users.findOne({ where: { guid } });
+      if (!user) throw new NotFoundException('用户不存在');
+      await this.authorizationService.assertUserMutation(
+        actorGuid,
+        guid,
+        'users.delete',
+        undefined,
+        manager,
+      );
+      await this.revokeActiveTokens([guid], manager);
+      await users.remove(user);
     });
-    if (!user) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    await this.userRepository.remove(user);
   }
 
-  async forceLogout(userGuids: string[]) {
-    const users = await this.userRepository.find({
-      where: { guid: In(userGuids) },
+  async forceLogout(userGuids: string[], actorGuid: string) {
+    const uniqueGuids = [...new Set(userGuids)];
+    await this.dataSource.transaction(async (manager) => {
+      const users = await manager.getRepository(User).find({
+        where: { guid: In(uniqueGuids) },
+      });
+      if (users.length !== uniqueGuids.length) {
+        throw new NotFoundException('一个或多个用户不存在');
+      }
+      for (const user of users) {
+        await this.authorizationService.assertUserMutation(
+          actorGuid,
+          user.guid,
+          'users.force_logout',
+          undefined,
+          manager,
+        );
+      }
+      await this.revokeActiveTokens(uniqueGuids, manager);
     });
-
-    if (users.length === 0) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    await this.userTokenRepository.update(
-      { userGuid: In(userGuids), isRevoked: false },
-      { isRevoked: true },
-    );
-
     return { message: '强制登出成功' };
   }
 
-  async batchUpdateStatus(dto: BatchStatusDto) {
+  private async revokeActiveTokens(
+    userGuids: string[],
+    manager?: import('typeorm').EntityManager,
+  ): Promise<void> {
+    const uniqueGuids = [...new Set(userGuids)];
+    if (uniqueGuids.length === 0) return;
+
+    const tokenRepository =
+      manager?.getRepository(UserToken) ?? this.userTokenRepository;
+    await tokenRepository.update(
+      { userGuid: In(uniqueGuids), isRevoked: false },
+      { isRevoked: true },
+    );
+    const sessionRepository =
+      manager?.getRepository(LoginSession) ?? this.loginSessionRepository;
+    await sessionRepository.delete({ userGuid: In(uniqueGuids), used: false });
+  }
+
+  async batchUpdateStatus(dto: BatchStatusDto, actorGuid: string) {
     const { user_guids, status } = dto;
-    const users = await this.userRepository.find({
-      where: { guid: In(user_guids) },
-    });
-
-    if (users.length === 0) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    const foundGuids = new Set(users.map((u) => u.guid));
     const succeeded: string[] = [];
     const failed: { guid: string; reason: string }[] = [];
 
-    for (const guid of user_guids) {
-      if (!foundGuids.has(guid)) {
-        failed.push({ guid, reason: 'User not found' });
+    await this.dataSource.transaction(async (manager) => {
+      const users = await manager.getRepository(User).find({
+        where: { guid: In(user_guids) },
+      });
+      if (users.length === 0) throw new NotFoundException('用户不存在');
+      const foundGuids = new Set(users.map((u) => u.guid));
+      for (const guid of user_guids) {
+        if (!foundGuids.has(guid))
+          failed.push({ guid, reason: 'User not found' });
       }
-    }
-
-    const guidsToUpdate = user_guids.filter((guid) => foundGuids.has(guid));
-
-    if (guidsToUpdate.length > 0) {
-      await this.userRepository
-        .createQueryBuilder()
-        .update(User)
-        .set({ status })
-        .where('guid IN (:...guids)', { guids: guidsToUpdate })
-        .execute();
-
-      succeeded.push(...guidsToUpdate);
-    }
+      const guidsToUpdate = user_guids.filter((guid) => foundGuids.has(guid));
+      if (guidsToUpdate.length > 0) {
+        await this.authorizationService.assertUsersMutation(
+          actorGuid,
+          guidsToUpdate,
+          'users.status',
+          manager,
+        );
+        const updateResult = await manager
+          .getRepository(User)
+          .update({ guid: In(guidsToUpdate) }, { status });
+        if (updateResult.affected !== new Set(guidsToUpdate).size) {
+          throw new ConflictException('用户信息已发生变化，请重试');
+        }
+        succeeded.push(...guidsToUpdate);
+        if (status !== UserStatus.ACTIVE) {
+          await this.revokeActiveTokens(guidsToUpdate, manager);
+        }
+      }
+    });
 
     return {
       succeeded,
@@ -602,31 +681,46 @@ export class UserService {
     };
   }
 
-  async batchUpdateSecurity(dto: BatchSecurityDto) {
+  async batchUpdateSecurity(dto: BatchSecurityDto, actorGuid: string) {
     const { user_guids, tfa_enforce, email_verification } = dto;
-    const users = await this.userRepository.find({
-      where: { guid: In(user_guids) },
+    const uniqueGuids = [...new Set(user_guids)];
+
+    await this.dataSource.transaction(async (manager) => {
+      const userRepository = manager.getRepository(User);
+      const users = await userRepository.find({
+        where: { guid: In(uniqueGuids) },
+      });
+
+      if (!users.length || users.length !== uniqueGuids.length) {
+        throw new NotFoundException('用户不存在');
+      }
+
+      await this.authorizationService.assertUsersMutation(
+        actorGuid,
+        uniqueGuids,
+        'users.security',
+        manager,
+      );
+
+      const usersByGuid = new Map(users.map((user) => [user.guid, user]));
+      for (const guid of uniqueGuids) {
+        const user = usersByGuid.get(guid)!;
+        const userInfo: UserInfo = user.getUserInfo();
+        userInfo.other = userInfo.other || {};
+
+        if (tfa_enforce !== undefined) {
+          userInfo.other.tfa_enforce = tfa_enforce;
+        }
+
+        if (email_verification !== undefined) {
+          userInfo.email_verification = email_verification;
+        }
+
+        user.setUserInfo(userInfo);
+        await userRepository.save(user);
+      }
+      await this.revokeActiveTokens(uniqueGuids, manager);
     });
-
-    if (users.length === 0) {
-      throw new NotFoundException('用户不存在');
-    }
-
-    for (const user of users) {
-      const userInfo: UserInfo = user.getUserInfo();
-      userInfo.other = userInfo.other || {};
-
-      if (tfa_enforce !== undefined) {
-        userInfo.other.tfa_enforce = tfa_enforce;
-      }
-
-      if (email_verification !== undefined) {
-        userInfo.email_verification = email_verification;
-      }
-
-      user.setUserInfo(userInfo);
-      await this.userRepository.save(user);
-    }
 
     return { message: '批量安全设置已更新' };
   }
@@ -645,7 +739,7 @@ export class UserService {
     }
   }
 
-  private buildUserResponse(user: User) {
+  private buildUserResponse(user: User, isProtected = user.isAdmin) {
     const response: Record<string, unknown> = {
       guid: user.guid,
       name: user.username,
@@ -654,6 +748,7 @@ export class UserService {
       note: user.note || '',
       status: user.status,
       is_admin: user.isAdmin,
+      is_protected: isProtected,
       user_group_guid: user.userGroupGuid || '',
       user_group_name: user.userGroup?.name || '',
     };


### PR DESCRIPTION
## Summary

This PR adds fine-grained, server-side role-based access control (RBAC) to RustDesk Console.

It introduces:

- A centralized permission catalog
- Persistent custom roles
- Global and device-group-scoped grants
- Server-side function-, object-, and property-level authorization
- Constrained role delegation
- Protected accounts
- Immediate permission freshness after security-sensitive changes
- Minimal-data strategy assignment candidates
- Transactional authorization for administrative batch operations
- Console authorization audit records
- A single immutable system-owner boundary

The goal is to let organizations delegate specific administrative work without turning every operator into a full Console administrator.

Examples include:

- A read-only auditor who can inspect devices, users, strategies, address books, and audit records
- A device operator limited to selected device groups
- A user administrator who cannot manage roles or system settings
- A strategy assigner who can assign policies without reading their full configuration
- A system administrator with all assignable permissions, while still remaining distinct from the unique system owner

All authorization decisions are enforced by the backend. Frontend menu visibility and disabled controls are treated only as user-experience helpers.

Paired frontend PR: https://github.com/databk/rustdesk-console-web/pull/281

## Motivation

Before this change, Console authorization was primarily based on whether a user was an administrator, with additional checks distributed across individual features.

That model could not safely express requirements such as:

- View devices but do not edit or delete them
- Edit devices only in selected device groups
- Manage users without changing roles or system settings
- Assign strategies without reading sensitive strategy configuration
- Allow one administrator to delegate only permissions they already possess
- Protect high-impact accounts from other delegated administrators

Authentication and authorization are separate concerns. A valid login proves who the user is, but it does not prove that the user may perform every Console operation.

This PR therefore adds an explicit, deny-by-default authorization model and applies it consistently to relevant requests.

## Identity model

The backend recognizes three identity states.

### System owner / super administrator

The original system owner remains the unique super administrator.

The system owner:

- Has complete Console authority
- Is not authorized through ordinary RBAC role assignments
- Cannot be recreated through LDAP or normal user creation
- Is protected by a database-level single-owner constraint
- Is the only identity allowed to create, edit, delete, or unprotect role definitions
- May manage protected accounts
- May use owner-only system capabilities such as system settings, identity sources, and device-group structure management

If an existing database contains more than one owner account, startup fails explicitly instead of silently selecting or modifying an owner.

### Ordinary user

A user without any assigned RBAC role is treated as an ordinary user.

An ordinary user retains only the existing personal address-book basic functionality. This basic capability is not stored as a role permission and cannot be removed through role editing.

### RBAC user

A non-owner user may receive one or more persisted custom roles.

Effective authorization is calculated from the union of the assigned role grants, subject to scope and protection rules. Assigning a real RBAC role replaces the UI representation of the virtual ordinary-user identity; the virtual identity itself is never stored as a database role.

## Permission catalog

The backend permission catalog is the source of truth for:

- Permission code
- Resource
- Action
- Human-readable description
- Scope type
- Assignability
- System-only status
- Required prerequisite permissions

The catalog covers the following resource areas.

| Resource | Supported operations | Scope |
| --- | --- | --- |
| Shared address books | View settings, edit shared address books, create and manage sharing | Global |
| Audit | View audit records | Global |
| Devices | View, edit metadata, change status, delete, disconnect | Global or selected device groups |
| Strategies | View, create, edit, delete, assign | Global or selected device groups where applicable |
| User groups | View, create, edit, delete, manage members | Global |
| Users | View, create, edit, change status, delete, manage security, force logout | Global |
| Roles | View and assign roles | Global |
| Role definitions | Create, edit, and delete roles | System owner only |

The following capabilities are intentionally not assignable through ordinary roles:

- System settings management
- Device-group structure management
- Identity-source management
- Role creation
- Role editing
- Role deletion

They remain visible to clients as owner-only capabilities so the UI can explain the boundary instead of presenting them as missing or unknown permissions.

## Permission dependencies

Permissions may declare prerequisites.

For example, a write operation generally requires the corresponding view permission. The backend validates these dependencies when a role is created or updated.

This prevents unusable or misleading roles such as being allowed to edit a resource that the same user is not permitted to retrieve.

Persisted roles are also filtered defensively when effective permissions are calculated. If stored data is incomplete or damaged, missing prerequisite permissions fail closed instead of granting the dependent operation.

Strategy assignment is an intentional exception: a user may receive `strategies.assign` without full `strategies.view`. In that case, the user can access only the minimal strategy candidate projection needed for assignment.

## Scope model

Permissions support two scope modes.

### Global scope

A global grant applies to all resources covered by that permission.

Example:

```text
devices.edit -> global
```

The user may edit every device they are otherwise allowed to access.

### Selected device-group scope

A scoped grant applies only to explicitly selected device groups.

Example:

```text
devices.edit -> Finance device group
devices.status -> Finance device group
```

The user may operate on Finance devices but cannot use the same actions on Sales or Engineering devices.

Scope checks are applied to:

- Lists
- Details
- Single-resource mutations
- Batch mutations
- Strategy assignment candidates
- Device-group-related projections

When the same permission is granted globally and through selected device groups, the global grant wins because it already covers the narrower grants.

Client-supplied user IDs, role IDs, device IDs, or device-group IDs are never trusted as proof of authorization.

## Request authorization flow

Relevant backend requests follow this authorization sequence:

```text
Authenticate the session
-> Verify that the account is active and the token is current
-> Check the required function permission
-> Load and verify the target object
-> Apply device-group scope rules where required
-> Check whether the target account is protected
-> Execute the business operation
-> Record the administrative authorization result
```

This design keeps authentication, function authorization, object authorization, and target protection as separate checks.

A missing permission check must not turn into an implicit allow. Protected routes use centralized metadata and guards, while service-level checks enforce object, scope, and write-boundary constraints.

## Role-definition management

Only the system owner may:

- Create roles
- Edit role names, notes, permissions, or protection status
- Delete roles
- Disable protection on a protected role

Role payloads are validated against the backend permission catalog.

The backend rejects:

- Unknown permission codes
- Duplicate permission codes
- System-only permissions in normal role payloads
- Missing prerequisite permissions
- Invalid or mixed scope assignments
- Device-group grants for permissions that do not support device-group scope
- Invalid device-group identifiers

Role presets are intentionally not persisted as backend identities.

The frontend presets:

- Global read-only
- Device operations
- User administrator
- Shared address-book administrator
- Strategy maintainer
- Device strategy assigner
- System administrator

are convenience templates that compile into explicit permission selections and role metadata. After submission, the backend treats the result as an ordinary validated role. If the user modifies a preset, it simply becomes a custom permission set.

This avoids coupling backend authorization to UI template names.

## Constrained role delegation

`roles.view` and `roles.assign` are separate permissions.

A delegated administrator with `roles.assign` may assign roles only when all of the following conditions are satisfied:

- The target is not the caller
- The target is not the system owner
- The target is not protected
- The role's permissions do not exceed the caller's effective permissions
- The role's device-group scope does not exceed the caller's effective scope
- The role does not grant protected delegation capabilities that the caller may not delegate
- Existing assignments that the caller is not allowed to remove remain locked
- The complete resulting role combination does not create a privilege escalation

The backend returns target-specific role eligibility, including whether each role can be assigned or removed and a stable reason code when it cannot.

The frontend may use this information to disable ineligible roles, but the backend repeats the complete validation when the assignment is saved.

This prevents request forgery, stale-page submission, combined-role escalation, and omission of locked assignments.

## Protected accounts

A role may mark its members as protected accounts.

Protection is role metadata, not a normal permission code.

A non-owner administrator cannot perform administrative operations against a protected account, including:

- Edit the account
- Enable or disable the account
- Delete the account
- Change security settings
- Force logout
- Modify user-group membership
- Assign or remove strategies
- Assign or remove roles

The restriction is enforced across single-item routes, batch routes, alternate mutation paths, and candidate lists.

The system owner remains able to manage protected accounts.

The system-administrator frontend preset enables account protection by default, but protection is still stored and validated as explicit role metadata.

Before the system owner disables protection on a role that already has members, the backend reports the affected member count and requires an explicit confirmed mutation. The current role state and member count are revalidated at the transactional write boundary.

Personal self-service security operations remain separate from administrative operations.

## Session and permission freshness

Role and account-security changes must not leave old authority active in an existing session.

The backend invalidates or rechecks relevant sessions after operations such as:

- Role assignment or removal
- Account disablement
- Password changes
- Security-setting changes
- Forced logout
- Other token-revoking account operations

Permission changes therefore take effect on the next protected backend request. A user cannot keep exercising revoked permissions simply because an older page remains open.

Pending login, TFA, and passkey flows are also invalidated where the corresponding security operation requires it.

## Strategy assignment without full strategy access

A user may have permission to assign a strategy without permission to inspect its complete configuration.

For this case, the backend provides a minimal candidate representation containing only assignment-required fields such as:

- Strategy identifier
- Strategy name
- Non-sensitive display metadata

The response does not include the full strategy configuration or secret-bearing fields.

Normal strategy detail endpoints still require the full strategy-view permission.

This preserves practical delegation without turning strategy assignment into an indirect data-exposure path.

## Transaction and batch semantics

Security-sensitive writes are authorized again at the transaction boundary.

For supported administrative batch operations:

- All targets are validated before mutation
- Protected or unauthorized targets reject the complete operation
- Invalid identifiers are handled explicitly
- A partial write is not reported as complete success
- Affected-row mismatches fail closed
- Concurrent protection or assignment changes are revalidated
- Audit data matches the committed result

This applies to relevant role, user, user-group, strategy, security, and status operations.

The goal is to prevent time-of-check/time-of-use authorization races and misleading partial-success responses.

## Audit records

The Console audit model records administrative authorization activity with sufficient context to reconstruct what happened.

Records include relevant fields such as:

- Actor user
- Action
- Target resource type
- Target identifier
- Result
- Reason
- Timestamp
- Before/after state for relevant privilege changes
- Affected-member count for protection changes

Actor identity remains attributable even when related user data later changes or is removed.

Audit access itself is protected by `audit.view`.

## Address-book behavior

Personal address-book access remains a basic authenticated-user capability and is not converted into a role permission.

Shared address-book administration is covered separately by explicit RBAC permissions.

Existing RustDesk client-facing address-book compatibility routes remain available because they are consumed by RustDesk clients. They were not removed merely because the Console Web application uses newer management endpoints.

Shared-address-book ACL operations continue to use their existing resource-level access rules and are not silently converted into unrestricted Console-administrator operations.

## Database and startup behavior

The RBAC schema is added through the project's existing TypeORM synchronization path.

The changes include storage for:

- Roles
- Role permissions
- User-role assignments
- Assignment scope
- Device-group grants
- Protected-role metadata
- Authorization audit data
- Session/token freshness state where required

The existing system owner is preserved.

A partial unique database constraint enforces that at most one user may be marked as the system owner. Startup accepts databases containing zero or one owner, but rejects databases containing multiple owners instead of silently repairing them.

A database backup is recommended before deploying this change to an existing installation.

## Compatibility and boundaries

This PR does not modify:

- `hbbs`
- `hbbr`
- RustDesk rendezvous configuration
- Relay configuration
- RustDesk server keys
- Client heartbeat identity
- RustDesk client connection protocol

The RBAC implementation protects Console management operations. It does not change how RustDesk clients connect to the RustDesk server.

Existing non-owner users without roles are intentionally reduced to ordinary-user access. Administrators should assign explicit roles before expecting those accounts to retain management access.

The implementation intentionally does not introduce:

- Arbitrary ABAC expressions
- A custom policy language
- Role hierarchy editing
- Dynamic separation-of-duty rules
- Cross-tenant sharing
- Wildcard permissions
- Self-service role assignment
- Delegated role-definition editing

These features would substantially increase the authorization and testing surface and are outside the scope of this PR.

## Security invariants

The implementation follows these invariants:

- Authentication does not imply authorization
- Authorization is enforced on the server
- Relevant operations are denied unless explicitly granted
- Function-, object-, scope-, and property-level checks are separate
- Client-supplied identifiers do not establish authority
- System-only permissions cannot enter ordinary role payloads
- Delegated administrators cannot grant more authority than they possess
- Protected accounts cannot be managed through alternate or batch routes
- Role or account-security changes invalidate stale authority
- Administrative changes are attributable through audit records

## Verification

Automated verification completed for the final backend branch:

- Jest: 12 suites, 126 tests passed
- TypeScript type check: passed
- Production build: passed
- ESLint on changed backend files: passed
- `git diff --check`: passed

Coverage includes:

- Permission-catalog validation
- Permission dependencies
- Global and device-group-scoped authorization
- Function- and object-level denial
- User-role replacement
- Delegated role eligibility
- Self-assignment prevention
- Combined-role escalation prevention
- Locked-assignment preservation
- Protected-account single and batch routes
- Concurrent protection and assignment changes
- Account state and token revocation
- Pending login/session invalidation
- Minimal strategy candidate projection
- Shared-address-book ACL compatibility
- Unique system-owner initialization
- LDAP owner-escalation prevention
- Console audit projections
- Invalid and missing batch identifiers
- Transaction rollback and affected-row mismatch handling

A read-only concurrency smoke test also completed without 5xx responses, timeouts, database-lock failures, or process termination.

## Suggested review scenarios

1. Start with the existing system owner and verify complete Console access.
2. Sign in as a user without roles and verify that only personal address-book functionality remains.
3. Assign a global read-only role and verify that mutation endpoints remain denied.
4. Assign device operations for one device group and verify list, detail, single-write, and batch-write scope enforcement.
5. Grant strategy assignment without strategy view and verify that only minimal candidate data is available.
6. Mark a role as protected and verify that non-owner administrators cannot manage its members through any user, group, strategy, security, logout, or role route.
7. Grant delegated role assignment and verify self-assignment, scope escalation, combined-role escalation, and locked-role removal are rejected.
8. Remove a role and verify that the revoked authority disappears on the next protected request.
9. Submit invalid and mixed batch targets and verify that the operation does not partially commit.
10. Verify that the existing RustDesk heartbeat and client connection paths are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based access control with permission management, role assignment, scoped device-group access, and protected-account handling.
  * Added role, user-role, permission, audit, address-book sharing, strategy candidate, and active-connection endpoints.
  * Added device filters for status, online state, operating system, and device group.
  * Login responses now include a stable user identifier.

* **Bug Fixes**
  * Improved token, account, session, and authorization validation.
  * Added transactional safeguards for address-book, user, device, and role changes.
  * Enforced a single system owner during startup.

* **Security**
  * Added granular permissions and authorization auditing across administrative features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->